### PR TITLE
Feat/retrieve csp

### DIFF
--- a/classes/NetlifyToml.js
+++ b/classes/NetlifyToml.js
@@ -1,0 +1,44 @@
+const axios = require('axios')
+const validateStatus = require('../utils/axios-utils')
+
+// Import error
+const { NotFoundError } = require('../errors/NotFoundError')
+
+const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
+const BRANCH_REF = process.env.BRANCH_REF
+
+class NetlifyToml {
+  constructor(accessToken, siteName) {
+    this.accessToken = accessToken
+    this.siteName = siteName
+  }
+
+  async read() {
+    try {
+      const endpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${this.siteName}/contents/netlify.toml`
+      
+      const params = {
+        "ref": BRANCH_REF,
+      }
+
+      const resp = await axios.get(endpoint, {
+        validateStatus,
+        params,
+        headers: {
+          Authorization: `token ${this.accessToken}`,
+          "Content-Type": "application/json"
+        }
+      })
+
+      if (resp.status === 404) throw new NotFoundError ('netlify.toml file does not exist')
+
+      const { content, sha } = resp.data
+      return { content, sha }
+
+    } catch (err) {
+      throw err
+    }
+  }
+}
+
+module.exports = { NetlifyToml }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -114,6 +114,9 @@ auth.post('/sites/:siteName/resources/:resourceName/rename/:newResourceName', ve
 auth.get('/sites/:siteName/settings', verifyJwt)
 auth.post('/sites/:siteName/settings', verifyJwt)
 
+// Netlify toml
+auth.get('/sites/:siteName/netlify-toml', verifyJwt)
+
 // Sites
 auth.get('/sites', verifyJwt)
 

--- a/routes/netlifyToml.js
+++ b/routes/netlifyToml.js
@@ -1,0 +1,32 @@
+const express = require('express')
+const router = express.Router()
+const toml = require('toml')
+
+// Import middleware
+const { attachRouteHandlerWrapper } = require('../middleware/routeHandler')
+
+// Import classes 
+const { NetlifyToml } = require('../classes/NetlifyToml')
+
+// List resources
+async function getNetlifyToml (req, res, next) {
+  const { accessToken } = req
+  const { siteName } = req.params
+
+  const netlifyTomlFile = new NetlifyToml(accessToken, siteName)
+  
+  const { content } = await netlifyTomlFile.read()
+  
+  // Convert to readable form
+  const netlifyTomlReadableContent = toml.parse(Base64.decode(content))
+  
+  // Headers is an array of objects, specifying a set of access rules for each specified path
+  // Under our current assumption, we apply the first set of access rules to all paths
+  const netlifyTomlHeaderValues = netlifyTomlReadableContent.headers[0].values
+
+  res.status(200).json({ netlifyTomlHeaderValues })
+}
+
+router.get('/:siteName/netlify-toml', attachRouteHandlerWrapper(getNetlifyToml))
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -28,6 +28,7 @@ const menuRouter = require('./routes/menus')
 const homepageRouter = require('./routes/homepage')
 const menuDirectoryRouter = require('./routes/menuDirectory')
 const settingsRouter = require('./routes/settings')
+const netlifyTomlRouter = require('./routes/netlifyToml')
 
 const app = express();
 
@@ -61,6 +62,7 @@ app.use('/sites', menuRouter)
 app.use('/sites', homepageRouter)
 app.use('/sites', menuDirectoryRouter)
 app.use('/sites', settingsRouter)
+app.use('/sites', netlifyTomlRouter)
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {


### PR DESCRIPTION
This PR creates a route to retrieve the `netlify.toml` file from the site's repo via the Github API and parse it to return its header values. This route is useful on the frontend because we are using the CSP rules specified in the header values to sanitise the page preview when users edit pages ([link](https://github.com/isomerpages/isomercms-frontend/pull/205)).

An example of the headers retrieved in the `netlify.toml` file:

```
[[headers]]
  for = "/*"
  [headers.values]
    X-XSS-Protection = "1; mode=block"
    Referrer-Policy = "no-referrer"
    X-Content-Type-Options = "nosniff"
    X-Frame-Options = "deny"
    Content-Security-Policy = "default-src 'self'; script-src 'self' blob: ..."
```

An example of the response sent to the frontend:

```
{  
    "X-XSS-Protection": "1; mode=block",
    "Referrer-Policy": "no-referrer",
    "X-Content-Type-Options": "nosniff",
    "X-Frame-Options": "deny",
    "Content-Security-Policy": "default-src 'self'; script-src 'self' blob: ..."
}
```

A new `NetlifyToml`  class was created because Isomer has a future goal to make the `netlify.toml` file a centralized setting across all sites, so we wouldn't need the other methods of the `File` class : `create`, `update`, `delete`. By creating a separate file, this allows us to maintain/ remove this functionality easily in the future.

***Note that we use the simplifying assumption that only one set of header values are specified and applied to all paths under each site.*** This is currently true for all Isomer repos, where `[[headers]]` is an array of length one, and `for = "/*"` which indicates that all paths on the site are affected by the corresponding set of `[header.values]`.

