### PR TITLE
Feat: add new InputNameConflictError

### DIFF
--- a/classes/File.js
+++ b/classes/File.js
@@ -4,6 +4,7 @@ const validateStatus = require('../utils/axios-utils')
 
 // Import error
 const { NotFoundError  } = require('../errors/NotFoundError')
+const { InputNameConflictError  } = require('../errors/InputValidationError')
 
 const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
 const BRANCH_REF = process.env.BRANCH_REF
@@ -78,7 +79,9 @@ class File {
 
       return { sha: resp.data.content.sha }
     } catch (err) {
-      throw err
+      const status = err.response.status
+      if (status === 422) throw new InputNameConflictError(fileName)
+      throw err.response
     }
   }
 

--- a/classes/File.js
+++ b/classes/File.js
@@ -3,8 +3,8 @@ const _ = require('lodash')
 const validateStatus = require('../utils/axios-utils')
 
 // Import error
-const { NotFoundError  } = require('../errors/NotFoundError')
-const { InputNameConflictError  } = require('../errors/InputValidationError')
+const { NotFoundError } = require('../errors/NotFoundError')
+const { ConflictError, inputNameConflictErrorMsg } = require('../errors/ConflictError')
 
 const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
 const BRANCH_REF = process.env.BRANCH_REF
@@ -80,7 +80,7 @@ class File {
       return { sha: resp.data.content.sha }
     } catch (err) {
       const status = err.response.status
-      if (status === 422) throw new InputNameConflictError(fileName)
+      if (status === 422) throw new ConflictError(inputNameConflictErrorMsg(fileName))
       throw err.response
     }
   }

--- a/errors/ConflictError.js
+++ b/errors/ConflictError.js
@@ -1,7 +1,9 @@
 // Import base error
 const { BaseIsomerError } = require('./BaseError')
 
-class InputNameConflictError extends BaseIsomerError {
+const inputNameConflictErrorMsg = (fileName) => `A file with ${fileName} already exists.`
+
+class ConflictError extends BaseIsomerError {
   constructor (fileName) {
     super(
       409,
@@ -10,5 +12,6 @@ class InputNameConflictError extends BaseIsomerError {
   }
 }
 module.exports = {
-    InputNameConflictError,
+  ConflictError,
+  inputNameConflictErrorMsg,
 }

--- a/errors/InputValidationError.js
+++ b/errors/InputValidationError.js
@@ -1,0 +1,14 @@
+// Import base error
+const { BaseIsomerError } = require('./BaseError')
+
+class InputNameConflictError extends BaseIsomerError {
+  constructor (fileName) {
+    super(
+      409,
+      `A file with ${fileName} already exists.`
+    )
+  }
+}
+module.exports = {
+    InputNameConflictError,
+}


### PR DESCRIPTION
This PR introduces a new error for handling the case where we fail to create a new file due to conflicting file names. This PR is to be reviewed in conjunction with PR #[247](https://github.com/isomerpages/isomercms-frontend/pull/247) on the isomercms-frontend repo.

One thing to note is that we convert the error thrown by the Github API when processing - this is due to the endpoint that we are calling to create a new file also being used to modify existing files, thus the Github API returns us a `422 Unprocessable Entity` error due to the missing sha, when we actually want to reflect that there is a conflict in file names.