### PR TITLE
Ci/refine gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 env:
   PRODUCTION_BRANCH: refs/heads/master
   STAGING_BRANCH: refs/heads/staging
-  DEV_BRANCH: refs/heads/staging-dev
+  DEV_BRANCH: refs/heads/ci/refine-gh-actions
   EB_APP: isomer-cms
   EB_ENV_PRODUCTION: isomercms-backend-prod
   EB_ENV_STAGING: isomercms-backend-staging
@@ -32,10 +32,26 @@ jobs:
             print('::set-output name=proceed::true')
           else:
             print('::set-output name=proceed::false')
+  test:
+    name: Check that application can run
+    runs-on: ubuntu-18.04
+    steps:
+        - uses: actions/checkout@v2
+        - name: Use Node.js
+          uses: actions/setup-node@v1
+          with:
+            node-version: '12.x'
+        - name: Install NPM
+          run: npm ci
+        - name: Start application
+          run: npm start
+        - name: Confirm that checks are completed
+          shell: bash
+          run: echo "App started successfully!"
   deploy:
     name: Build and deploy to EB
     runs-on: ubuntu-18.04
-    needs: [gatekeep]
+    needs: [gatekeep, test]
     if: needs.gatekeep.outputs.proceed == 'true'
     steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 on:
   push:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, synchronize, reopened]
 env:
   PRODUCTION_BRANCH: refs/heads/master
   STAGING_BRANCH: refs/heads/staging
@@ -13,12 +13,32 @@ env:
   EB_ENV_DEV: isomercms-backend-staging-dev
   COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 jobs:
+  exportEnv:
+    name: Make workflow-level env vars available at the job level
+    runs-on: ubuntu-18.04
+    outputs:
+      PRODUCTION_BRANCH: ${{ steps.export_env_vars.outputs.prod }}
+      STAGING_BRANCH: ${{ steps.export_env_vars.outputs.staging }}
+      DEV_BRANCH: ${{ steps.export_env_vars.outputs.dev }}
+    steps:
+      - name: Export env vars
+        shell: python
+        id: export_env_vars
+        run: |
+          import os
+          prod = os.environ['PRODUCTION_BRANCH']
+          staging = os.environ['STAGING_BRANCH']
+          dev = os.environ['DEV_BRANCH']
+          print('::set-output name=prod::' + prod)
+          print('::set-output name=staging::' + staging)
+          print('::set-output name=dev::' + dev)
   gatekeep:
     name: Determine if Build & Deploy is needed
+    runs-on: ubuntu-18.04
+    needs: [exportEnv]
     outputs:
       proceed: ${{ steps.determine_proceed.outputs.proceed }}
-    runs-on: ubuntu-18.04
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && (github.event.ref == needs.exportEnv.outputs.PRODUCTION_BRANCH || github.event.ref == needs.exportEnv.outputs.STAGING_BRANCH || github.event.ref == needs.exportEnv.outputs.DEV_BRANCH)
     steps:
       - shell: python
         id: determine_proceed
@@ -35,6 +55,7 @@ jobs:
   test:
     name: Check that application can run
     runs-on: ubuntu-18.04
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && (github.event.ref == needs.exportEnv.outputs.PRODUCTION_BRANCH || github.event.ref == needs.exportEnv.outputs.STAGING_BRANCH || github.event.ref == needs.exportEnv.outputs.DEV_BRANCH))
     steps:
         - uses: actions/checkout@v2
         - name: Use Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,32 +13,12 @@ env:
   EB_ENV_DEV: isomercms-backend-staging-dev
   COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 jobs:
-  exportEnv:
-    name: Make workflow-level env vars available at the job level
-    runs-on: ubuntu-18.04
-    outputs:
-      PRODUCTION_BRANCH: ${{ steps.export_env_vars.outputs.prod }}
-      STAGING_BRANCH: ${{ steps.export_env_vars.outputs.staging }}
-      DEV_BRANCH: ${{ steps.export_env_vars.outputs.dev }}
-    steps:
-      - name: Export env vars
-        shell: python
-        id: export_env_vars
-        run: |
-          import os
-          prod = os.environ['PRODUCTION_BRANCH']
-          staging = os.environ['STAGING_BRANCH']
-          dev = os.environ['DEV_BRANCH']
-          print('::set-output name=prod::' + prod)
-          print('::set-output name=staging::' + staging)
-          print('::set-output name=dev::' + dev)
   gatekeep:
     name: Determine if Build & Deploy is needed
     runs-on: ubuntu-18.04
-    needs: [exportEnv]
     outputs:
       proceed: ${{ steps.determine_proceed.outputs.proceed }}
