### PR TITLE
chore: log error message with distinct string for metric filter

### DIFF
--- a/middleware/errorHandler.js
+++ b/middleware/errorHandler.js
@@ -5,7 +5,7 @@ const { serializeError } = require('serialize-error')
 const logger = require('../logger/logger');
 
 function errorHandler (err, req, res, next) {
-    logger.info(`${new Date()}: ${JSON.stringify(serializeError(err))}`)
+    const errMsg = `${new Date()}: ${JSON.stringify(serializeError(err))}`
   
     // set locals, only providing error in development
     res.locals.message = err.message;
@@ -13,6 +13,7 @@ function errorHandler (err, req, res, next) {
   
     // Error handling for custom errors
     if (err.isIsomerError) {
+        logger.info(errMsg)
         res.status(err.status).json({
             error: {
                 name: err.name,
@@ -21,6 +22,7 @@ function errorHandler (err, req, res, next) {
             },
         })
     } else {
+        logger.info(`Unrecognized internal server error: ${errMsg}`)
         res.status(500).json({
             error: {
                 code: 500,


### PR DESCRIPTION
This PR logs the serialized error with a distinct string, "Unrecognized internal server error" so that we can create a CloudWatch metric filter based on this string to identify and trigger alerts on unrecognized / non-Isomer errors