### PR TITLE
[Fix - Sites] Display correct sites for users

### DIFF
--- a/routes/sites.js
+++ b/routes/sites.js
@@ -59,11 +59,15 @@ router.get('/', async function(req, res, next) {
     // Variables to track pagination of user's repos in case user has more than 100
     let pageCount = 1
     let hasNextPage = true;
-    const filePath = `https://api.github.com/user/repos?per_page=100&page=`;
+    const filePath = `https://api.github.com/user/repos`;
 
     // Loop through all user repos
     while (hasNextPage) {
-      const resp = await axios.get(filePath + pageCount, {
+      const resp = await axios.get(filePath, {
+        params: {
+          per_page: 100,
+          page: pageCount,
+        },
         headers: {
           Authorization: `token ${access_token}`,
           "Content-Type": "application/json"
@@ -85,7 +89,7 @@ router.get('/', async function(req, res, next) {
 
 
       siteNames= siteNames.concat(isomerRepos)
-      hasNextPage = resp.headers.link.includes('next')
+      hasNextPage = resp.headers.link ? resp.headers.link.includes('next') : false
       ++pageCount
     }
     

--- a/routes/sites.js
+++ b/routes/sites.js
@@ -77,11 +77,10 @@ router.get('/', async function(req, res, next) {
 
       // Filter for isomer repos
       const isomerRepos = resp.data.reduce((acc, repo) => {
-        const { permissions, updated_at, full_name } = repo
-        const fullName = full_name.split('/')
+        const { permissions, updated_at, name } = repo
         if (permissions.push === true) {
           return acc.concat({
-            repoName: fullName[1],
+            repoName: name,
             lastUpdated: timeDiff(updated_at),
           })
         }

--- a/routes/sites.js
+++ b/routes/sites.js
@@ -5,7 +5,7 @@ const jwtUtils = require('../utils/jwt-utils')
 const _ = require('lodash')
 const Bluebird = require('bluebird')
 
-const ISOMER_GITHUB_ORG_NAME = 'isomerpages'
+const ISOMER_GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
 // const ISOMER_ADMIN_REPOS = [
 //   'isomercms-backend',
 //   'isomercms-frontend',
@@ -59,26 +59,27 @@ router.get('/', async function(req, res, next) {
     // Variables to track pagination of user's repos in case user has more than 100
     let pageCount = 1
     let hasNextPage = true;
-    const filePath = `https://api.github.com/user/repos`;
+    const endpoint = `https://api.github.com/orgs/${ISOMER_GITHUB_ORG_NAME}/repos`;
 
     // Loop through all user repos
     while (hasNextPage) {
-      const resp = await axios.get(filePath, {
+      const resp = await axios.get(endpoint, {
         params: {
           per_page: 100,
           page: pageCount,
+          sort: "full_name",
         },
         headers: {
           Authorization: `token ${access_token}`,
-          "Content-Type": "application/json"
+          Accept: "application/vnd.github.baptiste-preview+json",
         }
       })
 
       // Filter for isomer repos
       const isomerRepos = resp.data.reduce((acc, repo) => {
-        const { updated_at, full_name } = repo
+        const { permissions, updated_at, full_name } = repo
         const fullName = full_name.split('/')
-        if (fullName[0] === ISOMER_GITHUB_ORG_NAME) {
+        if (permissions.push === true) {
           return acc.concat({
             repoName: fullName[1],
             lastUpdated: timeDiff(updated_at),


### PR DESCRIPTION
### Objective
This PR will restrict the repositories the user sees on the `Sites` page to the repositories that belong to the teams they are on.

### Context
Currently, all users receive access to all repositories when they log into IsomerCMS. This is not the intended behavior - we want to show users only the repositories they have write access to.

The way we retrieve repositories right now is to simply list all the repositories a user is associated with through Github's `user/repos` endpoint and filter for `isomerpages` organization repositories.

~Instead, we can use the `user/teams` [endpoint](https://developer.github.com/v3/teams/#list-user-teams) to retrieve all teams that the user is a part of, and then use the `teams/:team_id/repos` [endpoint](https://developer.github.com/v3/teams/#list-team-repos) to retrieve the repos. Note: using the teams API requires "`user`, `repo`, or `read:org` scope when authenticating via OAuth."~

Since technically, each user needs to belong to at least one team, and each member in the team has `write` access to all the repos associated with the team, we can filter based on which repos the user has `write` access to. 

We can use the `orgs/:orgs/repos` endpoint to get a full list of the repos in the `isomerpages` organization that the user has at least `read` access to, and then filter the response based on `permissions: { push: true }` to find the repos the user has `write` access to.