-    if: github.event_name == 'push' && (github.event.ref == needs.exportEnv.outputs.PRODUCTION_BRANCH || github.event.ref == needs.exportEnv.outputs.STAGING_BRANCH || github.event.ref == needs.exportEnv.outputs.DEV_BRANCH)
+    if: github.event_name == 'push' && (github.event.ref == 'refs/heads/master' || github.event.ref == 'refs/heads/staging' || github.event.ref == 'refs/heads/staging-dev')
     steps:
       - shell: python
         id: determine_proceed
@@ -55,7 +35,7 @@ jobs:
   test:
     name: Check that application can run
     runs-on: ubuntu-18.04
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && (github.event.ref == needs.exportEnv.outputs.PRODUCTION_BRANCH || github.event.ref == needs.exportEnv.outputs.STAGING_BRANCH || github.event.ref == needs.exportEnv.outputs.DEV_BRANCH))
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && (github.event.ref == 'refs/heads/master' || github.event.ref == 'refs/heads/staging' || github.event.ref == 'refs/heads/staging-dev'))
     steps:
         - uses: actions/checkout@v2
         - name: Use Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,15 @@ env:
   EB_ENV_STAGING: isomercms-backend-staging
   EB_ENV_DEV: isomercms-backend-staging-dev
   COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+  GH_EVENT_NAME: ${{ github.event_name }}
 jobs:
   gatekeep:
     name: Determine if Build & Deploy is needed
     runs-on: ubuntu-18.04
     outputs:
       proceed: ${{ steps.determine_proceed.outputs.proceed }}
-    if: github.event_name == 'push' && (github.event.ref == 'refs/heads/master' || github.event.ref == 'refs/heads/staging' || github.event.ref == 'refs/heads/staging-dev')
+      isBranch: ${{ steps.determine_proceed.outputs.isBranch }}
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     steps:
       - shell: python
         id: determine_proceed
@@ -28,20 +30,37 @@ jobs:
           prod = os.environ['PRODUCTION_BRANCH']
           staging = os.environ['STAGING_BRANCH']
           dev = os.environ['DEV_BRANCH']
-          if ref == prod or ref == staging or ref == dev:
+          eventName = os.environ['GH_EVENT_NAME']
+          if ref == prod or ref == staging or ref == dev or eventName == 'pull_request':
             print('::set-output name=proceed::true')
+            if eventName == 'pull_request':
+              print('::set-output name=isBranch::false')
+            else:
+              print('::set-output name=isBranch::true')
           else:
             print('::set-output name=proceed::false')
   test:
     name: Check that application can run
     runs-on: ubuntu-18.04
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && (github.event.ref == 'refs/heads/master' || github.event.ref == 'refs/heads/staging' || github.event.ref == 'refs/heads/staging-dev'))
+    needs: [gatekeep]
+    outputs:
+      proceed: ${{ steps.determine_proceed.outputs.proceed }}
+    if: needs.gatekeep.outputs.proceed == 'true'
     steps:
         - uses: actions/checkout@v2
         - name: Use Node.js
           uses: actions/setup-node@v1
           with:
             node-version: '12.x'
+        - name: Cache Node.js modules
+          uses: actions/cache@v2
+          with:
+            # npm cache files are stored in `~/.npm` on Linux/macOS
+            path: ~/.npm
+            key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+            restore-keys: |
+              ${{ runner.OS }}-node-
+              ${{ runner.OS }}-
         - name: Install NPM
           run: npm ci
         - name: Start application
@@ -61,28 +80,24 @@ jobs:
         - name: Confirm that checks are completed
           shell: bash
           run: echo "App started successfully!"
+        - shell: python
+          id: determine_proceed
+          run: |
+            import os
+            isBranch = os.environ['isBranch']
+            if isBranch == 'true':
+              print('::set-output name=proceed::true')
+            else:
+              print('::set-output name=proceed::false')
+          env:
+            isBranch: ${{ needs.gatekeep.outputs.isBranch }}
   deploy:
     name: Build and deploy to EB
     runs-on: ubuntu-18.04
-    needs: [gatekeep, test]
-    if: needs.gatekeep.outputs.proceed == 'true'
+    needs: [test]
+    if: needs.test.outputs.proceed == 'true'
     steps:
         - uses: actions/checkout@v2
-        - name: Use Node.js
-          uses: actions/setup-node@v1
-          with:
-            node-version: '12.x'
-        - name: Cache Node.js modules
-          uses: actions/cache@v2
-          with:
-            # npm cache files are stored in `~/.npm` on Linux/macOS
-            path: ~/.npm
-            key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-            restore-keys: |
-              ${{ runner.OS }}-node-
-              ${{ runner.OS }}-
-        - name: Install NPM
-          run: npm ci
         - name: Zip application
           run: zip -r "deploy.zip" * -x .env-example .gitignore package-lock.json
         - name: Get timestamp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 env:
   PRODUCTION_BRANCH: refs/heads/master
   STAGING_BRANCH: refs/heads/staging
