### PR TITLE
fix: remove unnecessary header

### DIFF
--- a/routes/sites.js
+++ b/routes/sites.js
@@ -71,7 +71,7 @@ router.get('/', async function(req, res, next) {
         },
         headers: {
           Authorization: `token ${access_token}`,
-          Accept: "application/vnd.github.baptiste-preview+json",
+          "Content-Type": "application/json",
         }
       })
 

--- a/routes/sites.js
+++ b/routes/sites.js
@@ -88,7 +88,7 @@ router.get('/', async function(req, res, next) {
       }, [])
 
 
-      siteNames= siteNames.concat(isomerRepos)
+      siteNames = siteNames.concat(isomerRepos)
       hasNextPage = resp.headers.link ? resp.headers.link.includes('next') : false
       ++pageCount
     }


### PR DESCRIPTION
This removes the unnecessary `vnd.github.baptiste-preview` header used in the Github Repos API call.