### PR TITLE
Feat/rollback changes if not all successful

### DIFF
--- a/classes/Collection.js
+++ b/classes/Collection.js
@@ -5,7 +5,7 @@ const _ = require('lodash')
 
 const { Config } = require('./Config.js')
 const { File, CollectionPageType, DataType } = require('./File.js')
-const { getRootTree, sendTree, deslugifyCollectionName } = require('../utils/utils.js')
+const { getCommitAndTreeSha, getTree, sendTree, deslugifyCollectionName } = require('../utils/utils.js')
 
 const NAV_FILE_NAME = 'navigation.yml'
 
@@ -147,7 +147,8 @@ class Collection {
       const newNavContent = base64.encode(yaml.safeDump(newNavContentObject))
       await nav.update(NAV_FILE_NAME, newNavContent, navSha)
 
-      const { gitTree, currentCommitSha } = await getRootTree(this.siteName, this.accessToken);
+      const { currentCommitSha, treeSha } = await getCommitAndTreeSha(this.siteName, this.accessToken)
+      const gitTree = await getTree(this.siteName, this.accessToken, treeSha);
       const oldCollectionDirectoryName = `_${oldCollectionName}`
       const newCollectionDirectoryName = `_${newCollectionName}`
       const newGitTree = gitTree.map(item => {

--- a/classes/Resource.js
+++ b/classes/Resource.js
@@ -4,7 +4,7 @@ const _ = require('lodash')
 // Import classes 
 const { File, ResourceCategoryType, ResourcePageType } = require('../classes/File.js')
 const { Directory, ResourceRoomType } = require('../classes/Directory.js')
-const { getRootTree, getTree, sendTree } = require('../utils/utils.js')
+const { getCommitAndTreeSha, getTree, sendTree } = require('../utils/utils.js')
 
 // Constants
 const RESOURCE_INDEX_PATH = 'index.html'
@@ -42,7 +42,8 @@ class Resource {
   async rename(resourceRoomName, resourceName, newResourceName) {
     try {
       const commitMessage = `Rename resource category from ${resourceName} to ${newResourceName}`
-      const { gitTree, currentCommitSha } = await getRootTree(this.siteName, this.accessToken);
+      const { currentCommitSha, treeSha } = await getCommitAndTreeSha(this.siteName, this.accessToken)
+      const gitTree = await getTree(this.siteName, this.accessToken, treeSha);
       let newGitTree = []
       let resourceRoomTreeSha
       // Retrieve all git trees of other items
@@ -53,7 +54,7 @@ class Resource {
           newGitTree.push(item)
         }
       })
-      const { gitTree: resourceRoomTree } = await getTree(this.siteName, this.accessToken, resourceRoomTreeSha)
+      const resourceRoomTree = await getTree(this.siteName, this.accessToken, resourceRoomTreeSha)
       resourceRoomTree.forEach(item => {
         // We need to append resource room to the file path because the path is relative to the subtree
         if (item.path === resourceName) {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -955,6 +955,23 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SiteListResponse"
+  /sites/{siteName}:
+    get:
+      tags:
+        - Sites
+      parameters:
+        - name: siteName
+          in: path
+          required: true
+          schema:
+            type: string
+      description: Checks if site exists and user has write access
+      responses:
+        200:
+          description: Success
+        404:
+          description: Not found
+
                 
   /sites/{siteName}/resource-room:
     get:

--- a/middleware/routeHandler.js
+++ b/middleware/routeHandler.js
@@ -1,10 +1,28 @@
+const { getCommitAndTreeSha, revertCommit } = require('../utils/utils.js')
+
 const attachRouteHandlerWrapper = (routeHandler) => async (req, res, next) => {
-    routeHandler(req, res).catch((err) => {
-      next(err)
-    })
+  routeHandler(req, res).catch((err) => {
+    next(err)
+  })
+}
+
+const attachRollbackRouteHandlerWrapper = (routeHandler) => async (req, res, next) => {
+  const { accessToken } = req
+  const { siteName } = req.params
+  let originalCommitSha
+  try {
+    const { currentCommitSha } = await getCommitAndTreeSha(siteName, accessToken)
+    originalCommitSha = currentCommitSha
+  } catch (err) {
+    next(err)
   }
+  routeHandler(req, res).catch((err) => {
+    revertCommit(originalCommitSha, siteName, accessToken)
+    next(err)
+  })
+}
   
-  module.exports = {
-    attachRouteHandlerWrapper,
-  }
-  
+module.exports = {
+  attachRouteHandlerWrapper,
+  attachRollbackRouteHandlerWrapper,
+}

--- a/middleware/routeHandler.js
+++ b/middleware/routeHandler.js
@@ -21,8 +21,8 @@ const attachRollbackRouteHandlerWrapper = (routeHandler) => async (req, res, nex
   routeHandler(req, res).catch(async (err) => {
     try {
       await backOff(() => revertCommit(originalCommitSha, siteName, accessToken))
-    } catch (err) {
-      next(err)
+    } catch (retryErr) {
+      next(retryErr)
     }
     next(err)
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1018,6 +1018,11 @@
         "homedir-polyfill": "^1.0.1"
       }
     },
+    "exponential-backoff": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.0.tgz",
+      "integrity": "sha512-oBuz5SYz5zzyuHINoe9ooePwSu0xApKWgeNzok4hZ5YKXFh9zrQBEM15CXqoZkJJPuI2ArvqjPQd8UKJA753XA=="
+    },
     "express": {
       "version": "4.16.4",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "debug": "~2.6.9",
     "dotenv": "^8.1.0",
+    "exponential-backoff": "^3.1.0",
     "express": "~4.16.1",
     "http-errors": "~1.6.3",
     "js-base64": "^2.5.1",

--- a/routes/collectionPages.js
+++ b/routes/collectionPages.js
@@ -6,7 +6,7 @@ const base64 = require('base-64');
 const _ = require('lodash');
 
 // Import middleware
-const { attachRouteHandlerWrapper } = require('../middleware/routeHandler')
+const { attachRouteHandlerWrapper, attachRollbackRouteHandlerWrapper } = require('../middleware/routeHandler')
 
 // Import classes 
 const { Collection } = require('../classes/Collection.js')
@@ -203,10 +203,10 @@ async function renameCollectionPage (req, res, next) {
 
 router.get('/:siteName/collections/:collectionName', attachRouteHandlerWrapper(listCollectionPages))
 router.get('/:siteName/collections/:collectionName/pages', attachRouteHandlerWrapper(listCollectionPagesDetails))
-router.post('/:siteName/collections/:collectionName/pages', attachRouteHandlerWrapper(createNewcollectionPage))
+router.post('/:siteName/collections/:collectionName/pages', attachRollbackRouteHandlerWrapper(createNewcollectionPage))
 router.get('/:siteName/collections/:collectionName/pages/:pageName', attachRouteHandlerWrapper(readCollectionPage))
 router.post('/:siteName/collections/:collectionName/pages/:pageName', attachRouteHandlerWrapper(updateCollectionPage))
-router.delete('/:siteName/collections/:collectionName/pages/:pageName', attachRouteHandlerWrapper(deleteCollectionPage))
+router.delete('/:siteName/collections/:collectionName/pages/:pageName', attachRollbackRouteHandlerWrapper(deleteCollectionPage))
 router.post('/:siteName/collections/:collectionName/pages/:pageName/rename/:newPageName', attachRouteHandlerWrapper(renameCollectionPage))
 
 module.exports = router;

--- a/routes/collectionPages.js
+++ b/routes/collectionPages.js
@@ -207,6 +207,6 @@ router.post('/:siteName/collections/:collectionName/pages', attachRollbackRouteH
 router.get('/:siteName/collections/:collectionName/pages/:pageName', attachRouteHandlerWrapper(readCollectionPage))
 router.post('/:siteName/collections/:collectionName/pages/:pageName', attachRouteHandlerWrapper(updateCollectionPage))
 router.delete('/:siteName/collections/:collectionName/pages/:pageName', attachRollbackRouteHandlerWrapper(deleteCollectionPage))
-router.post('/:siteName/collections/:collectionName/pages/:pageName/rename/:newPageName', attachRouteHandlerWrapper(renameCollectionPage))
+router.post('/:siteName/collections/:collectionName/pages/:pageName/rename/:newPageName', attachRollbackRouteHandlerWrapper(renameCollectionPage))
 
 module.exports = router;

--- a/routes/collections.js
+++ b/routes/collections.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 // Import middleware
-const { attachRouteHandlerWrapper } = require('../middleware/routeHandler')
+const { attachRouteHandlerWrapper, attachRollbackRouteHandlerWrapper } = require('../middleware/routeHandler')
 
 // Import classes 
 const { Collection } = require('../classes/Collection.js')
@@ -59,8 +59,8 @@ async function renameCollection (req, res, next) {
 }
 
 router.get('/:siteName/collections', attachRouteHandlerWrapper(listCollections))
-router.post('/:siteName/collections', attachRouteHandlerWrapper(createNewCollection))
-router.delete('/:siteName/collections/:collectionName', attachRouteHandlerWrapper(deleteCollection))
-router.post('/:siteName/collections/:collectionName/rename/:newCollectionName', attachRouteHandlerWrapper(renameCollection))
+router.post('/:siteName/collections', attachRollbackRouteHandlerWrapper(createNewCollection))
+router.delete('/:siteName/collections/:collectionName', attachRollbackRouteHandlerWrapper(deleteCollection))
+router.post('/:siteName/collections/:collectionName/rename/:newCollectionName', attachRollbackRouteHandlerWrapper(renameCollection))
 
 module.exports = router;

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -4,7 +4,7 @@ const Bluebird = require('bluebird')
 const _ = require('lodash')
 
 // Import middleware
-const { attachRouteHandlerWrapper } = require('../middleware/routeHandler')
+const { attachRouteHandlerWrapper, attachRollbackRouteHandlerWrapper } = require('../middleware/routeHandler')
 
 // Import classes
 const { File, PageType, CollectionPageType } = require('../classes/File.js')
@@ -163,6 +163,6 @@ router.post('/:siteName/pages', attachRouteHandlerWrapper(createNewPage))
 router.get('/:siteName/pages/:pageName', attachRouteHandlerWrapper(readPage))
 router.post('/:siteName/pages/:pageName', attachRouteHandlerWrapper(updatePage))
 router.delete('/:siteName/pages/:pageName', attachRouteHandlerWrapper(deletePage))
-router.post('/:siteName/pages/:pageName/rename/:newPageName', attachRouteHandlerWrapper(renamePage))
+router.post('/:siteName/pages/:pageName/rename/:newPageName', attachRollbackRouteHandlerWrapper(renamePage))
 
 module.exports = router;

--- a/routes/resourcePages.js
+++ b/routes/resourcePages.js
@@ -144,6 +144,6 @@ router.post('/:siteName/resources/:resourceName/pages', attachRollbackRouteHandl
 router.get('/:siteName/resources/:resourceName/pages/:pageName', attachRouteHandlerWrapper(readResourcePage))
 router.post('/:siteName/resources/:resourceName/pages/:pageName', attachRouteHandlerWrapper(updateResourcePage))
 router.delete('/:siteName/resources/:resourceName/pages/:pageName', attachRollbackRouteHandlerWrapper(deleteResourcePage))
-router.post('/:siteName/resources/:resourceName/pages/:pageName/rename/:newPageName', attachRouteHandlerWrapper(renameResourcePage))
+router.post('/:siteName/resources/:resourceName/pages/:pageName/rename/:newPageName', attachRollbackRouteHandlerWrapper(renameResourcePage))
 
 module.exports = router;

--- a/routes/resourcePages.js
+++ b/routes/resourcePages.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 // Import middleware
-const { attachRouteHandlerWrapper } = require('../middleware/routeHandler')
+const { attachRouteHandlerWrapper, attachRollbackRouteHandlerWrapper } = require('../middleware/routeHandler')
 
 // Import classes 
 const { File, ResourcePageType } = require('../classes/File.js')
@@ -140,10 +140,10 @@ async function renameResourcePage (req, res, next) {
   res.status(200).json({ resourceName, pageName: newPageName, content, sha: newSha })
 }
 router.get('/:siteName/resources/:resourceName', attachRouteHandlerWrapper(listResourcePages))
-router.post('/:siteName/resources/:resourceName/pages', attachRouteHandlerWrapper(createNewResourcePage))
+router.post('/:siteName/resources/:resourceName/pages', attachRollbackRouteHandlerWrapper(createNewResourcePage))
 router.get('/:siteName/resources/:resourceName/pages/:pageName', attachRouteHandlerWrapper(readResourcePage))
 router.post('/:siteName/resources/:resourceName/pages/:pageName', attachRouteHandlerWrapper(updateResourcePage))
-router.delete('/:siteName/resources/:resourceName/pages/:pageName', attachRouteHandlerWrapper(deleteResourcePage))
+router.delete('/:siteName/resources/:resourceName/pages/:pageName', attachRollbackRouteHandlerWrapper(deleteResourcePage))
 router.post('/:siteName/resources/:resourceName/pages/:pageName/rename/:newPageName', attachRouteHandlerWrapper(renameResourcePage))
 
 module.exports = router;

--- a/routes/resourceRoom.js
+++ b/routes/resourceRoom.js
@@ -3,7 +3,7 @@ const router = express.Router();
 
 // Import classes 
 const { ResourceRoom } = require('../classes/ResourceRoom.js');
-const { attachRouteHandlerWrapper } = require('../middleware/routeHandler');
+const { attachRouteHandlerWrapper, attachRollbackRouteHandlerWrapper } = require('../middleware/routeHandler');
 
 // Get resource room name
 async function getResourceRoomName (req, res, next) {
@@ -57,8 +57,8 @@ async function deleteResourceRoom(req, res, next) {
 }
 
 router.get('/:siteName/resource-room', attachRouteHandlerWrapper(getResourceRoomName))
-router.post('/:siteName/resource-room', attachRouteHandlerWrapper(createResourceRoom))
-router.post('/:siteName/resource-room/:resourceRoom', attachRouteHandlerWrapper(renameResourceRoom))
-router.delete('/:siteName/resource-room', attachRouteHandlerWrapper(deleteResourceRoom))
+router.post('/:siteName/resource-room', attachRollbackRouteHandlerWrapper(createResourceRoom))
+router.post('/:siteName/resource-room/:resourceRoom', attachRollbackRouteHandlerWrapper(renameResourceRoom))
+router.delete('/:siteName/resource-room', attachRollbackRouteHandlerWrapper(deleteResourceRoom))
 
 module.exports = router;

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 // Import middleware
-const { attachRouteHandlerWrapper } = require('../middleware/routeHandler')
+const { attachRouteHandlerWrapper, attachRollbackRouteHandlerWrapper } = require('../middleware/routeHandler')
 
 // Import classes 
 const { ResourceRoom } = require('../classes/ResourceRoom.js')
@@ -66,8 +66,8 @@ async function renameResource (req, res, next) {
 }
 
 router.get('/:siteName/resources', attachRouteHandlerWrapper(listResources))
-router.post('/:siteName/resources', attachRouteHandlerWrapper(createNewResource))
-router.delete('/:siteName/resources/:resourceName', attachRouteHandlerWrapper(deleteResource))
-router.post('/:siteName/resources/:resourceName/rename/:newResourceName', attachRouteHandlerWrapper(renameResource))
+router.post('/:siteName/resources', attachRollbackRouteHandlerWrapper(createNewResource))
+router.delete('/:siteName/resources/:resourceName', attachRollbackRouteHandlerWrapper(deleteResource))
+router.post('/:siteName/resources/:resourceName/rename/:newResourceName', attachRollbackRouteHandlerWrapper(renameResource))
 
 module.exports = router;

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 // Import middleware
-const { attachRouteHandlerWrapper } = require('../middleware/routeHandler')
+const { attachRouteHandlerWrapper, attachRollbackRouteHandlerWrapper } = require('../middleware/routeHandler')
 
 // Import Classes
 const { Settings } = require('../classes/Settings.js')
@@ -26,6 +26,6 @@ async function updateSettings (req, res, next) {
 }
 
 router.get('/:siteName/settings', attachRouteHandlerWrapper(getSettings))
-router.post('/:siteName/settings', attachRouteHandlerWrapper(updateSettings))
+router.post('/:siteName/settings', attachRollbackRouteHandlerWrapper(updateSettings))
 
 module.exports = router;

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -111,7 +111,7 @@ async function sendTree(gitTree, currentCommitSha, repo, accessToken, message, b
   });
 }
 
-// send the new tree object back to Github and point the latest commit on the staging branch to it
+// Revert the staging branch back to `originalCommitSha`
 async function revertCommit(originalCommitSha, repo, accessToken, branchRef='staging') {
   const headers = {
     Authorization: `token ${accessToken}`,
@@ -122,8 +122,7 @@ async function revertCommit(originalCommitSha, repo, accessToken, branchRef='sta
   const refEndpoint = `${baseRefEndpoint}/heads/${branchRef}`;
 
   /**
-   * The `staging` branch reference will now point
-   * to `newCommitSha` instead of `currentCommitSha`
+   * The `staging` branch reference will now point to `currentCommitSha`
    */
   await axios.patch(refEndpoint, {
     sha: originalCommitSha,

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -46,7 +46,7 @@ async function getCommitAndTreeSha(repo, accessToken, branchRef='staging') {
 
     return { treeSha, currentCommitSha };
   } catch (err) {
-    console.log(err);
+    throw err
   }
 }
 
@@ -67,7 +67,7 @@ async function getTree(repo, accessToken, treeSha, branchRef='staging') {
 
     return gitTree;
   } catch (err) {
-    console.log(err);
+    throw err
   }
 }
 

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -27,8 +27,7 @@ function deslugifyCollectionPage(collectionPageName) {
   )
 }
 
-// retrieve the tree item
-async function getRootTree(repo, accessToken, branchRef='staging') {
+async function getCommitAndTreeSha(repo, accessToken, branchRef='staging') {
   try {
     const headers = {
       Authorization: `token ${accessToken}`,
@@ -45,14 +44,7 @@ async function getRootTree(repo, accessToken, branchRef='staging') {
     const { commit: { tree: { sha: treeSha } } } = commits[0];
     const currentCommitSha = commits[0].sha;
 
-    const { data: { tree: gitTree } } = await axios.get(`https://api.github.com/repos/${GITHUB_ORG_NAME}/${repo}/git/trees/${treeSha}`, {
-      params: {
-        ref: branchRef,
-      },
-      headers,
-    });
-
-    return { gitTree, currentCommitSha };
+    return { treeSha, currentCommitSha };
   } catch (err) {
     console.log(err);
   }
@@ -73,7 +65,7 @@ async function getTree(repo, accessToken, treeSha, branchRef='staging') {
       headers,
     });
 
-    return { gitTree };
+    return gitTree;
   } catch (err) {
     console.log(err);
   }
@@ -119,6 +111,28 @@ async function sendTree(gitTree, currentCommitSha, repo, accessToken, message, b
   });
 }
 
+// send the new tree object back to Github and point the latest commit on the staging branch to it
+async function revertCommit(originalCommitSha, repo, accessToken, branchRef='staging') {
+  const headers = {
+    Authorization: `token ${accessToken}`,
+    Accept: 'application/json',
+  };
+
+  const baseRefEndpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${repo}/git/refs`;
+  const refEndpoint = `${baseRefEndpoint}/heads/${branchRef}`;
+
+  /**
+   * The `staging` branch reference will now point
+   * to `newCommitSha` instead of `currentCommitSha`
+   */
+  await axios.patch(refEndpoint, {
+    sha: originalCommitSha,
+    force: true,
+  }, {
+    headers,
+  });
+}
+
 /** 
  * A function to deslugify a collection's name
 */
@@ -132,7 +146,8 @@ function deslugifyCollectionName(collectionName) {
 module.exports = {
   deslugifyCollectionPage,
   deslugifyCollectionName,
-  getRootTree,
+  getCommitAndTreeSha,
   getTree,
   sendTree,
+  revertCommit,
 }


### PR DESCRIPTION
This PR builds on PR https://github.com/isomerpages/isomercms-backend/pull/88. Currently, when calling a particular endpoint, it is possible for some of the API calls to succeed, while others fail (for example, config is updated, but nav is not), leading to an inconsistent state. 

To prevent this behaviour, this PR introduces a new route handler for endpoints which involve multiple API calls. The sha of the initial state of the repo is stored before any changes have been made, and if an error is thrown at any point, the branch is reset to its original state. Only the endpoints which involve multiple calls to the Github API utilise this new route handler, to prevent unnecessary querying. The endpoints which have been changed are:

- Collection Page - create, delete
- Collection - create, delete, rename
- Resource Page - create, delete
- Resource room - create, delete, rename
- Resource Category - create, delete, rename
- Settings - update

For reference, the time taken to retrieve the latest commit sha is around 1.5-2s, while the time taken to retrieve the git tree from its sha is around 1s for the a-test repo. The time taken to retrieve the git tree might be longer for repos with more items, although it should be noted that size of subtrees does not impact the time taken, since we currently do not retrieve items recursively.