### PR TITLE
feat: truncate and remove chars from version desc. before deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 env:
   PRODUCTION_BRANCH: refs/heads/master
   STAGING_BRANCH: refs/heads/staging
-  DEV_BRANCH: refs/heads/setup-github-actions
+  DEV_BRANCH: refs/heads/staging-dev
   EB_APP: isomer-cms
   EB_ENV_PRODUCTION: isomercms-backend-prod
   EB_ENV_STAGING: isomercms-backend-staging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ env:
   EB_ENV_PRODUCTION: isomercms-backend-prod
   EB_ENV_STAGING: isomercms-backend-staging
   EB_ENV_DEV: isomercms-backend-staging-dev
+  COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 jobs:
   gatekeep:
     name: Determine if Build & Deploy is needed
@@ -65,6 +66,14 @@ jobs:
           id: get_label
           env:
             TIMESTAMP: ${{ steps.get_timestamp.outputs.timestamp }}
+        - name: Get truncated version_description
+          id: get_desc
+          shell: python
+          run: |
+            import os
+            commit_message = os.environ['COMMIT_MESSAGE']
+            description = commit_message[0:100].replace('(', '').replace(')', '').replace('\'', '')
+            print('::set-output name=desc::' + description)
         - name: Select Elastic Beanstalk variables
           shell: python
           run: |
@@ -94,7 +103,7 @@ jobs:
             aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_FOR_DEPLOYMENT }}
             application_name: ${{ steps.select_eb_vars.outputs.eb_app }}
             environment_name: ${{ steps.select_eb_vars.outputs.eb_env }}
-            version_description: ${{ github.event.head_commit.message }}
+            version_description: ${{ steps.get_desc.output.desc }}
             version_label: ${{ steps.get_label.outputs.label }}
             region: ap-southeast-1
             deployment_package: deploy.zip


### PR DESCRIPTION
## Overview
Currently, we get the following error when we attempt to deploy to AWS EB with certain commit messages:

```
Deployment failed: Error: Status: 403. Code: SignatureDoesNotMatch,
Message: The request signature we calculated does not match the
signature you provided. Check your AWS Secret Access Key and signing
method. Consult the service documentation for details.
```

This is not because our access key is wrong, but because there are certain characters in our commit message which are not dealt with properly by the beanstalk-deploy package. We know that the following characters have produced problems for us:

```
(    )    '
```

These are due to encoding [issues](https://github.com/einaregilsson/beanstalk-deploy/issues/28#issuecomment-721159380) on the original beanstalk-deploy library.

Rather than wait for a fix from the package author, we can first truncate the message, since the title is in the first few words, to lower the chance of a special character, and then we can replace these characters ourselves in the deploy step when setting the version description. 

Here is a [test run](https://github.com/isomerpages/isomercms-backend/runs/1352569766?check_suite_focus=true) where the updated workflow succeeded in deploying.