### PR TITLE
fix: allow collections to be empty in _config.yml

### DIFF
--- a/classes/Collection.js
+++ b/classes/Collection.js
@@ -16,10 +16,9 @@ class Collection {
     try {
     	const config = new Config(this.accessToken, this.siteName)
     	const { content, sha } = await config.read()
-    	const contentObject = yaml.safeLoad(base64.decode(content))
-
-    	return Object.keys(contentObject.collections)
-
+		const contentObject = yaml.safeLoad(base64.decode(content))
+		const collections = contentObject.collections ? Object.keys(contentObject.collections) : []
+		return collections
     } catch (err) {
       throw err
     }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -44,7 +44,7 @@ auth.get('/sites/:siteName/homepage', verifyJwt)
 auth.post('/sites/:siteName/homepage', verifyJwt)
 
 // Collection pages
-auth.get('/sites/sites/:siteName/collections/:collectionName', verifyJwt)
+auth.get('/sites/:siteName/collections/:collectionName', verifyJwt)
 auth.post('/sites/:siteName/collections/:collectionName/pages', verifyJwt)
 auth.get('/sites/:siteName/collections/:collectionName/pages/:pageName', verifyJwt)
 auth.post('/sites/:siteName/collections/:collectionName/pages/:pageName', verifyJwt)


### PR DESCRIPTION
## Overview
Currently, when faced with a repo which does not have any collections, our `Collection` class' `list` method throws an error since it tries to use `Object.keys` on the non-existent `collection` attribute.

This commit fixes that by only performing the operation if the `collections` attribute exists on the config object, otherwise an empty array is returned. This allows us to accommodate repositories without any collections. This PR resolves issue #61 