### PR TITLE
Fix/axios calls params

### DIFF
--- a/classes/Config.js
+++ b/classes/Config.js
@@ -24,7 +24,8 @@ class Config {
         "ref": BRANCH_REF,
 			}
 			
-	    const resp = await axios.get(endpoint, params, {
+	    const resp = await axios.get(endpoint, {
+				params,
 	      headers: {
 	        Authorization: `token ${this.accessToken}`,
 	        "Content-Type": "application/json"

--- a/classes/Directory.js
+++ b/classes/Directory.js
@@ -33,7 +33,8 @@ class Directory {
         "ref": BRANCH_REF,
       }
 
-      const resp = await axios.get(endpoint, params, {
+      const resp = await axios.get(endpoint, {
+        params,
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"

--- a/classes/File.js
+++ b/classes/File.js
@@ -32,7 +32,8 @@ class File {
         "ref": BRANCH_REF,
       }
 
-      const resp = await axios.get(endpoint, { params }, {
+      const resp = await axios.get(endpoint, {
+        params,
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"
@@ -68,7 +69,7 @@ class File {
         "branch": BRANCH_REF,
       }
   
-      const resp = await axios.put(endpoint, { params }, {
+      const resp = await axios.put(endpoint, params, {
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"
@@ -90,7 +91,8 @@ class File {
         "ref": BRANCH_REF,
       }
 
-      const resp = await axios.get(endpoint, { params }, {
+      const resp = await axios.get(endpoint, {
+        params,
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"
@@ -118,7 +120,7 @@ class File {
         "sha": sha
       }
   
-      const resp = await axios.put(endpoint, { params } , {
+      const resp = await axios.put(endpoint, params, {
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"

--- a/classes/File.js
+++ b/classes/File.js
@@ -144,7 +144,7 @@ class File {
       }
   
       await axios.delete(endpoint, {
-        data: params,
+        params,
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"


### PR DESCRIPTION
`axios` takes in params differently when it makes different kinds of requests. For example, a `GET `or a `DELETE` request should be structured: 

```
axios.get(endpoint, { params, headers })
```

But when doing `PUT` requests, the params is a separate argument: 

```
axios.put(endpoint, params, { headers })
```

This PR fixes some mistakes made in the way we made `axios` requests before. Namely:
- When making `GET` calls, we sometimes passed `params` as a separate argument
- When making `DELETE` calls, we passed `params` under a `data` attribute