### PR TITLE
chore: remove cookie domain

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -12,7 +12,6 @@ const { attachRouteHandlerWrapper } = require('../middleware/routeHandler')
 const CLIENT_ID = process.env.CLIENT_ID
 const CLIENT_SECRET = process.env.CLIENT_SECRET
 const REDIRECT_URI = process.env.REDIRECT_URI
-const COOKIE_DOMAIN = process.env.COOKIE_DOMAIN
 const AUTH_TOKEN_EXPIRY_MS = process.env.AUTH_TOKEN_EXPIRY_DURATION_IN_MILLISECONDS.toString()
 const FRONTEND_URL = process.env.FRONTEND_URL
 
@@ -40,7 +39,6 @@ async function githubAuth (req, res, next) {
   
   let cookieSettings = {
     path: '/',
-    domain: COOKIE_DOMAIN,
     expires: authTokenExpiry,
     httpOnly: true,
     sameSite: true,
@@ -57,7 +55,6 @@ async function githubAuth (req, res, next) {
 async function logout(req, res) {
   let cookieSettings
     cookieSettings = {
-      domain: COOKIE_DOMAIN,
       path: '/',
   }
   res.clearCookie(COOKIE_NAME, cookieSettings)


### PR DESCRIPTION
## Overview
On the staging version of the cms (`staging-cms.isomer.gov.sg`, which hits our staging backend server `staging-cms-api.isomer.gov.sg`), the frontend is sending the same cookie twice in the cookie header
(in bold) which is causing the API call to fail because the backend can't read the cookie properly

cookie: <other cookies>... **isomercms**=[redacted]; isomercms=[redacted]

I've set up an online dev environment mimicking the setup, `staging-dev-cms.isomer.gov.sg` and `staging-dev-cms-api.isomer.gov.sg`, and deployed the exact same code to them both, and set all configurations to be the same and the cookie sends properly (appears only once), so i'm not sure what the problem is the problem appears to be with the backend,
because i swapped the backends so that `staging-cms.isomer.gov.sg` points to `staging-dev-cms-api.isomer.gov.sg` and vice-versa, and then the problem disappeared on staging-cms and reappeared on staging-dev-cms.

Yuanruo suggested that the problem is because our cookie domain is set to our root domain, which means it will be sent by the browser on subdomains, which might then result in key resolution issues. He suggested removing the cookie entirely and letting it be set by express, which is what this PR does.