### PR TITLE
BREAKING CHANGE: Include collection pages in the `GET pages` endpoint

### DIFF
--- a/routes/pages.js
+++ b/routes/pages.js
@@ -41,14 +41,10 @@ router.get('/:siteName/pages', async function(req, res, next) {
       const CollectionPage = new File(access_token, siteName)
       const collectionPageType = new CollectionPageType(collectionName)
       CollectionPage.setFileType(collectionPageType)
-      const collectionPages = await Bluebird.map(await CollectionPage.list(), (item) => {
-        return {
-          ...item,
-          type: 'collection',
-          collectionName
-        }
-      })
-      return accumulator.concat(collectionPages)
+      const collectionPages = await CollectionPage.list()
+      const collectionPagesWithType = collectionPages.map((item) => ({ ...item, type: 'collection', collectionName })) // tagged with type for frontend
+
+      return accumulator.concat(collectionPagesWithType)
     }, [])
 
     const pages = simplePages.concat(allCollectionPages); // collection pages are then concatenated with simple pages


### PR DESCRIPTION
This PR now shows all collection pages, along with the existing simple pages on the `GET pages` endpoint.

### Context
Initially only simple pages were shown in the `GET pages` endpoint. The team decided that collection pages would be included as well as we were scraping the 'Collections' tab in the frontend.

### Implications
This pull request needs to be merged into `master` along with the frontend [PR](https://github.com/isomerpages/isomercms-frontend/pull/64) or else the frontend will break.