### PR TITLE
Feat: throw ConflictError if 409 received

### DIFF
--- a/classes/File.js
+++ b/classes/File.js
@@ -80,7 +80,7 @@ class File {
       return { sha: resp.data.content.sha }
     } catch (err) {
       const status = err.response.status
-      if (status === 422) throw new ConflictError(inputNameConflictErrorMsg(fileName))
+      if (status === 422 || status === 409) throw new ConflictError(inputNameConflictErrorMsg(fileName))
       throw err.response
     }
   }


### PR DESCRIPTION
This PR allows ConflictError to be thrown if a 409 error is received from the Github API. To be reviewed with PR [#247]https://github.com/isomerpages/isomercms-frontend/pull/247 on the isomercms-frontend repo.