### PR TITLE
feat: only update Settings file if field has changed

### DIFF
--- a/classes/Settings.js
+++ b/classes/Settings.js
@@ -137,21 +137,21 @@ class Settings {
 
     const settingsObj = {}
 
-    if (configSettings) {
+    if (!_.isEmpty(configSettings)) {
       settingsObj.config = {
         payload: configSettings,
         currentData: configContent,
       }
     }
 
-    if (footerSettings) {
+    if (!_.isEmpty(footerSettings)) {
       settingsObj.footer = {
         payload: footerSettings,
         currentData: footerContent,
       }
     }
     
-    if (navigationSettings) {
+    if (!_.isEmpty(navigationSettings)) {
       settingsObj.navigation = {
         payload: navigationSettings,
         currentData: navigationContent,
@@ -177,7 +177,7 @@ class Settings {
     const { configSettingsObj, footerSettingsObj, navigationSettingsObj } = updatedSettingsObj
 
     // To-do: use Git Tree to speed up operations
-    if (configSettings) {
+    if (!_.isEmpty(configSettings)) {
       const newConfigContent = Base64.encode(yaml.safeDump(configSettingsObj))
       await configResp.update(newConfigContent, config.sha)
 
@@ -195,12 +195,12 @@ class Settings {
       }
     }
 
-    if (footerSettings) {
+    if (!_.isEmpty(footerSettings)) {
       const newFooterContent = Base64.encode(yaml.safeDump(footerSettingsObj))
       await FooterFile.update(FOOTER_PATH, newFooterContent, footer.sha)
     }
 
-    if (navigationSettings) {
+    if (!_.isEmpty(navigationSettings)) {
       const newNavigationContent = Base64.encode(yaml.safeDump(navigationSettingsObj))
       await NavigationFile.update(NAVIGATION_PATH, newNavigationContent, navigation.sha)
     }


### PR DESCRIPTION
**Note:** This PR is to be reviewed with PR #[286](https://github.com/isomerpages/isomercms-frontend/pull/286) on the frontend.

## Overview
The `Settings` class deals with three different types of configuration files: `_config.yml`, `_data/footer.yml`, and `_data/navigation.yml`. Originally, we would write to all three files, even if the only fields that were changed involved only one of the files.

For example, even if I had only changed the `title` field (which affects only the `_config.yml` file), I would end up making API calls to update the remaining two settings files with their original content. With this PR, I would only update the `_config.yml` file and not the other two files.

By only making changes that need to be made, we can increase the speed of response by only updating a file if it needs to be updated - from preliminary tests, we found that we can reduce the load time by more than half, from 8 seconds to 3 or so seconds.