### PR TITLE
fix base endpoint for homepage

### DIFF
--- a/classes/File.js
+++ b/classes/File.js
@@ -54,7 +54,7 @@ class File {
 
   async create(fileName, content) {
     try {
-      const endpoint = `${this.baseEndpoint}/${fileName}`
+      const endpoint = `${this.baseEndpoint}${fileName}`
 
       let params = {
         "message": `Create file: ${fileName}`,
@@ -77,7 +77,7 @@ class File {
 
   async read(fileName) {
     try {
-      const endpoint = `${this.baseEndpoint}/${fileName}`
+      const endpoint = `${this.baseEndpoint}${fileName}`
 
       const resp = await axios.get(endpoint, {
         validateStatus: validateStatus,
@@ -99,7 +99,7 @@ class File {
 
   async update(fileName, content, sha) {
     try {
-      const endpoint = `${this.baseEndpoint}/${fileName}`
+      const endpoint = `${this.baseEndpoint}${fileName}`
 
       let params = {
         "message": `Update file: ${fileName}`,
@@ -123,7 +123,7 @@ class File {
 
   async delete (fileName, sha) {
     try {
-      const endpoint = `${this.baseEndpoint}/${fileName}`
+      const endpoint = `${this.baseEndpoint}${fileName}`
 
       let params = {
         "message": `Delete file: ${fileName}`,
@@ -146,7 +146,7 @@ class File {
 
 class PageType {
   constructor() {
-    this.folderName = 'pages'
+    this.folderName = 'pages/'
   }
   getFolderName() {
     return this.folderName
@@ -155,7 +155,7 @@ class PageType {
 
 class CollectionPageType {
   constructor(collectionName) {
-    this.folderName = `_${collectionName}`
+    this.folderName = `_${collectionName}/`
   }
   getFolderName() {
     return this.folderName
@@ -164,7 +164,7 @@ class CollectionPageType {
 
 class ResourcePageType {
   constructor(resourceRoomName, resourceName) {
-    this.folderName = `${resourceRoomName}/${resourceName}/_posts`
+    this.folderName = `${resourceRoomName}/${resourceName}/_posts/`
   }
   getFolderName() {
     return this.folderName
@@ -173,7 +173,7 @@ class ResourcePageType {
 
 class ResourceType {
   constructor(resourceRoomName) {
-    this.folderName = `${resourceRoomName}`
+    this.folderName = `${resourceRoomName}/`
   }
   getFolderName() {
     return this.folderName
@@ -182,7 +182,7 @@ class ResourceType {
 
 class ImageType {
   constructor() {
-    this.folderName = 'images'
+    this.folderName = 'images/'
   }
   getFolderName() {
     return this.folderName
@@ -191,7 +191,7 @@ class ImageType {
 
 class DocumentType {
   constructor() {
-    this.folderName = 'files'
+    this.folderName = 'files/'
   }
   getFolderName() {
     return this.folderName
@@ -200,7 +200,7 @@ class DocumentType {
 
 class DataType {
   constructor() {
-    this.folderName = '_data'
+    this.folderName = '_data/'
   }
   getFolderName() {
     return this.folderName


### PR DESCRIPTION
This PR changes the format of `folderName` to accommodate the fact that the `index.md` (homepage) file is located in the root of the folder.

Without this change, the `endpoint` for `index.md` will be `https://api.github.com/repos/${GITHUB_ORG_NAME}/${this.siteName}/contents/index.md/`. However, the endpoint is not valid because of the trailing `/`.

This change ensures that the endpoint is `https://api.github.com/repos/${GITHUB_ORG_NAME}/${this.siteName}/contents/index.md` instead, which is a valid endpoint.