### PR TITLE
fix: use validateStatus correctly

### DIFF
--- a/classes/Config.js
+++ b/classes/Config.js
@@ -1,13 +1,8 @@
 const axios = require('axios');
+const validateStatus = require('../utils/axios-utils')
 
 const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
 const BRANCH_REF = process.env.BRANCH_REF
-
-// validateStatus allows axios to handle a 404 HTTP status without rejecting the promise.
-// This is necessary because GitHub returns a 404 status when the file does not exist.
-const validateStatus = (status) => {
-  return (status >= 200 && status < 300) || status === 404
-}
 
 class Config {
   constructor(accessToken, siteName) {
@@ -20,11 +15,11 @@ class Config {
     	const endpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${this.siteName}/contents/_config.yml`
 
 			const params = {
-        validateStatus: validateStatus,
         "ref": BRANCH_REF,
 			}
 			
 	    const resp = await axios.get(endpoint, {
+				validateStatus,
 				params,
 	      headers: {
 	        Authorization: `token ${this.accessToken}`,

--- a/classes/Directory.js
+++ b/classes/Directory.js
@@ -29,11 +29,11 @@ class Directory {
       const endpoint = `${this.baseEndpoint}`
 
       const params = {
-        validateStatus: validateStatus,
         "ref": BRANCH_REF,
       }
 
       const resp = await axios.get(endpoint, {
+        validateStatus: validateStatus,
         params,
         headers: {
           Authorization: `token ${this.accessToken}`,

--- a/classes/Directory.js
+++ b/classes/Directory.js
@@ -1,14 +1,9 @@
 const axios = require('axios');
 const _ = require('lodash')
+const validateStatus = require('../utils/axios-utils')
 
 const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
 const BRANCH_REF = process.env.BRANCH_REF
-
-// validateStatus allows axios to handle a 404 HTTP status without rejecting the promise.
-// This is necessary because GitHub returns a 404 status when the file does not exist.
-const validateStatus = (status) => {
-  return (status >= 200 && status < 300) || status === 404
-}
 
 class Directory {
   constructor(accessToken, siteName) {
@@ -33,7 +28,7 @@ class Directory {
       }
 
       const resp = await axios.get(endpoint, {
-        validateStatus: validateStatus,
+        validateStatus,
         params,
         headers: {
           Authorization: `token ${this.accessToken}`,

--- a/classes/File.js
+++ b/classes/File.js
@@ -1,14 +1,9 @@
 const axios = require('axios');
 const _ = require('lodash')
+const validateStatus = require('../utils/axios-utils')
 
 const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
 const BRANCH_REF = process.env.BRANCH_REF
-
-// validateStatus allows axios to handle a 404 HTTP status without rejecting the promise.
-// This is necessary because GitHub returns a 404 status when the file does not exist.
-const validateStatus = (status) => {
-  return (status >= 200 && status < 300) || status === 404
-}
 
 class File {
   constructor(accessToken, siteName) {
@@ -32,7 +27,7 @@ class File {
       }
 
       const resp = await axios.get(endpoint, {
-        validateStatus: validateStatus,
+        validateStatus,
         params,
         headers: {
           Authorization: `token ${this.accessToken}`,
@@ -91,7 +86,7 @@ class File {
       }
 
       const resp = await axios.get(endpoint, {
-        validateStatus: validateStatus,
+        validateStatus,
         params,
         headers: {
           Authorization: `token ${this.accessToken}`,

--- a/classes/File.js
+++ b/classes/File.js
@@ -28,11 +28,11 @@ class File {
       const endpoint = `${this.baseEndpoint}`
 
       const params = {
-        validateStatus: validateStatus,
         "ref": BRANCH_REF,
       }
 
       const resp = await axios.get(endpoint, {
+        validateStatus: validateStatus,
         params,
         headers: {
           Authorization: `token ${this.accessToken}`,
@@ -87,11 +87,11 @@ class File {
       const endpoint = `${this.baseEndpoint}/${fileName}`
 
       const params = {
-        validateStatus: validateStatus,
         "ref": BRANCH_REF,
       }
 
       const resp = await axios.get(endpoint, {
+        validateStatus: validateStatus,
         params,
         headers: {
           Authorization: `token ${this.accessToken}`,

--- a/classes/ImageFile.js
+++ b/classes/ImageFile.js
@@ -1,13 +1,8 @@
 const axios = require('axios');
 const _ = require('lodash')
+const validateStatus = require('../utils/axios-utils')
 
 const GITHUB_ORG_NAME = 'isomerpages'
-
-// validateStatus allows axios to handle a 404 HTTP status without rejecting the promise.
-// This is necessary because GitHub returns a 404 status when the file does not exist.
-const validateStatus = (status) => {
-  return (status >= 200 && status < 300) || status === 404
-}
 
 class ImageFile {
   constructor(accessToken, siteName) {
@@ -32,7 +27,7 @@ class ImageFile {
       const endpoint = `${this.baseEndpoint}`
 
       const resp = await axios.get(endpoint, {
-        validateStatus: validateStatus,
+        validateStatus,
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"

--- a/routes/sites.js
+++ b/routes/sites.js
@@ -3,7 +3,6 @@ const router = express.Router();
 const axios = require('axios');
 const jwtUtils = require('../utils/jwt-utils')
 const _ = require('lodash')
-const Bluebird = require('bluebird')
 
 const ISOMER_GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
 // const ISOMER_ADMIN_REPOS = [
@@ -23,12 +22,6 @@ const ISOMER_GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
 //   'infra',
 //   'markdown-helper',
 // ]
-
-// validateStatus allows axios to handle a 404 HTTP status without rejecting the promise.
-// This is necessary because GitHub returns a 404 status when the file does not exist.
-const validateStatus = (status) => {
-  return (status >= 200 && status < 300) || status === 404
-}
 
 // timeDiff tells us when a repo was last updated in terms of days (for e.g. 2 days ago,
 // today)

--- a/utils/axios-utils.js
+++ b/utils/axios-utils.js
@@ -1,0 +1,7 @@
+// validateStatus allows axios to handle a 404 HTTP status without rejecting the promise.
+// This is necessary because GitHub returns a 404 status when the file does not exist.
+const validateStatus = (status) => {
+  return (status >= 200 && status < 300) || status === 404
+}
+
+module.exports = validateStatus


### PR DESCRIPTION
This PR fixes the bug where axios throws an error if the response status is 404 despite having a `validateStatus` param. The error is still thrown because `validateStatus` should exist as a field outside of `params` - this fix moves `validateStatus` out of the `params` field.