### PR TITLE
Feat/add settings fields

### DIFF
--- a/classes/Settings.js
+++ b/classes/Settings.js
@@ -42,6 +42,9 @@ class Settings {
       url: configReadableContent.url,
       title: configReadableContent.title,
       favicon: configReadableContent.favicon,
+      shareicon: configReadableContent.shareicon,
+      facebook_pixel: configReadableContent['facebook-pixel'],
+      google_analytics: configReadableContent.google_analytics,
       resources_name: configReadableContent.resources_name,
       colors: configReadableContent.colors,
     }

--- a/classes/Settings.js
+++ b/classes/Settings.js
@@ -77,6 +77,7 @@ class Settings {
       title: configContent.title,
       favicon: configContent.favicon,
       shareicon: configContent.shareicon,
+      is_government: configContent.is_government,
       facebook_pixel: configContent['facebook-pixel'],
       google_analytics: configContent.google_analytics,
       resources_name: configContent.resources_name,

--- a/classes/Settings.js
+++ b/classes/Settings.js
@@ -119,21 +119,21 @@ class Settings {
     const settingsObjArr = [
       {
         payload: configSettings,
-        retrievedData: configContent,
+        currentData: configContent,
       },
       {
         payload: footerSettings,
-        retrievedData: footerContent,
+        currentData: footerContent,
       },
       {
         payload: navigationSettings,
-        retrievedData: navigationContent,
+        currentData: navigationContent,
       },
     ]
 
-    const updatedSettingsObjArr = settingsObjArr.map(({ payload, retrievedData}) => {
-      const settingsObj = _.cloneDeep(payload);
-      Object.keys(retrievedData).forEach((setting) => (settingsObj[setting] = payload[setting]));
+    const updatedSettingsObjArr = settingsObjArr.map(({ payload, currentData}) => {
+      const settingsObj = _.cloneDeep(currentData);
+      Object.keys(payload).forEach((setting) => (settingsObj[setting] = payload[setting]));
       return settingsObj
     })
 


### PR DESCRIPTION
Note: this PR is to be reviewed with PR #[275](https://github.com/isomerpages/isomercms-frontend/pull/275) in the frontend.

## Overview

This PR introduces major changes in the `Settings` class to accommodate business requirements on the frontend. The new requirements are:
1. Allow users to retrieve and update the following values: `shareicon`, facebook pixel, google analytics, `is_government`
2. Reintroduce `title` field
3. Allow users to modify the agency logo
4. Allow users to set `title` of both the browser tab and the footer title at the same time

Requirements 1 & 2 are straightforward to achieve, since it simply involves sending new fields in the HTTP response.

Requirement 3 requires us to retrieve from and write to a new file, `_data/navigation.yml`, in addition to the `_config.yml` and `_data/footer.yml` file that we currently use.

Finally, requirement 4 requires us to write to a new file, `index.md`, if the `title` field is found to have changed.

This PR accomplishes all of the above, and also refactors the code for readability by creating a utility function for retrieving files concurrently since this code is repeated in both the `get` and `post` methods.