### PR TITLE
feat: use footer.yml instead of social-media.yml

### DIFF
--- a/classes/Settings.js
+++ b/classes/Settings.js
@@ -4,7 +4,7 @@ const Bluebird = require('bluebird')
 
 // import classes
 const { Config } = require('../classes/Config.js')
-const { File, DataType, HomepageType } = require('../classes/File.js')
+const { File, DataType } = require('../classes/File.js')
 
 // Constants
 const FOOTER_PATH = 'footer.yml'
@@ -17,7 +17,7 @@ class Settings {
 
   async get() {
     try {
-      // retrieve _config.yml, index.md, and footer.yml
+      // retrieve _config.yml and footer.yml
       const configResp = new Config(this.accessToken, this.siteName)
 
       const IsomerDataFile = new File(this.accessToken, this.siteName)


### PR DESCRIPTION
**Note:** This PR is to be reviewed together with PR #[155](https://github.com/isomerpages/isomercms-frontend/pull/155) on the frontend.

## Overview

Currently, we are reading and writing social media data from the `_data/social-media.yml` file and creating one of these files if they do not exist. However, this is wrong - we don't actually use a `social-media.yml` file in the Isomer V2 templates. Instead this information is found in the `_data/footer.yml` file. This commit fixes that by retrieving information from and writing to the `_data/footer.yml` file instead. The updated code sends all footer content to as a response.

This commit also modifies the Settings class so that when retrieving the settings information, the api calls for both the config and footer files are made concurrently using the Bluebird library.