### PR TITLE
fix: allow larger image uploads

### DIFF
--- a/classes/File.js
+++ b/classes/File.js
@@ -68,7 +68,8 @@ class File {
         headers: {
           Authorization: `token ${this.accessToken}`,
           "Content-Type": "application/json"
-        }
+        },
+        maxContentLength: Infinity
       })
 
       return { sha: resp.data.content.sha }

--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ const settingsRouter = require('./routes/settings')
 const app = express();
 
 app.use(logger('dev'));
-app.use(express.json({ limit: '5mb'}));
+app.use(express.json({ limit: '100mb'}));
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
This is to fix the inability to upload large images. There were two
stoppers, the express server receiving it and sending it to github's
API. The solution for both issues were to increase the size limits.

