### PR TITLE
Feat: add endpoint to check if user has access to site

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -124,6 +124,7 @@ auth.get('/sites/:siteName/netlify-toml', verifyJwt)
 
 // Sites
 auth.get('/sites', verifyJwt)
+auth.get('/sites/:siteName', verifyJwt)
 
 auth.use((req, res, next) => {
     if (!req.route) {

--- a/routes/sites.js
+++ b/routes/sites.js
@@ -99,13 +99,12 @@ async function checkHasAccess (req, res, next) {
     const { siteName } = req.params
     
     const endpoint = `https://api.github.com/repos/${ISOMER_GITHUB_ORG_NAME}/${siteName}/collaborators/${userId}`
-    const resp = await axios.get(endpoint, {
+    await axios.get(endpoint, {
       headers: {
         Authorization: `token ${accessToken}`,
         "Content-Type": "application/json",
       }
     })
-    console.log(resp)
 
     res.status(200).json()
   } catch (err) {


### PR DESCRIPTION
This PR adds a new endpoint to check if users have access to a given site. To be reviewed in conjunction with PR[#280](https://github.com/isomerpages/isomercms-frontend/pull/280) on the isomercms-frontend repo.

To check if a user has access to a site, we check if the user is one of the collaborators on that repo, and throw an error message if either the site does not exist or the user does not have the appropriate permissions. We have opted to throw the same 404 error in both of these cases.