### PR TITLE
Fix/handle renaming of folders with multiple files

### DIFF
--- a/classes/Collection.js
+++ b/classes/Collection.js
@@ -109,6 +109,7 @@ class Collection {
 
   async rename(oldCollectionName, newCollectionName) {
     try {
+      const commitMessage = `Rename collection from ${oldCollectionName} to ${newCollectionName}`
       // Rename collection in config
       const config = new Config(this.accessToken, this.siteName)
       const { content, sha } = await config.read()
@@ -159,7 +160,7 @@ class Collection {
           return item
         }
       })
-      await sendTree(newGitTree, currentCommitSha, this.siteName, this.accessToken, `Rename collection from ${oldCollectionName} to ${newCollectionName}`);
+      await sendTree(newGitTree, currentCommitSha, this.siteName, this.accessToken, commitMessage);
     } catch (err) {
       throw err
     }

--- a/classes/Resource.js
+++ b/classes/Resource.js
@@ -41,6 +41,7 @@ class Resource {
 
   async rename(resourceRoomName, resourceName, newResourceName) {
     try {
+      const commitMessage = `Rename resource category from ${resourceName} to ${newResourceName}`
       const { gitTree, currentCommitSha } = await getRootTree(this.siteName, this.accessToken);
       let newGitTree = []
       let resourceRoomTreeSha
@@ -67,7 +68,7 @@ class Resource {
           })
         }
       })
-      await sendTree(newGitTree, currentCommitSha, this.siteName, this.accessToken, `Rename resource category from ${resourceName} to ${newResourceName}`);
+      await sendTree(newGitTree, currentCommitSha, this.siteName, this.accessToken, commitMessage);
     } catch (err) {
       throw err
     }

--- a/classes/Resource.js
+++ b/classes/Resource.js
@@ -4,6 +4,7 @@ const _ = require('lodash')
 // Import classes 
 const { File, ResourceCategoryType, ResourcePageType } = require('../classes/File.js')
 const { Directory, ResourceRoomType } = require('../classes/Directory.js')
+const { getRootTree, getTree, sendTree } = require('../utils/utils.js')
 
 // Constants
 const RESOURCE_INDEX_PATH = 'index.html'
@@ -38,42 +39,35 @@ class Resource {
     }
   }
 