-  DEV_BRANCH: refs/heads/ci/refine-gh-actions
+  DEV_BRANCH: refs/heads/staging-dev
   EB_APP: isomer-cms
   EB_ENV_PRODUCTION: isomercms-backend-prod
   EB_ENV_STAGING: isomercms-backend-staging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,19 @@ jobs:
         - name: Install NPM
           run: npm ci
         - name: Start application
-          run: npm start
+          run: |
+            npm start &
+            sleep 10 &&
+            curl http://localhost:8081
+          env:
+            AUTH_TOKEN_EXPIRY_DURATION_IN_MILLISECONDS: ${{ secrets.AUTH_TOKEN_EXPIRY_DURATION_IN_MILLISECONDS }}
+            CLIENT_ID: ${{ secrets.CLIENT_ID }}
+            CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+            COOKIE_DOMAIN: ${{ secrets.COOKIE_DOMAIN }}
+            FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
+            GH_ORG_NAME: ${{ secrets.GH_ORG_NAME }}
+            JWT_SECRET: ${{ secrets.JWT_SECRET }}
+            NODE_ENV: ${{ secrets.NODE_ENV }}
         - name: Confirm that checks are completed
           shell: bash
           run: echo "App started successfully!"

--- a/classes/Config.js
+++ b/classes/Config.js
@@ -4,7 +4,7 @@ const validateStatus = require('../utils/axios-utils')
 // Import error
 const { NotFoundError  } = require('../errors/NotFoundError')
 
-const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
+const GITHUB_ORG_NAME = process.env.GH_ORG_NAME
 const BRANCH_REF = process.env.BRANCH_REF
 
 class Config {

--- a/classes/Directory.js
+++ b/classes/Directory.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const _ = require('lodash')
 const validateStatus = require('../utils/axios-utils')
 
-const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
+const GITHUB_ORG_NAME = process.env.GH_ORG_NAME
 const BRANCH_REF = process.env.BRANCH_REF
 
 class Directory {

--- a/classes/File.js
+++ b/classes/File.js
@@ -5,7 +5,7 @@ const validateStatus = require('../utils/axios-utils')
 // Import error
 const { NotFoundError  } = require('../errors/NotFoundError')
 
-const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
+const GITHUB_ORG_NAME = process.env.GH_ORG_NAME
 const BRANCH_REF = process.env.BRANCH_REF
 
 class File {

--- a/routes/sites.js
+++ b/routes/sites.js
@@ -4,7 +4,7 @@ const axios = require('axios');
 const _ = require('lodash');
 const { attachRouteHandlerWrapper } = require('../middleware/routeHandler');
 
-const ISOMER_GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
+const ISOMER_GITHUB_ORG_NAME = process.env.GH_ORG_NAME
 const ISOMER_ADMIN_REPOS = [
   'isomercms-backend',
   'isomercms-frontend',


### PR DESCRIPTION
## Overview

This PR refines the repo's GitHub actions workflow file in the following ways:

1. Add the `test` job, which starts the application server as a test
2. Update `gatekeep` to also return `true` if the GitHub event is a `pull_request` in addition to the existing branch conditions
3. Allow the `test` job to run if the output of `gatekeep` is `true`
4. Make the `deploy` job dependent on the `test` job instead of `gatekeep`

The rationale is that we don't want the `test` job to be run when making random, mostly meaningless pushes to feature branches, but only if we're pushing to a major branch or if we're in a pull request. And also we want to run tests and make sure the server can start before deploying.

## Other notes

Since we run now start the server as a test, we also need to add environment variables into the repository's GitHub Secrets. This PR renames the `GITHUB_ORG_NAME` env var to `GH_ORG_NAME` since GitHub Secrets prevents users from setting secrets which start with the substring `GITHUB`. The elastic beanstalk environments have also been updated with the new environment variable.

## Tips

If you want to check what the full GitHub context is (to check what event is being pushed, what the event name is, what the action is, etc.), add the following snippet to your workflow file:

```
     - name: Dump GitHub context
        env:
          GITHUB_CONTEXT: ${{ toJson(github) }}
        run: echo "$GITHUB_CONTEXT"
```

This is taken from the official GitHub documentation ([link](https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions)). Do note that when using the whole `github` context, be mindful that it includes sensitive information such as `github.token`. GitHub masks secrets when they are printed to the console, but you should be cautious when exporting or printing the context.