### PR TITLE
Feat: add endpoint for drag and drop navigation menu

### DIFF
--- a/classes/Directory.js
+++ b/classes/Directory.js
@@ -14,9 +14,11 @@ class Directory {
     this.accessToken = accessToken
     this.siteName = siteName
     this.baseEndpoint = null
+    this.dirType = null
   }
 
   setDirType(dirType) {
+    this.dirType = dirType
     const folderPath = dirType.getFolderName()
     this.baseEndpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${this.siteName}/contents/${folderPath}`
   }
@@ -46,7 +48,11 @@ class Directory {
         }
       })
   
-      return _.compact(directories)
+      if (this.dirType instanceof ResourceRoomType) {
+        return _.compact(directories)
+      }
+
+      return resp.data
     } catch (err) {
       throw err
     }

--- a/classes/File.js
+++ b/classes/File.js
@@ -87,7 +87,7 @@ class File {
       const resp = await axios.get(endpoint, {
         validateStatus: validateStatus,
         params: {
-          ref: `${this.branchRef}`
+          ref: this.branchRef
         },
         headers: {
           Authorization: `token ${this.accessToken}`,

--- a/classes/File.js
+++ b/classes/File.js
@@ -224,14 +224,5 @@ class HomepageType {
   }
 }
 
-class MenuType {
-  constructor() {
-    this.folderName = '_data/'
-  }
-  getFolderName() {
-    return this.folderName
-  }
-}
 
-
-module.exports = { File, MenuType, PageType, CollectionPageType, ResourcePageType, ResourceType, ImageType, DocumentType, DataType, HomepageType }
+module.exports = { File, PageType, CollectionPageType, ResourcePageType, ResourceType, ImageType, DocumentType, DataType, HomepageType }

--- a/classes/File.js
+++ b/classes/File.js
@@ -14,7 +14,7 @@ class File {
     this.accessToken = accessToken
     this.siteName = siteName
     this.baseEndpoint = null
-    this.branchRef = "staging"
+    this.branchRef = 'staging'
   }
 
   setBranchRef(branchRef) {
@@ -64,7 +64,7 @@ class File {
       let params = {
         "message": `Create file: ${fileName}`,
         "content": content,
-        "branch": `${this.branchRef}`,
+        "branch": this.branchRef,
       }
   
       const resp = await axios.put(endpoint, params, {
@@ -112,7 +112,7 @@ class File {
       let params = {
         "message": `Update file: ${fileName}`,
         "content": content,
-        "branch": `${this.branchRef}`,
+        "branch": this.branchRef,
         "sha": sha
       }
   
@@ -135,7 +135,7 @@ class File {
 
       let params = {
         "message": `Delete file: ${fileName}`,
-        "branch":`${this.branchRef}`,
+        "branch": this.branchRef,
         "sha": sha
       }
   

--- a/classes/File.js
+++ b/classes/File.js
@@ -14,6 +14,11 @@ class File {
     this.accessToken = accessToken
     this.siteName = siteName
     this.baseEndpoint = null
+    this.branchRef = "staging"
+  }
+
+  setBranchRef(branchRef) {
+    this.branchRef = branchRef
   }
 
   setFileType(fileType) {
@@ -59,7 +64,7 @@ class File {
       let params = {
         "message": `Create file: ${fileName}`,
         "content": content,
-        "branch": "staging",
+        "branch": `${this.branchRef}`,
       }
   
       const resp = await axios.put(endpoint, params, {
@@ -81,6 +86,9 @@ class File {
 
       const resp = await axios.get(endpoint, {
         validateStatus: validateStatus,
+        params: {
+          ref: `${this.branchRef}`
+        },
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"
@@ -104,7 +112,7 @@ class File {
       let params = {
         "message": `Update file: ${fileName}`,
         "content": content,
-        "branch": "staging",
+        "branch": `${this.branchRef}`,
         "sha": sha
       }
   
@@ -127,7 +135,7 @@ class File {
 
       let params = {
         "message": `Delete file: ${fileName}`,
-        "branch": "staging",
+        "branch":`${this.branchRef}`,
         "sha": sha
       }
   

--- a/classes/File.js
+++ b/classes/File.js
@@ -216,4 +216,14 @@ class HomepageType {
   }
 }
 
-module.exports = { File, PageType, CollectionPageType, ResourcePageType, ResourceType, ImageType, DocumentType, DataType, HomepageType }
+class MenuType {
+  constructor() {
+    this.folderName = '_data/'
+  }
+  getFolderName() {
+    return this.folderName
+  }
+}
+
+
+module.exports = { File, MenuType, PageType, CollectionPageType, ResourcePageType, ResourceType, ImageType, DocumentType, DataType, HomepageType }

--- a/classes/Tree.js
+++ b/classes/Tree.js
@@ -30,7 +30,7 @@ class Tree {
     async getLinkedPages() {
         try {
             // Obtain items in the navigation bar
-            const IsomerNavFile = new File(this.access_token, this.siteName)
+            const IsomerNavFile = new File(this.accessToken, this.siteName)
             IsomerNavFile.setFileType(new DataType())
             const { content } = await IsomerNavFile.read('navigation.yml')
             const navItems = yaml.safeLoad(base64.decode(content)).links;
@@ -56,7 +56,7 @@ class Tree {
                     url: item.url,
                 }
                 } else if (item.collection) {
-                collections.push(item.collection)
+                this.collections.push(item.collection)
                 return {
                     type: 'collection',
                     title: item.title,
@@ -79,7 +79,7 @@ class Tree {
              * `thirdnav` groups when necessary
              */
             this.directory = await Bluebird.map(directoryCollections, async (item) => {
-                return pageAggregator(item, this.access_token, this.siteName)
+                return pageAggregator(item, this.accessToken, this.siteName)
             })
         } catch (err) {
           throw err
@@ -88,7 +88,7 @@ class Tree {
 
     async getUnlinkedPages() {
         // Get all files in pages folder in the repo
-        const IsomerPageFile = new File(this.access_token, this.siteName)
+        const IsomerPageFile = new File(this.accessToken, this.siteName)
         IsomerPageFile.setFileType(new PageType())
         const pages = await IsomerPageFile.list()
 
@@ -110,13 +110,13 @@ class Tree {
         const unlinkedArr = [{
             type: 'collection',
             title: 'Unlinked Pages',
-            collectionPages: unlinkedPages,
+            collectionPages: this.unlinkedPages,
           }]
 
         // Check if resources are linked in the navigation bar
         // If they are not linked, include resources in the unlinked section
         if (!this.navHasResources) {
-            const resourceRoomName = await new ResourceRoom(this.access_token, this.siteName).get()
+            const resourceRoomName = await new ResourceRoom(this.accessToken, this.siteName).get()
             unlinkedArr.push({
                 type: 'resource room',
                 title: deslugifyCollectionName(resourceRoomName),
@@ -124,8 +124,8 @@ class Tree {
         }
 
         // Get the list of collections which are not linked in the navigation bar
-        const repoCollections = await new Collection(this.access_token, this.siteName).list()
-        const unlinkedCollections = _.differenceBy(repoCollections, collections)
+        const repoCollections = await new Collection(this.accessToken, this.siteName).list()
+        const unlinkedCollections = _.differenceBy(repoCollections, this.collections)
 
         // If there are any unlinked collections, generate a similar data structure
         // as this.directory
@@ -143,7 +143,7 @@ class Tree {
 
         // run the unlinked array through the same process as we did with directory
         this.unlinked = await Bluebird.map(unlinkedArr, async (item) => {
-            return pageAggregator(item, this.access_token, this.siteName)
+            return pageAggregator(item, this.accessToken, this.siteName)
         })
     }
 }

--- a/classes/Tree.js
+++ b/classes/Tree.js
@@ -1,0 +1,151 @@
+const Bluebird = require('bluebird')
+const yaml = require('js-yaml')
+const base64 = require('base-64')
+const _ = require('lodash')
+
+
+
+// Import classes and util functions
+const { File, DataType, PageType } = require('./File')
+const { ResourceRoom } = require('./ResourceRoom')
+const { Collection } = require('./Collection')
+const { pageAggregator } = require('../utils/menu-utils')
+const { deslugifyCollectionName } = require('../utils/utils')
+
+
+
+// Tree can have two methods: get linked, and get unlinked pages
+class Tree {
+    constructor(accessToken, siteName) {
+      this.accessToken = accessToken
+      this.siteName = siteName
+      this.navHasSimplePage = false
+      this.navHasResources = false
+      this.collections = []
+      this.directory = []
+      this.unlinkedPages = []
+      this.unlinked = []
+    }
+
+    async getLinkedPages() {
+        try {
+            // Obtain items in the navigation bar
+            const IsomerNavFile = new File(this.access_token, this.siteName)
+            IsomerNavFile.setFileType(new DataType())
+            const { content } = await IsomerNavFile.read('navigation.yml')
+            const navItems = yaml.safeLoad(base64.decode(content)).links;
+
+            /**
+             * The following function tokenizes the items 
+             * loaded from `navigation.yml` into these types:
+             * `page` - Simple pages
+             * `collection` - Collection pages
+             * `resource room` - Resource room pages
+             */
+
+            const directoryCollections = navItems.map(item => {
+                // If navigation item has a url it links to a simple page / external page
+                // TODO - know if it links to an external page
+                if (item.url) {
+                this.navHasSimplePage = true;
+                const fileName = item.title.toLowerCase().replace(" ", "-") + ".md"
+                return {
+                    type: 'page',
+                    title: item.title,
+                    path: encodeURIComponent(new PageType().getFolderName() + fileName),
+                    url: item.url,
+                }
+                } else if (item.collection) {
+                collections.push(item.collection)
+                return {
+                    type: 'collection',
+                    title: item.title,
+                    collection: item.collection,
+                }
+                } else if (item.resource_room) {
+                this.navHasResources = true
+                return {
+                    type: 'resource room',
+                    title: item.title,
+                }
+                }
+                return item
+            });
+
+            /**
+             * We loop through the directoryCollections item
+             * to find items of type `collection`, and retrieve the 
+             * relevant `collection-page`(s) & groups them up into
+             * `thirdnav` groups when necessary
+             */
+            this.directory = await Bluebird.map(directoryCollections, async (item) => {
+                return pageAggregator(item, this.access_token, this.siteName)
+            })
+        } catch (err) {
+          throw err
+        }
+    }
+
+    async getUnlinkedPages() {
+        // Get all files in pages folder in the repo
+        const IsomerPageFile = new File(this.access_token, this.siteName)
+        IsomerPageFile.setFileType(new PageType())
+        const pages = await IsomerPageFile.list()
+
+      
+        // Check if there are any simple pages linked in the navigation bar
+        if (this.navHasSimplePage) {
+            // Get the list of pages which are not linked in the navigation bar
+            const linkedPages = this.directory
+                                .filter(item => item.type === 'page')
+                                .map(item => ({
+                                    path: item.path,
+                                    fileName: item.path.split('%2F')[1],
+                                }))
+            this.unlinkedPages = _.differenceBy(pages, linkedPages, 'fileName')
+        } else {
+            this.unlinkedPages = pages
+        }
+
+        const unlinkedArr = [{
+            type: 'collection',
+            title: 'Unlinked Pages',
+            collectionPages: unlinkedPages,
+          }]
+
+        // Check if resources are linked in the navigation bar
+        // If they are not linked, include resources in the unlinked section
+        if (!this.navHasResources) {
+            const resourceRoomName = await new ResourceRoom(this.access_token, this.siteName).get()
+            unlinkedArr.push({
+                type: 'resource room',
+                title: deslugifyCollectionName(resourceRoomName),
+            })
+        }
+
+        // Get the list of collections which are not linked in the navigation bar
+        const repoCollections = await new Collection(this.access_token, this.siteName).list()
+        const unlinkedCollections = _.differenceBy(repoCollections, collections)
+
+        // If there are any unlinked collections, generate a similar data structure
+        // as this.directory
+        if (unlinkedCollections.length > 0) {
+            // Create an array of collection items to mimic directoryCollections above
+            const unlinkedCollectionsToAdd = unlinkedCollections.map((collection) => ({
+                type: 'collection',
+                title: deslugifyCollectionName(collection), // Convert collection name into title
+                collection,
+            }))
+            
+            // Add these collections to the array of unlinked objects
+            unlinkedArr.push(...unlinkedCollectionsToAdd)
+        }
+
+        // run the unlinked array through the same process as we did with directory
+        this.unlinked = await Bluebird.map(unlinkedArr, async (item) => {
+            return pageAggregator(item, this.access_token, this.siteName)
+        })
+    }
+}
+
+module.exports = { Tree }

--- a/routes/menuDirectory.js
+++ b/routes/menuDirectory.js
@@ -7,7 +7,7 @@ const base64 = require('base-64')
 const _ = require('lodash')
 const Bluebird = require('bluebird')
 
-const { PageType, File, CollectionPageType, MenuType } = require('../classes/File')
+const { PageType, File, CollectionPageType, DataType } = require('../classes/File')
 const { Collection } = require('../classes/Collection')
 const { ResourceRoom } = require('../classes/ResourceRoom')
 const { pageAggregator } = require('../utils/menu-utils')
@@ -35,7 +35,7 @@ router.get('/:siteName/tree', async function(req, res, next) {
   
       // read the _data/navigation.yml file
       const IsomerNavFile = new File(access_token, siteName)
-      IsomerNavFile.setFileType(new MenuType())
+      IsomerNavFile.setFileType(new DataType())
       const { content } = await IsomerNavFile.read('navigation.yml')
 
       const navItems = yaml.safeLoad(base64.decode(content)).links;

--- a/routes/menuDirectory.js
+++ b/routes/menuDirectory.js
@@ -5,6 +5,7 @@ const jwtUtils = require('../utils/jwt-utils')
 const yaml = require('js-yaml')
 const base64 = require('base-64')
 const _ = require('lodash')
+const Bluebird = require('bluebird')
 
 const { PageType, File, CollectionPageType, MenuType } = require('../classes/File')
 
@@ -37,13 +38,13 @@ router.get('/:siteName/tree', async function(req, res, next) {
           const fileName = item.title.toLowerCase().replace(" ", "-") + ".md"
           return {
             type: 'page',
-            name: fileName,
+            title: fileName,
             path: encodeURIComponent(new PageType().getFolderName() + fileName)
           }
         } else if (item.collection) {
           return {
             type: 'collection',
-            name: item.collection
+            title: item.collection
           }
         } else if (item.resource_room) {
           return {
@@ -59,73 +60,72 @@ router.get('/:siteName/tree', async function(req, res, next) {
       /**
        * This function then loops through the directory items
        * to find items of type `collection`, and retrieve the 
-       * relevant "Sub Collections" or "Collection Pages"
-       * `Promise.all()` was used as an async function was needed to 
-       * retrieve the relevant items and `Promse.all` resolves when all
-       * its array contents are resolved/rejected
+       * relevant `collection-page`(s) & groups them up into
+       * `thirdnav` groups when necessary
        */
-      directory = await Promise.all(directory.map(async item => {
+      directory = await Bluebird.map(directory, async item => {
         if (item.type === 'collection') {
-          const IsomerFile = new File(access_token, siteName)
-          const collectionPageType = new CollectionPageType(item.name)
-          IsomerFile.setFileType(collectionPageType)
-          let collectionPages = await IsomerFile.list()
+          const CollectionFile = new File(access_token, siteName)
+          const collectionPageType = new CollectionPageType(item.title)
+          CollectionFile.setFileType(collectionPageType)
+          let collectionPages = await CollectionFile.list()
 
           /**
            * Within the listed collection pages, we need to group them up
-           * into their respective sub collections
+           * into their respective thirdnav groups
            */
-          collectionPages = collectionPages.reduce((accumulator, page) => {
-            // Create a deep copy of the accumulated value
-            let accumulatorCopy = [...accumulator]
+          collectionPages = await Bluebird.reduce(collectionPages, async (accumulator, collectionPage) => {
             /**
              * Files such as `2c-filename.md` will be split
-             * by the `-` and checked if it's part of a subcollection
-             * Collection pages that are split into subcollections contains a letter
+             * by the `-` and checked if it's part of a thirdnav group
+             * Collection pages that are part of a thirdnav contains a letter
              * after their group number (i.e `c` in `2c-filename.md`)
              * Link: https://isomer.gov.sg/documentation/navbar-and-footer/creating-3rd-level-nav/
              */
-            const identifier = page.fileName.split("-")[0]
-            const isSubcollection = /[0-9][a-z]/.test(identifier)
+            const identifier = collectionPage.fileName.split("-")[0]
+            const isThirdnav = /[0-9][a-z]/.test(identifier)
 
             /**
-             * `canCreateSubcollection` is to reflect the moment
-             * a filename is start of a new subcollection
-             * (i.e `1a-filename.md` is the start of a new subcollection
+             * `canCreateThirdnav` is to check if the filename indicates
+             * a need to create a new thirdnav group to store it in
+             * (i.e `1a-filename.md` is the start of a new thirdnav
              * while `1b-filename.md` is not)
              */
-            const canCreateSubcollection = /[0-9]a$/.test(identifier)
+            const canCreateThirdnav = /[0-9]a$/.test(identifier)
         
             // Treat it as a normal collection page and proceed to the next item
-            if (!isSubcollection) {
-               accumulatorCopy.push({...page, type: 'leftnav', name: page.fileName}) 
-               return accumulatorCopy
+            if (!isThirdnav) {
+               accumulator.push({path: collectionPage.path, type: 'collection-page', title: collectionPage.fileName}) 
+               return accumulator
             }
         
-            // Create a subcollection object
-            if (canCreateSubcollection) {
-                accumulatorCopy.push({ type: "subcollection", children: [], name: "subcollection" })
+            // Create a thirdnav object
+            if (canCreateThirdnav) {
+              // Retrieve third_nav_title from frontmatter in the thirdnav page
+              const { content } = await CollectionFile.read(collectionPage.fileName)
+              const frontMatter = yaml.safeLoad(base64.decode(content).split('---')[1]);
+              accumulator.push({ title: `${frontMatter.third_nav_title}`, type: "thirdnav", children: [] })
             }
         
             /**
-             * If the program gets this far, it would mean the item is
-             * meant to be part of the last subcollection being populated in `accumulatorCopy`
+             * If the program gets this far, it would mean the item is a thirdnav-page and is
+             * meant to be part of the last thirdnav in `accumulator`
              */
-            const lastSubCollectionIndex = accumulatorCopy.length - 1
-            accumulatorCopy[lastSubCollectionIndex].children.push({...page, name: page.fileName})
+            const lastSubCollectionIndex = accumulator.length - 1
+            accumulator[lastSubCollectionIndex].children.push({path: collectionPage.path, title: collectionPage.fileName, type: 'thirdnav-page'})
             
-            return accumulatorCopy
+            return accumulator
           }, [])
 
           // Return the fully branched out collection
           return {
             type: item.type,
-            name: item.name,
+            title: item.title,
             children: collectionPages
           }
         }
         return item
-      }))
+      })
 
       const IsomerPageFile = new File(access_token, siteName)
       IsomerPageFile.setFileType(new PageType())

--- a/routes/menuDirectory.js
+++ b/routes/menuDirectory.js
@@ -1,0 +1,142 @@
+// A route to show the tree structure of the pages and collections directory
+const express = require('express');
+const router = express.Router();
+const jwtUtils = require('../utils/jwt-utils')
+const yaml = require('js-yaml')
+const base64 = require('base-64')
+const _ = require('lodash')
+
+const { PageType, File, CollectionPageType, MenuType } = require('../classes/File')
+
+// Read tree of directory
+router.get('/:siteName/tree', async function(req, res, next) {
+    try {
+      const { oauthtoken } = req.cookies
+      const { access_token } = jwtUtils.verifyToken(oauthtoken)
+  
+      const { siteName } = req.params
+  
+      const IsomerNavFile = new File(access_token, siteName)
+      IsomerNavFile.setFileType(new MenuType())
+      const { content } = await IsomerNavFile.read('navigation.yml')
+      const navItems = yaml.safeLoad(base64.decode(content)).links
+
+      /**
+       * This tokenizes the items loaded from `navigation.yml`
+       * into these types:
+       * `page` - Simple pages
+       * `collection` - Collection pages
+       * `resource room` - Resource room pages
+       */
+
+      let directory = navItems.map(item => {
+        // If navigation item has a url it links to a simple page / external page
+        // For now it defaults to a simple page
+        // TODO know if it links to an external page
+        if (item.url) {
+          const fileName = item.title.toLowerCase().replace(" ", "-") + ".md"
+          return {
+            type: 'page',
+            name: fileName,
+            path: encodeURIComponent(new PageType().getFolderName() + fileName)
+          }
+        } else if (item.collection) {
+          return {
+            type: 'collection',
+            name: item.collection
+          }
+        } else if (item.resource_room) {
+          return {
+            type: 'resource room',
+            name: item.title,
+            title: item.title
+          }
+        }
+
+        return item
+      });
+
+      /**
+       * This function then loops through the directory items
+       * to find items of type `collection`, and retrieve the 
+       * relevant "Sub Collections" or "Collection Pages"
+       * `Promise.all()` was used as an async function was needed to 
+       * retrieve the relevant items and `Promse.all` resolves when all
+       * its array contents are resolved/rejected
+       */
+      directory = await Promise.all(directory.map(async item => {
+        if (item.type === 'collection') {
+          const IsomerFile = new File(access_token, siteName)
+          const collectionPageType = new CollectionPageType(item.name)
+          IsomerFile.setFileType(collectionPageType)
+          let collectionPages = await IsomerFile.list()
+
+          /**
+           * Within the listed collection pages, we need to group them up
+           * into their respective sub collections
+           */
+          collectionPages = collectionPages.reduce((accumulator, page) => {
+            // Create a deep copy of the accumulated value
+            let accumulatorCopy = [...accumulator]
+            /**
+             * Files such as `2c-filename.md` will be split
+             * by the `-` and checked if it's part of a subcollection
+             * Collection pages that are split into subcollections contains a letter
+             * after their group number (i.e `c` in `2c-filename.md`)
+             * Link: https://isomer.gov.sg/documentation/navbar-and-footer/creating-3rd-level-nav/
+             */
+            const identifier = page.fileName.split("-")[0]
+            const isSubcollection = /[0-9][a-z]/.test(identifier)
+
+            /**
+             * `canCreateSubcollection` is to reflect the moment
+             * a filename is start of a new subcollection
+             * (i.e `1a-filename.md` is the start of a new subcollection
+             * while `1b-filename.md` is not)
+             */
+            const canCreateSubcollection = /[0-9]a$/.test(identifier)
+        
+            // Treat it as a normal collection page and proceed to the next item
+            if (!isSubcollection) {
+               accumulatorCopy.push({...page, type: 'leftnav', name: page.fileName}) 
+               return accumulatorCopy
+            }
+        
+            // Create a subcollection object
+            if (canCreateSubcollection) {
+                accumulatorCopy.push({ type: "subcollection", children: [], name: "subcollection" })
+            }
+        
+            /**
+             * If the program gets this far, it would mean the item is
+             * meant to be part of the last subcollection being populated in `accumulatorCopy`
+             */
+            const lastSubCollectionIndex = accumulatorCopy.length - 1
+            accumulatorCopy[lastSubCollectionIndex].children.push({...page, name: page.fileName})
+            
+            return accumulatorCopy
+          }, [])
+
+          // Return the fully branched out collection
+          return {
+            type: item.type,
+            name: item.name,
+            children: collectionPages
+          }
+        }
+        return item
+      }))
+
+      const IsomerPageFile = new File(access_token, siteName)
+      IsomerPageFile.setFileType(new PageType())
+      const pages = await IsomerPageFile.list()
+      const linkedPages = directory.filter(item => item.type === 'page')
+      const unlinkedPages = _.differenceBy(pages, linkedPages, 'fileName')
+      
+      res.status(200).json({ directory , unlinkedPages })
+    } catch (err) {
+      console.log(err)
+    }
+  })
+
+module.exports = router

--- a/routes/menuDirectory.js
+++ b/routes/menuDirectory.js
@@ -136,7 +136,7 @@ router.get('/:siteName/tree', async function(req, res, next) {
 
 
       // get the list of collections which are not linked in the navigation bar
-      const repoCollections = await (new Collection(access_token, siteName)).list()
+      const repoCollections = await new Collection(access_token, siteName).list()
       unlinkedCollections = _.differenceBy(repoCollections, collections)
 
       // if there are any unlinked collections, generate the same data structure
@@ -153,12 +153,12 @@ router.get('/:siteName/tree', async function(req, res, next) {
       }
 
       // run the unlinked array through the same process as we did with directory
-      unlinkedArr = await Bluebird.map(unlinkedArr, async (item) => {
+      const unlinked = await Bluebird.map(unlinkedArr, async (item) => {
         return pageAggregator(item, access_token, siteName)
       })
       
       Object.assign(response, {
-        unlinked: unlinkedArr,
+        unlinked,
       })
 
       res.status(200).json(response)

--- a/routes/menuDirectory.js
+++ b/routes/menuDirectory.js
@@ -102,7 +102,12 @@ router.get('/:siteName/tree', async function(req, res, next) {
         const pages = await IsomerPageFile.list()
 
         // get the list of pages which are not linked in the navigation bar
-        const linkedPages = directory.filter(item => item.type === 'page')
+        const linkedPages = directory
+                              .filter(item => item.type === 'page')
+                              .map(item => ({
+                                path: item.path,
+                                fileName: item.path.split('%2F')[1],
+                              }))
         unlinkedPages = _.differenceBy(pages, linkedPages, 'fileName') // THIS IS WRONG
       } else {
         unlinkedPages = pages

--- a/routes/menuDirectory.js
+++ b/routes/menuDirectory.js
@@ -130,7 +130,7 @@ router.get('/:siteName/tree', async function(req, res, next) {
         const resourceRoomName = await(new ResourceRoom(access_token, siteName)).get()
         unlinkedArr.push({
           type: 'resource room',
-          title: resourceRoomName,
+          title: deslugifyCollectionName(resourceRoomName),
         })
       }
 

--- a/routes/menuDirectory.js
+++ b/routes/menuDirectory.js
@@ -56,7 +56,6 @@ router.get('/:siteName/tree', async function(req, res, next) {
           // navigation contains simple page
           navHasSimplePage = true;
 
-          // this is the wrong way to do it, we should look at how exactly the titles are slugified
           const fileName = item.title.toLowerCase().replace(" ", "-") + ".md"
           return {
             type: 'page',
@@ -108,7 +107,7 @@ router.get('/:siteName/tree', async function(req, res, next) {
                                 path: item.path,
                                 fileName: item.path.split('%2F')[1],
                               }))
-        unlinkedPages = _.differenceBy(pages, linkedPages, 'fileName') // THIS IS WRONG
+        unlinkedPages = _.differenceBy(pages, linkedPages, 'fileName')
       } else {
         unlinkedPages = pages
       }
@@ -127,7 +126,7 @@ router.get('/:siteName/tree', async function(req, res, next) {
       // check whether resources are linked in the navigation bar
       // if they are not linked, include resources in the unlinked section
       if (!navHasResources) {
-        const resourceRoomName = await(new ResourceRoom(access_token, siteName)).get()
+        const resourceRoomName = await new ResourceRoom(access_token, siteName).get()
         unlinkedArr.push({
           type: 'resource room',
           title: deslugifyCollectionName(resourceRoomName),

--- a/routes/menuDirectory.js
+++ b/routes/menuDirectory.js
@@ -8,21 +8,38 @@ const _ = require('lodash')
 const Bluebird = require('bluebird')
 
 const { PageType, File, CollectionPageType, MenuType } = require('../classes/File')
-const { deslugifyCollectionPage } = require('../utils/utils')
+const { Collection } = require('../classes/Collection')
+const { ResourceRoom } = require('../classes/ResourceRoom')
+const { collectionPageAggregator } = require('../utils/menu-utils')
+const { deslugifyCollectionName } = require('../utils/utils')
 
 // Read tree of directory
 router.get('/:siteName/tree', async function(req, res, next) {
     try {
+      // variables to keep track of whether there are simple pages or 
+      // resources in the navigation bar
+      let navHasSimplePage = false;
+      let navHasResources = false;
+      // variable to store unlinked pages
+      let unlinkedPages;
+      // variable to keep track of collections in the nav bar
+      let collections = [];
+      let unlinkedCollections = [];
+      // object to accumulate what to send back as response
+      let response = {};
+
+      // verify credentials
       const { oauthtoken } = req.cookies
       const { access_token } = jwtUtils.verifyToken(oauthtoken)
-  
       const { siteName } = req.params
   
+      // read the _data/navigation.yml file
       const IsomerNavFile = new File(access_token, siteName)
       IsomerNavFile.setFileType(new MenuType())
       const { content } = await IsomerNavFile.read('navigation.yml')
 
       const navItems = yaml.safeLoad(base64.decode(content)).links;
+
       /**
        * This tokenizes the items loaded from `navigation.yml`
        * into these types:
@@ -36,25 +53,31 @@ router.get('/:siteName/tree', async function(req, res, next) {
         // For now it defaults to a simple page
         // TODO know if it links to an external page
         if (item.url) {
+          // navigation contains simple page
+          navHasSimplePage = true;
+
           // this is the wrong way to do it, we should look at how exactly the titles are slugified
           const fileName = item.title.toLowerCase().replace(" ", "-") + ".md"
           return {
             type: 'page',
             title: item.title,
-            path: encodeURIComponent(new PageType().getFolderName() + fileName)
+            path: encodeURIComponent(new PageType().getFolderName() + fileName),
+            url: item.url,
           }
         } else if (item.collection) {
-          console.log(item)
+          // keep track of list of collections in navigation bar
+          collections.push(item.collection)
           return {
             type: 'collection',
             title: item.title,
             collection: item.collection,
           }
         } else if (item.resource_room) {
+          // navigation contains resource room
+          navHasResources = true
           return {
             type: 'resource room',
-            name: item.title,
-            title: item.title
+            title: item.title,
           }
         }
 
@@ -62,94 +85,79 @@ router.get('/:siteName/tree', async function(req, res, next) {
       });
 
       /**
-       * This function then loops through the directory items
+       * This function then loops through the directory item
        * to find items of type `collection`, and retrieve the 
        * relevant `collection-page`(s) & groups them up into
        * `thirdnav` groups when necessary
        */
       directory = await Bluebird.map(directory, async item => {
         if (item.type === 'collection') {
-          const CollectionFile = new File(access_token, siteName)
-          const collectionPageType = new CollectionPageType(item.collection)
-          CollectionFile.setFileType(collectionPageType)
-          let collectionPages = await CollectionFile.list()
-
-          /**
-           * Within the listed collection pages, we need to group them up
-           * into their respective thirdnav groups
-           */
-          collectionPages = await Bluebird.reduce(collectionPages, async (accumulator, collectionPage) => {
-            /**
-             * Files such as `2c-filename.md` will be split
-             * by the `-` and checked if it's part of a thirdnav group
-             * Collection pages that are part of a thirdnav contains a letter
-             * after their group number (i.e `c` in `2c-filename.md`)
-             * Link: https://isomer.gov.sg/documentation/navbar-and-footer/creating-3rd-level-nav/
-             */
-            const identifier = collectionPage.fileName.split('-')[0]
-            const isThirdnav = /[0-9][a-z]/.test(identifier)
-
-            /**
-             * `canCreateThirdnav` is to check if the filename indicates
-             * a need to create a new thirdnav group to store it in
-             * (i.e `1a-filename.md` is the start of a new thirdnav
-             * while `1b-filename.md` is not)
-             */
-            const canCreateThirdnav = /[0-9]a$/.test(identifier)
-        
-            // Treat it as a normal collection page and proceed to the next item
-            if (!isThirdnav) {
-              accumulator.push({
-                 path: collectionPage.path,
-                 type: 'collection-page',
-                 title: deslugifyCollectionPage(collectionPage.fileName)
-              }) 
-              return accumulator
-            }
-        
-            // Create a thirdnav object
-            if (canCreateThirdnav) {
-              // Retrieve third_nav_title from frontmatter in the thirdnav page - this is slow
-              const { content } = await CollectionFile.read(collectionPage.fileName);
-              const frontMatter = yaml.safeLoad(base64.decode(content).split('---')[1]);
-              accumulator.push({
-                title: `${frontMatter.third_nav_title}`,
-                type: "thirdnav",
-                children: []
-              })
-            }
-        
-            /**
-             * If the program gets this far, it would mean the item is a thirdnav-page and is
-             * meant to be part of the last thirdnav in `accumulator`
-             */
-            const lastSubCollectionIndex = accumulator.length - 1
-            accumulator[lastSubCollectionIndex].children.push({
-              path: collectionPage.path,
-              title: deslugifyCollectionPage(collectionPage.fileName),
-              type: 'thirdnav-page',
-            })
-            
-            return accumulator
-          }, [])
-
-          // Return the fully branched out collection
-          return {
-            type: item.type,
-            title: item.title,
-            children: collectionPages
-          }
+          return collectionPageAggregator(item, access_token, siteName)
         }
         return item
       })
 
-      const IsomerPageFile = new File(access_token, siteName)
-      IsomerPageFile.setFileType(new PageType())
-      const pages = await IsomerPageFile.list()
-      const linkedPages = directory.filter(item => item.type === 'page')
-      const unlinkedPages = _.differenceBy(pages, linkedPages, 'fileName')
+      // check whether simple pages are linked in the navigation bar
+      if (navHasSimplePage) {
+        // get all files in pages folder in the repo
+        const IsomerPageFile = new File(access_token, siteName)
+        IsomerPageFile.setFileType(new PageType())
+        const pages = await IsomerPageFile.list()
+
+        // get the list of pages which are not linked in the navigation bar
+        const linkedPages = directory.filter(item => item.type === 'page')
+        unlinkedPages = _.differenceBy(pages, linkedPages, 'fileName') // THIS IS WRONG
+      } else {
+        unlinkedPages = pages
+      }
       
-      res.status(200).json({ directory , unlinkedPages })
+      // add directory and unlinkedPages to response since they must both exist
+      Object.assign(response, {
+        directory,
+        unlinked: {
+          unlinkedPages,
+        },
+      })
+
+      // check whether resources are linked in the navigation bar
+      // if they are not linked, include resources in the unlinked section
+      if (!navHasResources) {
+        const resourceRoomName = await(new ResourceRoom(access_token, siteName)).get()
+        Object.assign(response.unlinked, {
+          resourceRoom: {
+            type: 'resource room',
+            title: resourceRoomName,
+          },
+        })
+      }
+
+
+      // get the list of collections which are not linked in the navigation bar
+      const repoCollections = await (new Collection(access_token, siteName)).list()
+      unlinkedCollections = _.differenceBy(repoCollections, collections)
+
+      // if there are any unlinked collections, generate the same data structure
+      if (unlinkedCollections.length > 0) {
+        // create an array of collection items to mimic what is received from navigation.yml
+        unlinkedCollections = unlinkedCollections.map((collection) => ({
+          type: 'collection',
+          title: deslugifyCollectionName(collection), // convert collection name into title
+          collection,
+        }))
+
+        // go through the whole process of generating a directory
+        unlinkedCollections = await Bluebird.map(unlinkedCollections, async item => (
+          collectionPageAggregator(item, access_token, siteName)
+        ))
+  
+        unlinkedCollections.forEach((collection) => {
+          Object.assign(response.unlinked, {
+            [collection.title]: collection,
+          })
+        })
+      }
+      
+      res.status(200).json(response)
     } catch (err) {
       console.log(err)
     }

--- a/routes/menuDirectory.js
+++ b/routes/menuDirectory.js
@@ -2,155 +2,24 @@
 const express = require('express');
 const router = express.Router();
 const jwtUtils = require('../utils/jwt-utils')
-const yaml = require('js-yaml')
-const base64 = require('base-64')
-const _ = require('lodash')
-const Bluebird = require('bluebird')
 
-const { PageType, File, CollectionPageType, DataType } = require('../classes/File')
-const { Collection } = require('../classes/Collection')
-const { ResourceRoom } = require('../classes/ResourceRoom')
-const { pageAggregator } = require('../utils/menu-utils')
-const { deslugifyCollectionName } = require('../utils/utils')
+// Import classes 
+const { Tree } = require('../classes/Tree.js')
 
 // Read tree of directory
 router.get('/:siteName/tree', async function(req, res, next) {
     try {
-      // variables to keep track of whether there are simple pages or 
-      // resources in the navigation bar
-      let navHasSimplePage = false;
-      let navHasResources = false;
-      // variable to store unlinked pages
-      let unlinkedPages;
-      // variable to keep track of collections in the nav bar
-      const collections = [];
-
-      // verify credentials
       const { oauthtoken } = req.cookies
       const { access_token } = jwtUtils.verifyToken(oauthtoken)
       const { siteName } = req.params
-  
-      // read the _data/navigation.yml file
-      const IsomerNavFile = new File(access_token, siteName)
-      IsomerNavFile.setFileType(new DataType())
-      const { content } = await IsomerNavFile.read('navigation.yml')
 
-      const navItems = yaml.safeLoad(base64.decode(content)).links;
-
-      /**
-       * This tokenizes the items loaded from `navigation.yml`
-       * into these types:
-       * `page` - Simple pages
-       * `collection` - Collection pages
-       * `resource room` - Resource room pages
-       */
-
-      const directoryCollections = navItems.map(item => {
-        // If navigation item has a url it links to a simple page / external page
-        // For now it defaults to a simple page
-        // TODO know if it links to an external page
-        if (item.url) {
-          // navigation contains simple page
-          navHasSimplePage = true;
-
-          const fileName = item.title.toLowerCase().replace(" ", "-") + ".md"
-          return {
-            type: 'page',
-            title: item.title,
-            path: encodeURIComponent(new PageType().getFolderName() + fileName),
-            url: item.url,
-          }
-        } else if (item.collection) {
-          // keep track of list of collections in navigation bar
-          collections.push(item.collection)
-          return {
-            type: 'collection',
-            title: item.title,
-            collection: item.collection,
-          }
-        } else if (item.resource_room) {
-          // navigation contains resource room
-          navHasResources = true
-          return {
-            type: 'resource room',
-            title: item.title,
-          }
-        }
-
-        return item
-      });
-
-      /**
-       * This function then loops through the directoryCollections item
-       * to find items of type `collection`, and retrieve the 
-       * relevant `collection-page`(s) & groups them up into
-       * `thirdnav` groups when necessary
-       */
-      const directory = await Bluebird.map(directoryCollections, async (item) => {
-        return pageAggregator(item, access_token, siteName)
-      })
-
-      // check whether simple pages are linked in the navigation bar
-      if (navHasSimplePage) {
-        // get all files in pages folder in the repo
-        const IsomerPageFile = new File(access_token, siteName)
-        IsomerPageFile.setFileType(new PageType())
-        const pages = await IsomerPageFile.list()
-
-        // get the list of pages which are not linked in the navigation bar
-        const linkedPages = directory
-                              .filter(item => item.type === 'page')
-                              .map(item => ({
-                                path: item.path,
-                                fileName: item.path.split('%2F')[1],
-                              }))
-        unlinkedPages = _.differenceBy(pages, linkedPages, 'fileName')
-      } else {
-        unlinkedPages = pages
-      }
-
-      const unlinkedArr = [{
-        type: 'collection',
-        title: 'Unlinked Pages',
-        collectionPages: unlinkedPages,
-      }]
-
-      // check whether resources are linked in the navigation bar
-      // if they are not linked, include resources in the unlinked section
-      if (!navHasResources) {
-        const resourceRoomName = await new ResourceRoom(access_token, siteName).get()
-        unlinkedArr.push({
-          type: 'resource room',
-          title: deslugifyCollectionName(resourceRoomName),
-        })
-      }
-
-
-      // get the list of collections which are not linked in the navigation bar
-      const repoCollections = await new Collection(access_token, siteName).list()
-      const unlinkedCollections = _.differenceBy(repoCollections, collections)
-
-      // if there are any unlinked collections, generate the same data structure
-      if (unlinkedCollections.length > 0) {
-        // create an array of collection items to mimic what is received from navigation.yml
-        const unlinkedCollectionsToAdd = unlinkedCollections.map((collection) => ({
-          type: 'collection',
-          title: deslugifyCollectionName(collection), // convert collection name into title
-          collection,
-        }))
-        
-        // add these collections to the array of unlinked objects
-        unlinkedArr.push(...unlinkedCollectionsToAdd)
-      }
-
-      // run the unlinked array through the same process as we did with directory
-      const unlinked = await Bluebird.map(unlinkedArr, async (item) => {
-        return pageAggregator(item, access_token, siteName)
-      })
+      const IsomerTreeMenu = new Tree(access_token, siteName)
+      await IsomerTreeMenu.getLinkedPages()
+      await IsomerTreeMenu.getUnlinkedPages()
       
       const response = {
-        directory,
-        unlinked,
+        directory: IsomerTreeMenu.directory,
+        unlinked: IsomerTreeMenu.unlinked,
       }
 
       res.status(200).json(response)

--- a/server.js
+++ b/server.js
@@ -22,6 +22,7 @@ const imagesRouter = require('./routes/images')
 const documentsRouter = require('./routes/documents')
 const menuRouter = require('./routes/menus')
 const homepageRouter = require('./routes/homepage')
+const menuDirectoryRouter = require('./routes/menuDirectory')
 
 const app = express();
 
@@ -50,6 +51,7 @@ app.use('/sites', imagesRouter)
 app.use('/sites', documentsRouter)
 app.use('/sites', menuRouter)
 app.use('/sites', homepageRouter)
+app.use('/sites', menuDirectoryRouter)
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/utils/menu-utils.js
+++ b/utils/menu-utils.js
@@ -43,7 +43,7 @@ const thirdNavAggregator = async (collectionPages, CollectionFile, item) => {
      * Link: https://isomer.gov.sg/documentation/navbar-and-footer/creating-3rd-level-nav/
      */
     const identifier = collectionPage.fileName.split('-')[0]
-    const isThirdnav = /[0-9][a-z]/.test(identifier)
+    const isThirdnav = /^[0-9]+[a-z]/.test(identifier)
 
     /**
      * `canCreateThirdnav` is to check if the filename indicates
@@ -51,7 +51,7 @@ const thirdNavAggregator = async (collectionPages, CollectionFile, item) => {
      * (i.e `1a-filename.md` is the start of a new thirdnav
      * while `1b-filename.md` is not)
      */
-    const canCreateThirdnav = /[0-9]a$/.test(identifier)
+    const canCreateThirdnav = /^[0-9]+a$/.test(identifier)
 
     // Treat it as a normal collection page and proceed to the next item
     if (!isThirdnav) {
@@ -69,7 +69,7 @@ const thirdNavAggregator = async (collectionPages, CollectionFile, item) => {
       const { content } = await CollectionFile.read(collectionPage.fileName);
       const frontMatter = yaml.safeLoad(base64.decode(content).split('---')[1]);
       accumulator.push({
-        title: `${frontMatter.third_nav_title}`,
+        title: frontMatter.third_nav_title,
         type: "thirdnav",
         children: []
       })

--- a/utils/menu-utils.js
+++ b/utils/menu-utils.js
@@ -1,0 +1,85 @@
+const Bluebird = require('bluebird')
+const yaml = require('js-yaml')
+const base64 = require('base-64')
+const { File, CollectionPageType } = require('../classes/File')
+const { deslugifyCollectionPage } = require('./utils')
+
+// this takes a collection and returns an object that contains
+// all the items in the collection
+const collectionPageAggregator = async (item, access_token, siteName) => {
+  // list all pages in the collection
+  const CollectionFile = new File(access_token, siteName)
+  const collectionPageType = new CollectionPageType(item.collection)
+  CollectionFile.setFileType(collectionPageType)
+  const collectionPages = await CollectionFile.list()
+
+  /**
+   * Within the listed collection pages, we need to group them up
+   * into their respective thirdnav groups
+   */
+  const groupedCollectionPages = await Bluebird.reduce(collectionPages, async (accumulator, collectionPage) => {
+    /**
+     * Files such as `2c-filename.md` will be split
+     * by the `-` and checked if it's part of a thirdnav group
+     * Collection pages that are part of a thirdnav contains a letter
+     * after their group number (i.e `c` in `2c-filename.md`)
+     * Link: https://isomer.gov.sg/documentation/navbar-and-footer/creating-3rd-level-nav/
+     */
+    const identifier = collectionPage.fileName.split('-')[0]
+    const isThirdnav = /[0-9][a-z]/.test(identifier)
+
+    /**
+     * `canCreateThirdnav` is to check if the filename indicates
+     * a need to create a new thirdnav group to store it in
+     * (i.e `1a-filename.md` is the start of a new thirdnav
+     * while `1b-filename.md` is not)
+     */
+    const canCreateThirdnav = /[0-9]a$/.test(identifier)
+
+    // Treat it as a normal collection page and proceed to the next item
+    if (!isThirdnav) {
+      accumulator.push({
+        path: collectionPage.path,
+        type: 'collection-page',
+        title: deslugifyCollectionPage(collectionPage.fileName)
+      }) 
+      return accumulator
+    }
+
+    // Create a thirdnav object
+    if (canCreateThirdnav) {
+      // Retrieve third_nav_title from frontmatter in the thirdnav page - this is slow
+      const { content } = await CollectionFile.read(collectionPage.fileName);
+      const frontMatter = yaml.safeLoad(base64.decode(content).split('---')[1]);
+      accumulator.push({
+        title: `${frontMatter.third_nav_title}`,
+        type: "thirdnav",
+        children: []
+      })
+    }
+
+    /**
+     * If the program gets this far, it would mean the item is a thirdnav-page and is
+     * meant to be part of the last thirdnav in `accumulator`
+     */
+    const lastSubCollectionIndex = accumulator.length - 1
+    accumulator[lastSubCollectionIndex].children.push({
+      path: collectionPage.path,
+      title: deslugifyCollectionPage(collectionPage.fileName),
+      type: 'thirdnav-page',
+    })
+    
+    return accumulator
+  }, [])
+
+  // Return the fully branched out collection
+  return {
+    type: item.type,
+    title: item.title,
+    children: groupedCollectionPages,
+  }
+}
+
+module.exports = {
+  collectionPageAggregator,
+}

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -1,0 +1,14 @@
+/** 
+ * A function to deslugify a collection page's file name, taken from isomercms-frontend src/utils
+*/
+function deslugifyCollectionPage(collectionPageName) {
+  return collectionPageName
+    .split('.')[0] // remove the file extension
+    .split('-').slice(1) // remove the number at the start
+    .map((string) => string.charAt(0).toUpperCase() + string.slice(1)) // capitalize first letter
+    .join(' '); // join it back together
+}
+
+module.exports = {
+  deslugifyCollectionPage,
+}

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -9,6 +9,17 @@ function deslugifyCollectionPage(collectionPageName) {
     .join(' '); // join it back together
 }
 
+/** 
+ * A function to deslugify a collection's name
+*/
+function deslugifyCollectionName(collectionName) {
+  return collectionName
+    .split('-')
+    .map((string) => string.charAt(0).toUpperCase() + string.slice(1)) // capitalize first letter
+    .join(' '); // join it back together
+}
+
 module.exports = {
   deslugifyCollectionPage,
+  deslugifyCollectionName,
 }

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -2,11 +2,26 @@
  * A function to deslugify a collection page's file name, taken from isomercms-frontend src/utils
 */
 function deslugifyCollectionPage(collectionPageName) {
-  return collectionPageName
-    .split('.')[0] // remove the file extension
-    .split('-').slice(1) // remove the number at the start
-    .map((string) => string.charAt(0).toUpperCase() + string.slice(1)) // capitalize first letter
-    .join(' '); // join it back together
+  // split the collection page name 
+  const pageName = collectionPageName
+                    .split('.')[0] // remove the file extension
+                    .split('-')
+
+  // unlinked pages are special collections where, the file name doesn't start with a number
+  // if the first character of the first element in pageName is not a number, then it is an
+  // unlinked page
+  return (
+    isNaN(pageName[0][0])
+    ? 
+    pageName
+      .map((string) => string.charAt(0).toUpperCase() + string.slice(1)) // capitalize first letter
+      .join(' ') // join it back together
+    :
+    pageName
+      .slice(1)
+      .map((string) => string.charAt(0).toUpperCase() + string.slice(1)) // capitalize first letter
+      .join(' ') // join it back together
+  )
 }
 
 /** 


### PR DESCRIPTION
This pull request adds a new endpoint, `/:siteName/tree`, which returns data that is used to construct the tree for the drag and drop navigation menu in the frontend. In the context of this PR, the word **unlinked** means "not present in the main navigation bar" of the webpage.

### Context
The drag and drop navigation menu consists of two sections:
- **Navigation**, which consists of elements in the main navigation bar at the top of the webpage 
- **Unlinked**, which consists of all unlinked pages, collections, or resource room.

To obtain data for **Navigation**, we pull data from the `_data/navigation.yml` file in the site's repository and manipulate it to fit the requirements of the drag and drop tree builder in the front end.

To obtain data for **Unlinked**, we query the Github API to get the full list of pages, collections, and the resource room, and difference it against the pages already in **Navigation**, before manipulating it to also fit the requirements of the drag and drop tree builder.

The data objects for **Navigation** and **Unlinked** are then sent back to the front end together in a single object called `response`.