### PR TITLE
feat: add support for false collections

### DIFF
--- a/classes/Tree.js
+++ b/classes/Tree.js
@@ -47,27 +47,33 @@ class Tree {
                 // If navigation item has a url it links to a simple page / external page
                 // TODO - know if it links to an external page
                 if (item.url) {
-                this.navHasSimplePage = true;
-                const fileName = item.title.toLowerCase().replace(" ", "-") + ".md"
-                return {
-                    type: 'page',
-                    title: item.title,
-                    path: encodeURIComponent(new PageType().getFolderName() + fileName),
-                    url: item.url,
-                }
+                    this.navHasSimplePage = true;
+                    const fileName = item.title.toLowerCase().replace(" ", "-") + ".md"
+                    return {
+                        type: 'page',
+                        title: item.title,
+                        path: encodeURIComponent(new PageType().getFolderName() + fileName),
+                        url: item.url,
+                    }
                 } else if (item.collection) {
-                this.collections.push(item.collection)
-                return {
-                    type: 'collection',
-                    title: item.title,
-                    collection: item.collection,
-                }
+                    this.collections.push(item.collection)
+                    return {
+                        type: 'collection',
+                        title: item.title,
+                        collection: item.collection,
+                    }
                 } else if (item.resource_room) {
-                this.navHasResources = true
-                return {
-                    type: 'resource room',
-                    title: item.title,
-                }
+                    this.navHasResources = true
+                    return {
+                        type: 'resource room',
+                        title: item.title,
+                    }
+                } else if (item.sublinks) {
+                    return {
+                        type: 'falseCollection',
+                        title: item.title,
+                        children: item.sublinks.map((item) => (Object.assign(item, { type: 'page' }))),
+                    }
                 }
                 return item
             });


### PR DESCRIPTION
This PR adds a case for false collections in the navigation bar which act like collections do (with a dropdown on hover) but are not actual collections in the repository. This PR works with [PR#86](https://github.com/isomerpages/isomercms-frontend/pull/86) in `isomercms-frontend`