### PR TITLE
Return resourceRoomName in GET /resources API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -84,6 +84,8 @@ components:
           type: array
           items:
             type: string
+        resourceRoomName:
+          type: string
     MenuListResponse:
       properties:
         menus:

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -19,7 +19,7 @@ router.get('/:siteName/resources', async function(req, res, next) {
     const IsomerResource = new Resource(access_token, siteName)
     const resources = await IsomerResource.list(resourceRoomName)
 
-    res.status(200).json({ resources })
+    res.status(200).json({ resourceRoomName, resources })
   } catch (err) {
     console.log(err)
   }


### PR DESCRIPTION
This PR returns `resourceRoomName` in the GET `/resources` endpoint so that the frontend does not need to also call GET `/resource-room` to obtain the field.