### PR TITLE
Fix: throw NotFoundError for files

### DIFF
--- a/classes/File.js
+++ b/classes/File.js
@@ -89,6 +89,7 @@ class File {
     try {
       const files = await this.list()
       const fileToRead = files.filter((file) => file.fileName === fileName)[0]
+      if (fileToRead === undefined) throw new NotFoundError ('File does not exist')
       const endpoint = `${this.baseBlobEndpoint}/${fileToRead.sha}`
 
       const params = {
@@ -103,9 +104,7 @@ class File {
           "Content-Type": "application/json"
         }
       })
-  
-      if (resp.status === 404) throw new NotFoundError ('File does not exist')
-  
+
       const { content, sha } = resp.data
   
       return { content, sha }
@@ -134,6 +133,8 @@ class File {
 
       return { newSha: resp.data.commit.sha }
     } catch (err) {
+      const status = err.response.status
+      if (status === 404) throw new NotFoundError ('File does not exist')
       throw err
     }
   }
@@ -156,6 +157,8 @@ class File {
         }
       })
     } catch (err) {
+      const status = err.response.status
+      if (status === 404) throw new NotFoundError ('File does not exist')
       throw err
     }
   }


### PR DESCRIPTION
This PR fixes the behaviour for throwing NotFoundErrors in File. Previously, it was not possible to reach the condition to throw the NotFoundError in read, as a file which could not be retrieved would have have a defined endpoint. This resulted in a different error being thrown. This PR fixes that and also adds in the check during deleting and updating files.

To be reviewed in conjunction with PR [#280](https://github.com/isomerpages/isomercms-frontend/pull/280) on the isomercms-frontend repo.