### PR TITLE
Fix/creation and renaming of resource categories

### DIFF
--- a/classes/File.js
+++ b/classes/File.js
@@ -185,6 +185,15 @@ class ResourcePageType {
   }
 }
 
+class ResourceCategoryType {
+  constructor(resourceRoomName, resourceName) {
+    this.folderName = `${resourceRoomName}/${resourceName}`
+  }
+  getFolderName() {
+    return this.folderName
+  }
+}
+
 class ResourceType {
   constructor(resourceRoomName) {
     this.folderName = `${resourceRoomName}`
@@ -230,4 +239,4 @@ class HomepageType {
   }
 }
 
-module.exports = { File, PageType, CollectionPageType, ResourcePageType, ResourceType, ImageType, DocumentType, DataType, HomepageType }
+module.exports = { File, PageType, CollectionPageType, ResourcePageType, ResourceCategoryType, ResourceType, ImageType, DocumentType, DataType, HomepageType }

--- a/classes/Resource.js
+++ b/classes/Resource.js
@@ -2,7 +2,7 @@ const Bluebird = require('bluebird')
 const _ = require('lodash')
 
 // Import classes 
-const { File, ResourceType, ResourcePageType } = require('../classes/File.js')
+const { File, ResourceCategoryType, ResourcePageType } = require('../classes/File.js')
 const { Directory, ResourceRoomType } = require('../classes/Directory.js')
 
 // Constants
@@ -30,9 +30,9 @@ class Resource {
     try {
       // Create an index file in the resource folder
       const IsomerFile = new File(this.accessToken, this.siteName)
-      const resourceType = new ResourceType(resourceRoomName)
+      const resourceType = new ResourceCategoryType(resourceRoomName, resourceName)
       IsomerFile.setFileType(resourceType)
-      return IsomerFile.create(`${resourceName}/${RESOURCE_INDEX_PATH}`, RESOURCE_INDEX_CONTENT)
+      return IsomerFile.create(`${RESOURCE_INDEX_PATH}`, RESOURCE_INDEX_CONTENT)
     } catch (err) {
       throw err
     }
@@ -42,16 +42,16 @@ class Resource {
     try {
       // Delete old index file in old resource
       const OldIsomerIndexFile = new File(this.accessToken, this.siteName)
-      const resourceType = new ResourceType(resourceRoomName)
+      const resourceType = new ResourceCategoryType(resourceRoomName, resourceName)
       OldIsomerIndexFile.setFileType(resourceType)
-      const { sha: oldSha } = await OldIsomerIndexFile.read(`${resourceName}/${RESOURCE_INDEX_PATH}`)
-      await OldIsomerIndexFile.delete(`${resourceName}/${RESOURCE_INDEX_PATH}`, oldSha)
+      const { sha: oldSha } = await OldIsomerIndexFile.read(`${RESOURCE_INDEX_PATH}`)
+      await OldIsomerIndexFile.delete(`${RESOURCE_INDEX_PATH}`, oldSha)
 
       // Create new index file in new resource
       const NewIsomerIndexFile = new File(this.accessToken, this.siteName)
-      const newResourceType = new ResourceType(newResourceRoomName)
+      const newResourceType = new ResourceCategoryType(newResourceRoomName, newResourceName)
       NewIsomerIndexFile.setFileType(newResourceType)
-      await NewIsomerIndexFile.create(`${newResourceName}/${RESOURCE_INDEX_PATH}`, RESOURCE_INDEX_CONTENT)
+      await NewIsomerIndexFile.create(`${RESOURCE_INDEX_PATH}`, RESOURCE_INDEX_CONTENT)
 
       // Rename resourcePages
       const OldIsomerFile = new File(this.accessToken, this.siteName)
@@ -83,10 +83,10 @@ class Resource {
     try {
       // Delete index file in resource
       const IsomerIndexFile = new File(this.accessToken, this.siteName)
-      const resourceType = new ResourceType(resourceRoomName)
+      const resourceType = new ResourceCategoryType(resourceRoomName, resourceName)
       IsomerIndexFile.setFileType(resourceType)
-      const { sha } = await IsomerIndexFile.read(`${resourceName}/${RESOURCE_INDEX_PATH}`)
-      await IsomerIndexFile.delete(`${resourceName}/${RESOURCE_INDEX_PATH}`, sha)
+      const { sha } = await IsomerIndexFile.read(`${RESOURCE_INDEX_PATH}`)
+      await IsomerIndexFile.delete(`${RESOURCE_INDEX_PATH}`, sha)
 
       // Delete all resourcePages in resource
       // 1. List all resourcePages in resource

--- a/routes/resourcePages.js
+++ b/routes/resourcePages.js
@@ -7,6 +7,7 @@ const { attachRouteHandlerWrapper } = require('../middleware/routeHandler')
 // Import classes 
 const { File, ResourcePageType } = require('../classes/File.js')
 const { ResourceRoom } = require('../classes/ResourceRoom.js')
+const { Resource } = require('../classes/Resource.js')
 
 // List pages in resource
 async function listResourcePages (req, res, next) {
@@ -33,9 +34,17 @@ async function createNewResourcePage(req, res, next) {
 
   // TO-DO:
   // Validate pageName and content
-
   const ResourceRoomInstance = new ResourceRoom(accessToken, siteName)
   const resourceRoomName = await ResourceRoomInstance.get()
+
+  // Check if resource category exists and create if it does not
+  const IsomerResource = new Resource(accessToken, siteName)
+  const resources = await IsomerResource.list(resourceRoomName)
+  const resourceCategories = resources.map(resource => resource.dirName)
+  if (!resourceCategories.includes(resourceName)) {
+    await IsomerResource.create(resourceRoomName, resourceName)
+  }
+
   const IsomerFile = new File(accessToken, siteName)
   const resourcePageType = new ResourcePageType(resourceRoomName, resourceName)
   IsomerFile.setFileType(resourcePageType)

--- a/routes/resourcePages.js
+++ b/routes/resourcePages.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const router = express.Router();
-const _ = require('lodash')
 
 // Import middleware
 const { attachRouteHandlerWrapper } = require('../middleware/routeHandler')
@@ -105,13 +104,13 @@ async function deleteResourcePage(req, res, next) {
   const IsomerFile = new File(accessToken, siteName)
   const resourcePageType = new ResourcePageType(resourceRoomName, resourceName)
   IsomerFile.setFileType(resourcePageType)
-  await IsomerFile.delete(pageName, sha)
-
-  // Check if collection has any pages left, and delete if none left
   const resources = await IsomerFile.list()
-  if (_.isEmpty(resources)) {
+  if (resources.length === 1) {
+    // If there is only 1 page left, we can delete the entire category
     const IsomerResource = new Resource(accessToken, siteName)
     await IsomerResource.delete(resourceRoomName, resourceName)
+  } else {
+    await IsomerFile.delete(pageName, sha)
   }
 
   res.status(200).send('OK')

--- a/routes/resourcePages.js
+++ b/routes/resourcePages.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+const _ = require('lodash')
 
 // Import middleware
 const { attachRouteHandlerWrapper } = require('../middleware/routeHandler')
@@ -105,6 +106,13 @@ async function deleteResourcePage(req, res, next) {
   const resourcePageType = new ResourcePageType(resourceRoomName, resourceName)
   IsomerFile.setFileType(resourcePageType)
   await IsomerFile.delete(pageName, sha)
+
+  // Check if collection has any pages left, and delete if none left
+  const resources = await IsomerFile.list()
+  if (_.isEmpty(resources)) {
+    const IsomerResource = new Resource(accessToken, siteName)
+    await IsomerResource.delete(resourceRoomName, resourceName)
+  }
 
   res.status(200).send('OK')
 }


### PR DESCRIPTION
This PR fixes several existing bugs related to resources. 
- Previously, when creating a resource page, we did not check for the existence of the resource category, hence it was possible to create a resource category with no index file.
- Similarly, when deleting the last resource page in a category, the index file was not cleared, so the category continued to exist.
- The endpoints related to deleting the index file of resource categories were not working correctly - this was due to us attempting to read and retrieve the sha of a file belonging to a subdirectory, which did not work. Instead, we have created a new File type (ResourceCategoryFile) which we use to query the file details.