### PR TITLE
[sites] Fix sites endpoint

### DIFF
--- a/routes/sites.js
+++ b/routes/sites.js
@@ -20,14 +20,15 @@ router.get('/', async function(req, res, next) {
     const { oauthtoken } = req.cookies
     let { access_token } = jwtUtils.verifyToken(oauthtoken)
 
-    // variable to store user repos
-    const userRepos = []
-    let pageCount = 1
+    // Variable to store user repos
+    let siteNames = []
 
-    // variable to track pagination of user's repos in case user has more than 100
+    // Variables to track pagination of user's repos in case user has more than 100
+    let pageCount = 1
     let hasNextPage = true;
     const filePath = `https://api.github.com/user/repos?per_page=100&page=`;
 
+    // Loop through all user repos
     while (hasNextPage) {
       const resp = await axios.get(filePath + pageCount, {
         headers: {
@@ -36,26 +37,21 @@ router.get('/', async function(req, res, next) {
         }
       })
 
-      // keep only isomer repos
+      // Filter for isomer repos
       const isomerRepos = resp.data.reduce((acc, repo) => {
         if (repo.full_name.split('/')[0] === ISOMER_GITHUB_ORG_NAME) {
           return acc.concat(repo.full_name)
         }
+        return acc
       }, [])
 
-      // push to results
-      userRepos.concat(...isomerRepos)
 
-      // keeps going if there is a next page
+      siteNames= siteNames.concat(isomerRepos)
       hasNextPage = resp.headers.link.includes('next')
-
-      // increment the pageCount
       ++pageCount
     }
 
-    console.log(userRepos.length)
-
-    res.status(200).json({ userRepos })
+    res.status(200).json({ siteNames })
   } catch (err) {
     console.log(err)
   }

--- a/routes/sites.js
+++ b/routes/sites.js
@@ -42,7 +42,7 @@ const timeDiff = (lastUpdated) => {
     case 1: 
       return 'Updated 1 day ago';
     default:
-      return `Updated ${numDaysago} days ago` 
+      return `Updated ${numDaysAgo} days ago` 
   }
 }
 

--- a/routes/sites.js
+++ b/routes/sites.js
@@ -6,6 +6,23 @@ const _ = require('lodash')
 const Bluebird = require('bluebird')
 
 const ISOMER_GITHUB_ORG_NAME = 'isomerpages'
+const ISOMER_ADMIN_REPOS = [
+  'isomercms-backend',
+  'isomercms-frontend',
+  'isomer-redirection',
+  'isomerpages-template',
+  'isomer-conversion-scripts',
+  'isomer-wysiwyg',
+  'isomer-slackbot',
+  'isomer-tooling',
+  'generate-site',
+  'travisci-scripts',
+  'recommender-train',
+  'editor',
+  'ci-test',
+  'infra',
+  'markdown-helper',
+]
 
 // validateStatus allows axios to handle a 404 HTTP status without rejecting the promise.
 // This is necessary because GitHub returns a 404 status when the file does not exist.
@@ -51,7 +68,10 @@ router.get('/', async function(req, res, next) {
       hasNextPage = resp.headers.link.includes('next')
       ++pageCount
     }
-
+    
+    // Remove Isomer admin repositories from this list
+    siteNames = _.difference(siteNames, ISOMER_ADMIN_REPOS)
+    
     res.status(200).json({ siteNames })
   } catch (err) {
     console.log(err)

--- a/routes/sites.js
+++ b/routes/sites.js
@@ -30,6 +30,22 @@ const validateStatus = (status) => {
   return (status >= 200 && status < 300) || status === 404
 }
 
+// timeDiff tells us when a repo was last updated in terms of days (for e.g. 2 days ago,
+// today)
+const timeDiff = (lastUpdated) => {
+  const gapInUpdate =  new Date().getTime() - new Date(lastUpdated).getTime()
+  const numDaysAgo = Math.floor(gapInUpdate/(1000 * 60 * 60 * 24))
+  // return a message for number of days ago repo was last updated
+  switch (numDaysAgo) {
+    case 0:
+      return 'Updated today';
+    case 1: 
+      return 'Updated 1 day ago';
+    default:
+      return `Updated ${numDaysago} days ago` 
+  }
+}
+
 /* Returns a list of all sites (repos) that the user has access to on Isomer. */
 // TO-DO: Paginate properly
 router.get('/', async function(req, res, next) {
@@ -56,6 +72,8 @@ router.get('/', async function(req, res, next) {
 
       // Filter for isomer repos
       const isomerRepos = resp.data.reduce((acc, repo) => {
+        // get the last updated time
+        const test = timeDiff(repo.updated_at)
         const fullName = repo.full_name.split('/')
         if (fullName[0] === ISOMER_GITHUB_ORG_NAME) {
           return acc.concat(fullName[1])

--- a/routes/sites.js
+++ b/routes/sites.js
@@ -39,8 +39,9 @@ router.get('/', async function(req, res, next) {
 
       // Filter for isomer repos
       const isomerRepos = resp.data.reduce((acc, repo) => {
-        if (repo.full_name.split('/')[0] === ISOMER_GITHUB_ORG_NAME) {
-          return acc.concat(repo.full_name)
+        const fullName = repo.full_name.split('/')
+        if (fullName[0] === ISOMER_GITHUB_ORG_NAME) {
+          return acc.concat(fullName[1])
         }
         return acc
       }, [])

--- a/routes/sites.js
+++ b/routes/sites.js
@@ -6,23 +6,23 @@ const _ = require('lodash')
 const Bluebird = require('bluebird')
 
 const ISOMER_GITHUB_ORG_NAME = 'isomerpages'
-const ISOMER_ADMIN_REPOS = [
-  'isomercms-backend',
-  'isomercms-frontend',
-  'isomer-redirection',
-  'isomerpages-template',
-  'isomer-conversion-scripts',
-  'isomer-wysiwyg',
-  'isomer-slackbot',
-  'isomer-tooling',
-  'generate-site',
-  'travisci-scripts',
-  'recommender-train',
-  'editor',
-  'ci-test',
-  'infra',
-  'markdown-helper',
-]
+// const ISOMER_ADMIN_REPOS = [
+//   'isomercms-backend',
+//   'isomercms-frontend',
+//   'isomer-redirection',
+//   'isomerpages-template',
+//   'isomer-conversion-scripts',
+//   'isomer-wysiwyg',
+//   'isomer-slackbot',
+//   'isomer-tooling',
+//   'generate-site',
+//   'travisci-scripts',
+//   'recommender-train',
+//   'editor',
+//   'ci-test',
+//   'infra',
+//   'markdown-helper',
+// ]
 
 // validateStatus allows axios to handle a 404 HTTP status without rejecting the promise.
 // This is necessary because GitHub returns a 404 status when the file does not exist.
@@ -72,11 +72,13 @@ router.get('/', async function(req, res, next) {
 
       // Filter for isomer repos
       const isomerRepos = resp.data.reduce((acc, repo) => {
-        // get the last updated time
-        const test = timeDiff(repo.updated_at)
-        const fullName = repo.full_name.split('/')
+        const { updated_at, full_name } = repo
+        const fullName = full_name.split('/')
         if (fullName[0] === ISOMER_GITHUB_ORG_NAME) {
-          return acc.concat(fullName[1])
+          return acc.concat({
+            repoName: fullName[1],
+            lastUpdated: timeDiff(updated_at),
+          })
         }
         return acc
       }, [])
@@ -88,7 +90,7 @@ router.get('/', async function(req, res, next) {
     }
     
     // Remove Isomer admin repositories from this list
-    siteNames = _.difference(siteNames, ISOMER_ADMIN_REPOS)
+    // siteNames = _.difference(siteNames, ISOMER_ADMIN_REPOS)
     
     res.status(200).json({ siteNames })
   } catch (err) {


### PR DESCRIPTION
### Requirements
Use the `style-sites` branch on the frontend

### Context
The `Sites` page is supposed to show the Isomer websites the login user has access to. To do that, we first find the list of repositories ascribed to the user, and filter that list for Isomer websites.

However, currently, the sites endpoint returns only the first page of results when hitting the Github V3 API endpoint `https://api.github.com/user/repos`. As the maximum number of results returned per API call is 100, this means that for users with more than 100 repos, we might not be getting all Isomer repositories associated with that user. 

This can happen in the following example. If the user has 150 repos, and the first 50 repos are non-Isomer repos and the last 100 repos are Isomer repos, then with our current implementation, we get the first 50 non-Isomer repos and the following 50 Isomer repos. We thus end up missing out on the remaining Isomer repos the user has access too.

### Solution
The naive solution which this PR will implement is to get all pages from the Github API so we have all repos the user has access to and filter for Isomer repositories from there, so that we can definitively get all Isomer repos associated with that user.

In the future, we can consider using the Github V4 GraphQL API endpoint `https://developer.github.com/v4/object/user/` to get more fine grained results, such as filtering for `ownerAffiliations`.