-  async rename(resourceRoomName, resourceName, newResourceRoomName, newResourceName) {
+  async rename(resourceRoomName, resourceName, newResourceName) {
     try {
-      // Delete old index file in old resource
-      const OldIsomerIndexFile = new File(this.accessToken, this.siteName)
-      const resourceType = new ResourceCategoryType(resourceRoomName, resourceName)
-      OldIsomerIndexFile.setFileType(resourceType)
-      const { sha: oldSha } = await OldIsomerIndexFile.read(`${RESOURCE_INDEX_PATH}`)
-      await OldIsomerIndexFile.delete(`${RESOURCE_INDEX_PATH}`, oldSha)
-
-      // Create new index file in new resource
-      const NewIsomerIndexFile = new File(this.accessToken, this.siteName)
-      const newResourceType = new ResourceCategoryType(newResourceRoomName, newResourceName)
-      NewIsomerIndexFile.setFileType(newResourceType)
-      await NewIsomerIndexFile.create(`${RESOURCE_INDEX_PATH}`, RESOURCE_INDEX_CONTENT)
-
-      // Rename resourcePages
-      const OldIsomerFile = new File(this.accessToken, this.siteName)
-      const resourcePageType = new ResourcePageType(resourceRoomName, resourceName)
-      OldIsomerFile.setFileType(resourcePageType)
-
-      const NewIsomerFile = new File(this.accessToken, this.siteName)
-      const newResourcePageType = new ResourcePageType(newResourceRoomName, newResourceName)
-      NewIsomerFile.setFileType(newResourcePageType)
-
-      // 1. List all resourcePages in old resource
-      const resourcePages = await OldIsomerFile.list()
-
-      if (_.isEmpty(resourcePages)) return
-
-      await Bluebird.each(resourcePages, async(resourcePage) => {
-        // 2. Create new resourcePages in newResource
-        const { content, sha } = await OldIsomerFile.read(resourcePage.fileName)
-        await NewIsomerFile.create(resourcePage.fileName, content)
-        // 3. Delete all resourcePages in resource
-        return OldIsomerFile.delete(resourcePage.fileName, sha)
+      const { gitTree, currentCommitSha } = await getRootTree(this.siteName, this.accessToken);
+      let newGitTree = []
+      let resourceRoomTreeSha
+      // Retrieve all git trees of other items
+      gitTree.forEach((item) => {
+        if (item.path === resourceRoomName) {
+          resourceRoomTreeSha = item.sha
+        } else {
+          newGitTree.push(item)
+        }
       })
+      const { gitTree: resourceRoomTree } = await getTree(this.siteName, this.accessToken, resourceRoomTreeSha)
+      resourceRoomTree.forEach(item => {
+        // We need to append resource room to the file path because the path is relative to the subtree
+        if (item.path === resourceName) {
+          newGitTree.push({
+            ...item,
+            path: `${resourceRoomName}/${newResourceName}`
+          })
+        } else {
+          newGitTree.push({
+            ...item,
+            path: `${resourceRoomName}/${item.path}`
+          })
+        }
+      })
+      await sendTree(newGitTree, currentCommitSha, this.siteName, this.accessToken, `Rename resource category from ${resourceName} to ${newResourceName}`);
     } catch (err) {
       throw err
     }

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -60,7 +60,7 @@ async function renameResource (req, res, next) {
   const resourceRoomName = await IsomerResourceRoom.get()
 
   const IsomerResource = new Resource(accessToken, siteName)
-  await IsomerResource.rename(resourceRoomName, resourceName, resourceRoomName, newResourceName)
+  await IsomerResource.rename(resourceRoomName, resourceName, newResourceName)
 
   res.status(200).json({ resourceName, newResourceName })
 }

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -1,3 +1,6 @@
+const axios = require('axios');
+const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
+
 /** 
  * A function to deslugify a collection page's file name, taken from isomercms-frontend src/utils
 */
@@ -24,6 +27,98 @@ function deslugifyCollectionPage(collectionPageName) {
   )
 }
 
+// retrieve the tree item
+async function getRootTree(repo, accessToken, branchRef='staging') {
+  try {
+    const headers = {
+      Authorization: `token ${accessToken}`,
+      Accept: 'application/json',
+    };
+    // Get the commits of the repo
+    const { data: commits } = await axios.get(`https://api.github.com/repos/${GITHUB_ORG_NAME}/${repo}/commits`, {
+      params: {
+        ref: branchRef,
+      },
+      headers,
+    });
+    // Get the tree sha of the latest commit
+    const { commit: { tree: { sha: treeSha } } } = commits[0];
+    const currentCommitSha = commits[0].sha;
+
+    const { data: { tree: gitTree } } = await axios.get(`https://api.github.com/repos/${GITHUB_ORG_NAME}/${repo}/git/trees/${treeSha}${isRecursive ? `?recursive=1` : ''}`, {
+      params: {
+        ref: branchRef,
+      },
+      headers,
+    });
+
+    return { gitTree, currentCommitSha };
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+// retrieve the tree from given tree sha
+async function getTree(repo, accessToken, treeSha, branchRef='staging') {
+  try {
+    const headers = {
+      Authorization: `token ${accessToken}`,
+      Accept: 'application/json',
+    };
+
+    const { data: { tree: gitTree } } = await axios.get(`https://api.github.com/repos/${GITHUB_ORG_NAME}/${repo}/git/trees/${treeSha}`, {
+      params: {
+        ref: branchRef,
+      },
+      headers,
+    });
+
+    return { gitTree };
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+// send the new tree object back to Github and point the latest commit on the staging branch to it
+async function sendTree(gitTree, currentCommitSha, repo, accessToken, message, branchRef='staging') {
+  const headers = {
+    Authorization: `token ${accessToken}`,
+    Accept: 'application/json',
+  };
+  const resp = await axios.post(`https://api.github.com/repos/${GITHUB_ORG_NAME}/${repo}/git/trees`, {
+    tree: gitTree,
+  }, {
+    headers,
+  });
+
+  const { data: { sha: newTreeSha } } = resp;
+
+  const baseRefEndpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${repo}/git/refs`;
+  const baseCommitEndpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${repo}/git/commits`;
+  const refEndpoint = `${baseRefEndpoint}/heads/${branchRef}`;
+
+  const newCommitResp = await axios.post(baseCommitEndpoint, {
+    message: message,
+    tree: newTreeSha,
+    parents: [currentCommitSha],
+  }, {
+    headers,
+  });
+
+  const newCommitSha = newCommitResp.data.sha;
+
+  /**
+   * The `staging` branch reference will now point
+   * to `newCommitSha` instead of `currentCommitSha`
+   */
+  await axios.patch(refEndpoint, {
+    sha: newCommitSha,
+    force: true,
+  }, {
+    headers,
+  });
+}
+
 /** 
  * A function to deslugify a collection's name
 */
@@ -37,4 +132,7 @@ function deslugifyCollectionName(collectionName) {
 module.exports = {
   deslugifyCollectionPage,
   deslugifyCollectionName,
+  getRootTree,
+  getTree,
+  sendTree,
 }

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -45,7 +45,7 @@ async function getRootTree(repo, accessToken, branchRef='staging') {
     const { commit: { tree: { sha: treeSha } } } = commits[0];
     const currentCommitSha = commits[0].sha;
 
-    const { data: { tree: gitTree } } = await axios.get(`https://api.github.com/repos/${GITHUB_ORG_NAME}/${repo}/git/trees/${treeSha}${isRecursive ? `?recursive=1` : ''}`, {
+    const { data: { tree: gitTree } } = await axios.get(`https://api.github.com/repos/${GITHUB_ORG_NAME}/${repo}/git/trees/${treeSha}`, {
       params: {
         ref: branchRef,
       },


### PR DESCRIPTION
This PR addresses issue [#282](https://github.com/isomerpages/isomercms-frontend/issues/282) on the isomercms-frontend repo.

Currently, we encounter an issue when attempting to rename collections with multiple items inside. After a single file was moved, subsequent files would encounter an error due to a difference in current state? The error message shown is 
`"message":"is at 3e3261a537a9ca6b50615e4cc11fcfcc3406c1d4 but expected 2f51524a07f82e7225da00c0c652263457ed2919","documentation_url":"https://docs.github.com/rest/reference/repos#delete-a-file"}},"isAxiosError":true,"name":"Error","message":"Request failed with status code 409"` 
I'm not entirely sure what causes this issue, and why we don't have this problem when deleting folders, which also chains commits. 

The solution introduced in this PR involves the usage of git trees, which also provide us with a more efficient way of retrieving file information in a single API call. The endpoints to rename Collections and Resources have been changed to use git trees, as well as the unused endpoint to rename Resource Room.

One issue I faced for the rename resource category endpoint was the nesting of the resource folders - if I recursively retrieved the subtrees with a single API call, then directly modified the pathname of all items in that subtree, for some reason the old folder would not be deleted. I got around this by making 2 non-recursive calls instead, so I could rename the subtree directly, but would like to hear if a better method exists.