### PR TITLE
Feat/third nav retrieval

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -45,6 +45,7 @@ auth.post('/sites/:siteName/homepage', verifyJwt)
 
 // Collection pages
 auth.get('/sites/:siteName/collections/:collectionName', verifyJwt)
+auth.get('/sites/:siteName/collections/:collectionName/pages', verifyJwt)
 auth.post('/sites/:siteName/collections/:collectionName/pages', verifyJwt)
 auth.get('/sites/:siteName/collections/:collectionName/pages/:pageName', verifyJwt)
 auth.post('/sites/:siteName/collections/:collectionName/pages/:pageName', verifyJwt)

--- a/routes/collectionPages.js
+++ b/routes/collectionPages.js
@@ -1,12 +1,20 @@
 const express = require('express');
 const router = express.Router();
+const Bluebird = require('bluebird');
+const yaml = require('js-yaml');
+const base64 = require('base-64');
+const _ = require('lodash');
 
 // Import middleware
 const { attachRouteHandlerWrapper } = require('../middleware/routeHandler')
 
 // Import classes 
+const { Collection } = require('../classes/Collection.js')
 const { File, CollectionPageType } = require('../classes/File.js');
 const { update } = require('lodash');
+
+// Import utils
+const { readCollectionPageUtilFunc } = require('../utils/route-utils')
 
 // List pages in collection
 async function listCollectionPages(req, res, next) {

--- a/routes/collectionPages.js
+++ b/routes/collectionPages.js
@@ -23,6 +23,70 @@ async function listCollectionPages(req, res, next) {
   res.status(200).json({ collectionPages })
 }
 
+// Get details on all pages in a collection
+async function listCollectionPagesDetails(req, res, next) {
+  const { accessToken } = req
+  const { siteName, collectionName } = req.params
+
+  // Verify that collection exists
+  const IsomerCollection = new Collection(accessToken, siteName)
+  const collections = await IsomerCollection.list()
+  if (!(collections.includes(collectionName))) throw new NotFoundError('Collection provided was not a valid collection')
+
+  // Retrieve metadata of files in collection
+  const CollectionPage = new File(accessToken, siteName)
+  const collectionPageType = new CollectionPageType(collectionName)
+  CollectionPage.setFileType(collectionPageType)
+  const collectionPages = await CollectionPage.list()
+  const collectionPagesMetadata = await Bluebird.map(collectionPages, async (page) => {
+    const { content } = await readCollectionPageUtilFunc(accessToken, siteName, collectionName, page.fileName)
+    const frontMatter = yaml.safeLoad(base64.decode(content).split('---')[1])
+    return {
+      fileName: page.fileName,
+      title: frontMatter.title,
+      thirdNavTitle: frontMatter.third_nav_title
+    }
+  })
+
+  const collectionHierarchy = collectionPagesMetadata.reduce((acc, file) => {
+    if (file.thirdNavTitle) {
+      // Check whether third nav section already exists
+      const thirdNavIteratee = { type: 'third-nav', 'title': file.thirdNavTitle }
+      if (_.some(acc, thirdNavIteratee)) {
+        const thirdNavIdx = _.findIndex(acc, thirdNavIteratee)
+        acc[thirdNavIdx].contents.push({
+          type: 'third-nav-page',
+          title: file.title,
+          fileName: file.fileName,
+        })
+        return acc
+      }
+
+      // Create new third nav section
+      acc.push({
+        type: 'third-nav',
+        title: file.thirdNavTitle,
+        contents: [{
+          type: 'third-nav-page',
+          title: file.title,
+          fileName: file.fileName,
+        }]
+      })
+      return acc
+    }
+
+    // If no third nav title, just push into array
+    acc.push({
+      type: 'page',
+      title: file.title,
+      fileName: file.fileName,
+    })
+    return acc
+  }, [])
+
+  res.status(200).json({ collectionPages: collectionHierarchy })
+}
+
 // Create new page in collection
 async function createNewcollectionPage (req, res, next) {
   const { accessToken } = req
@@ -118,6 +182,7 @@ async function renameCollectionPage (req, res, next) {
 }
 
 router.get('/:siteName/collections/:collectionName', attachRouteHandlerWrapper(listCollectionPages))
+router.get('/:siteName/collections/:collectionName/pages', attachRouteHandlerWrapper(listCollectionPagesDetails))
 router.post('/:siteName/collections/:collectionName/pages', attachRouteHandlerWrapper(createNewcollectionPage))
 router.get('/:siteName/collections/:collectionName/pages/:pageName', attachRouteHandlerWrapper(readCollectionPage))
 router.post('/:siteName/collections/:collectionName/pages/:pageName', attachRouteHandlerWrapper(updateCollectionPage))

--- a/utils/route-utils.js
+++ b/utils/route-utils.js
@@ -1,0 +1,37 @@
+// Import classes
+const {
+    File,
+    PageType,
+    CollectionPageType,
+    DataType,
+} = require('../classes/File')
+
+const readPageUtilFunc = async (accessToken, siteName, pageName) => {
+    const IsomerFile = new File(accessToken, siteName)
+    const pageType = new PageType()
+    IsomerFile.setFileType(pageType)
+    const fileContents = await IsomerFile.read(pageName)
+    return fileContents
+}
+
+const readCollectionPageUtilFunc = async (accessToken, siteName, collectionName, pageName) => {
+    const IsomerFile = new File(accessToken, siteName)
+    const collectionPageType = new CollectionPageType(collectionName)
+    IsomerFile.setFileType(collectionPageType)
+    const fileContents = await IsomerFile.read(pageName)
+    return fileContents
+}
+
+const createDataFileUtilFunc = async (accessToken, siteName, filePath, content) => {
+    const IsomerFile = new File(accessToken, siteName)
+    const dataType = new DataType()
+    IsomerFile.setFileType(dataType)
+    await IsomerFile.create(filePath, content)
+    return
+}
+
+module.exports = {
+    readPageUtilFunc,
+    readCollectionPageUtilFunc,
+    createDataFileUtilFunc,
+}


### PR DESCRIPTION
## Overview

This PR introduces a new endpoint, GET `/sites/:siteName/collections/:collectionName/pages`, which responds with the page structure of the collection being queried. It allows the requester to know the order of the pages, as well as whether they are in third nav sections, and the title + file names of all files and third nav sections.