### PR TITLE
Refactor/fix environment variables

### DIFF
--- a/classes/Config.js
+++ b/classes/Config.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 
-const GITHUB_ORG_NAME = 'isomerpages'
+const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
+const BRANCH_REF = process.env.BRANCH_REF
 
 // validateStatus allows axios to handle a 404 HTTP status without rejecting the promise.
 // This is necessary because GitHub returns a 404 status when the file does not exist.
@@ -18,8 +19,12 @@ class Config {
     try {
     	const endpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${this.siteName}/contents/_config.yml`
 
-	    const resp = await axios.get(endpoint, {
-	      validateStatus: validateStatus,
+			const params = {
+        validateStatus: validateStatus,
+        "branch": this.branchRef,
+			}
+			
+	    const resp = await axios.get(endpoint, params, {
 	      headers: {
 	        Authorization: `token ${this.accessToken}`,
 	        "Content-Type": "application/json"

--- a/classes/Config.js
+++ b/classes/Config.js
@@ -46,7 +46,7 @@ class Config {
     try {
     	const endpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${this.siteName}/contents/_config.yml`
 
-		let params = {
+		const params = {
 			"message": 'Edit config',
 			"content": newContent,
 			"branch": BRANCH_REF,

--- a/classes/Config.js
+++ b/classes/Config.js
@@ -21,7 +21,7 @@ class Config {
 
 			const params = {
         validateStatus: validateStatus,
-        "branch": this.branchRef,
+        "ref": BRANCH_REF,
 			}
 			
 	    const resp = await axios.get(endpoint, params, {
@@ -49,7 +49,7 @@ class Config {
 		let params = {
 			"message": 'Edit config',
 			"content": newContent,
-			"branch": "staging",
+			"branch": BRANCH_REF,
 			"sha": sha
 		}
 

--- a/classes/Directory.js
+++ b/classes/Directory.js
@@ -1,7 +1,8 @@
 const axios = require('axios');
 const _ = require('lodash')
 
-const GITHUB_ORG_NAME = 'isomerpages'
+const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
+const BRANCH_REF = process.env.BRANCH_REF
 
 // validateStatus allows axios to handle a 404 HTTP status without rejecting the promise.
 // This is necessary because GitHub returns a 404 status when the file does not exist.
@@ -15,6 +16,7 @@ class Directory {
     this.siteName = siteName
     this.baseEndpoint = null
     this.dirType = null
+    this.branchRef = BRANCH_REF
   }
 
   setDirType(dirType) {
@@ -27,8 +29,12 @@ class Directory {
     try {
       const endpoint = `${this.baseEndpoint}`
 
-      const resp = await axios.get(endpoint, {
+      const params = {
         validateStatus: validateStatus,
+        "branch": this.branchRef,
+      }
+
+      const resp = await axios.get(endpoint, params, {
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"

--- a/classes/Directory.js
+++ b/classes/Directory.js
@@ -16,7 +16,6 @@ class Directory {
     this.siteName = siteName
     this.baseEndpoint = null
     this.dirType = null
-    this.branchRef = BRANCH_REF
   }
 
   setDirType(dirType) {
@@ -31,7 +30,7 @@ class Directory {
 
       const params = {
         validateStatus: validateStatus,
-        "branch": this.branchRef,
+        "ref": BRANCH_REF,
       }
 
       const resp = await axios.get(endpoint, params, {

--- a/classes/File.js
+++ b/classes/File.js
@@ -15,7 +15,6 @@ class File {
     this.accessToken = accessToken
     this.siteName = siteName
     this.baseEndpoint = null
-    this.branchRef = BRANCH_REF
   }
 
   setFileType(fileType) {
@@ -29,10 +28,10 @@ class File {
 
       const params = {
         validateStatus: validateStatus,
-        "branch": this.branchRef,
+        "ref": BRANCH_REF,
       }
 
-      const resp = await axios.get(endpoint, params, {
+      const resp = await axios.get(endpoint, { params }, {
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"
@@ -65,7 +64,7 @@ class File {
       const params = {
         "message": `Create file: ${fileName}`,
         "content": content,
-        "branch": this.branchRef,
+        "branch": BRANCH_REF,
       }
   
       const resp = await axios.put(endpoint, params, {
@@ -87,7 +86,7 @@ class File {
 
       const params = {
         validateStatus: validateStatus,
-        "branch": this.branchRef,
+        "ref": BRANCH_REF,
       }
 
       const resp = await axios.get(endpoint, params, {
@@ -114,7 +113,7 @@ class File {
       let params = {
         "message": `Update file: ${fileName}`,
         "content": content,
-        "branch": this.branchRef,
+        "branch": BRANCH_REF,
         "sha": sha
       }
   
@@ -137,7 +136,7 @@ class File {
 
       let params = {
         "message": `Delete file: ${fileName}`,
-        "branch": this.branchRef,
+        "branch": BRANCH_REF,
         "sha": sha
       }
   

--- a/classes/File.js
+++ b/classes/File.js
@@ -1,7 +1,8 @@
 const axios = require('axios');
 const _ = require('lodash')
 
-const GITHUB_ORG_NAME = 'isomerpages'
+const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
+const BRANCH_REF = process.env.BRANCH_REF
 
 // validateStatus allows axios to handle a 404 HTTP status without rejecting the promise.
 // This is necessary because GitHub returns a 404 status when the file does not exist.
@@ -14,11 +15,7 @@ class File {
     this.accessToken = accessToken
     this.siteName = siteName
     this.baseEndpoint = null
-    this.branchRef = 'staging'
-  }
-
-  setBranchRef(branchRef) {
-    this.branchRef = branchRef
+    this.branchRef = BRANCH_REF
   }
 
   setFileType(fileType) {
@@ -30,8 +27,12 @@ class File {
     try {
       const endpoint = `${this.baseEndpoint}`
 
-      const resp = await axios.get(endpoint, {
+      const params = {
         validateStatus: validateStatus,
+        "branch": this.branchRef,
+      }
+
+      const resp = await axios.get(endpoint, params, {
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"
@@ -61,7 +62,7 @@ class File {
     try {
       const endpoint = `${this.baseEndpoint}${fileName}`
 
-      let params = {
+      const params = {
         "message": `Create file: ${fileName}`,
         "content": content,
         "branch": this.branchRef,
@@ -84,11 +85,12 @@ class File {
     try {
       const endpoint = `${this.baseEndpoint}${fileName}`
 
-      const resp = await axios.get(endpoint, {
+      const params = {
         validateStatus: validateStatus,
-        params: {
-          ref: this.branchRef
-        },
+        "branch": this.branchRef,
+      }
+
+      const resp = await axios.get(endpoint, params, {
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"

--- a/classes/File.js
+++ b/classes/File.js
@@ -67,7 +67,7 @@ class File {
         "branch": BRANCH_REF,
       }
   
-      const resp = await axios.put(endpoint, params, {
+      const resp = await axios.put(endpoint, { params }, {
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"
@@ -89,7 +89,7 @@ class File {
         "ref": BRANCH_REF,
       }
 
-      const resp = await axios.get(endpoint, params, {
+      const resp = await axios.get(endpoint, { params }, {
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"
@@ -117,7 +117,7 @@ class File {
         "sha": sha
       }
   
-      const resp = await axios.put(endpoint, params, {
+      const resp = await axios.put(endpoint, { params } , {
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"

--- a/classes/File.js
+++ b/classes/File.js
@@ -15,11 +15,12 @@ class File {
     this.accessToken = accessToken
     this.siteName = siteName
     this.baseEndpoint = null
+    this.folderPath = null
   }
 
   setFileType(fileType) {
-    const folderPath = fileType.getFolderName()
-    this.baseEndpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${this.siteName}/contents/${folderPath}`
+    this.folderPath = fileType.getFolderName()
+    this.baseEndpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${this.siteName}/contents${ this.folderPath ? '/' : '' }${this.folderPath}`
   }
 
   async list() {
@@ -59,7 +60,7 @@ class File {
 
   async create(fileName, content) {
     try {
-      const endpoint = `${this.baseEndpoint}${fileName}`
+      const endpoint = `${this.baseEndpoint}/${fileName}`
 
       const params = {
         "message": `Create file: ${fileName}`,
@@ -82,7 +83,7 @@ class File {
 
   async read(fileName) {
     try {
-      const endpoint = `${this.baseEndpoint}${fileName}`
+      const endpoint = `${this.baseEndpoint}/${fileName}`
 
       const params = {
         validateStatus: validateStatus,
@@ -108,7 +109,7 @@ class File {
 
   async update(fileName, content, sha) {
     try {
-      const endpoint = `${this.baseEndpoint}${fileName}`
+      const endpoint = `${this.baseEndpoint}/${fileName}`
 
       const params = {
         "message": `Update file: ${fileName}`,
@@ -132,7 +133,7 @@ class File {
 
   async delete (fileName, sha) {
     try {
-      const endpoint = `${this.baseEndpoint}${fileName}`
+      const endpoint = `${this.baseEndpoint}/${fileName}`
 
       const params = {
         "message": `Delete file: ${fileName}`,
@@ -155,7 +156,7 @@ class File {
 
 class PageType {
   constructor() {
-    this.folderName = 'pages/'
+    this.folderName = 'pages'
   }
   getFolderName() {
     return this.folderName
@@ -164,7 +165,7 @@ class PageType {
 
 class CollectionPageType {
   constructor(collectionName) {
-    this.folderName = `_${collectionName}/`
+    this.folderName = `_${collectionName}`
   }
   getFolderName() {
     return this.folderName
@@ -173,7 +174,7 @@ class CollectionPageType {
 
 class ResourcePageType {
   constructor(resourceRoomName, resourceName) {
-    this.folderName = `${resourceRoomName}/${resourceName}/_posts/`
+    this.folderName = `${resourceRoomName}/${resourceName}/_posts`
   }
   getFolderName() {
     return this.folderName
@@ -182,7 +183,7 @@ class ResourcePageType {
 
 class ResourceType {
   constructor(resourceRoomName) {
-    this.folderName = `${resourceRoomName}/`
+    this.folderName = `${resourceRoomName}`
   }
   getFolderName() {
     return this.folderName
@@ -191,7 +192,7 @@ class ResourceType {
 
 class ImageType {
   constructor() {
-    this.folderName = 'images/'
+    this.folderName = 'images'
   }
   getFolderName() {
     return this.folderName
@@ -200,7 +201,7 @@ class ImageType {
 
 class DocumentType {
   constructor() {
-    this.folderName = 'files/'
+    this.folderName = 'files'
   }
   getFolderName() {
     return this.folderName
@@ -209,7 +210,7 @@ class DocumentType {
 
 class DataType {
   constructor() {
-    this.folderName = '_data/'
+    this.folderName = '_data'
   }
   getFolderName() {
     return this.folderName
@@ -218,7 +219,7 @@ class DataType {
 
 class HomepageType {
   constructor() {
-    this.folderName = 'index.md'
+    this.folderName = ''
   }
   getFolderName() {
     return this.folderName

--- a/classes/File.js
+++ b/classes/File.js
@@ -110,7 +110,7 @@ class File {
     try {
       const endpoint = `${this.baseEndpoint}${fileName}`
 
-      let params = {
+      const params = {
         "message": `Update file: ${fileName}`,
         "content": content,
         "branch": BRANCH_REF,
@@ -134,7 +134,7 @@ class File {
     try {
       const endpoint = `${this.baseEndpoint}${fileName}`
 
-      let params = {
+      const params = {
         "message": `Delete file: ${fileName}`,
         "branch": BRANCH_REF,
         "sha": sha

--- a/routes/homepage.js
+++ b/routes/homepage.js
@@ -6,7 +6,7 @@ const jwtUtils = require('../utils/jwt-utils')
 const { File, HomepageType } = require('../classes/File.js')
 
 // Constants
-const HOMEPAGE_INDEX_PATH = '' // Empty string
+const HOMEPAGE_INDEX_PATH = 'index.md' // Empty string
 
 // Read homepage index file
 router.get('/:siteName/homepage', async function(req, res, next) {

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -18,7 +18,7 @@ router.get('/:siteName/pages', async function(req, res, next) {
     const IsomerFile = new File(access_token, siteName)
     const pageType = new PageType()
     IsomerFile.setFileType(pageType)
-    let simplePages = await IsomerFile.list()
+    const simplePages = await IsomerFile.list()
     // After listing all simple pages, they're tagged for the frontend
     simplePages = simplePages.map(simplePage => {
       return {

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -20,7 +20,7 @@ router.get('/:siteName/pages', async function(req, res, next) {
     IsomerFile.setFileType(pageType)
     const simplePages = await IsomerFile.list()
     // After listing all simple pages, they're tagged for the frontend
-    simplePages = simplePages.map(simplePage => {
+    const taggedSimplePages = simplePages.map(simplePage => {
       return {
         ...simplePage,
         type: 'simple-page'
@@ -51,7 +51,7 @@ router.get('/:siteName/pages', async function(req, res, next) {
       return accumulator.concat(collectionPagesWithType)
     }, [])
 
-    const pages = simplePages.concat(allCollectionPages); // collection pages are then concatenated with simple pages
+    const pages = taggedSimplePages.concat(allCollectionPages); // collection pages are then concatenated with simple pages
     res.status(200).json({ pages })
   } catch (err) {
     console.log(err)


### PR DESCRIPTION
This PR achieves three things:
1. It introduces two new environment variables: `GITHUB_ORG_NAME` and `BRANCH_REF`. Existing code was refactored to accommodate these env variables.
2. Code was refactored so that the `baseEndpoints` do not end with a `/` (for example, for `PageType` the endpoint is now `pages` instead of `pages/`). This effectively undoes #19 but fixes the homepage `baseEndpoint` problem by using a ternary operator in `setFileType()`
2. It explicitly requests for the staging branch when making calls to the Github API