### PR TITLE
Fix/error handling for large payload

### DIFF
--- a/middleware/errorHandler.js
+++ b/middleware/errorHandler.js
@@ -22,15 +22,27 @@ function errorHandler (err, req, res, next) {
             },
         })
     } else {
-        logger.info(`Unrecognized internal server error: ${errMsg}`)
-        res.status(500).json({
-            error: {
-                code: 500,
-                message: 'Something went wrong',
-            },
-        })
+        // Error thrown by large payload is done by express
+        if (err.name === "PayloadTooLargeError") {
+            logger.info(errMsg)
+            res.status(413).json({
+                error: {
+                    name: err.name,
+                    code: 413,
+                    message: err.message,
+                },
+            })
+        } else {
+            logger.info(`Unrecognized internal server error: ${errMsg}`)
+            res.status(500).json({
+                error: {
+                    code: 500,
+                    message: 'Something went wrong',
+                },
+            })
+        }
     }
-  }
+}
 
 module.exports = {
     errorHandler,

--- a/server.js
+++ b/server.js
@@ -34,15 +34,14 @@ const netlifyTomlRouter = require('./routes/netlifyToml')
 const app = express();
 
 app.use(logger('dev'));
-app.use(express.json({ limit: '5mb'}));
-app.use(express.urlencoded({ extended: false }));
-app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
-
 app.use(cors({
   'origin': FRONTEND_URL,
   'credentials': true,
 }))
+app.use(express.json({ limit: '5mb'}));
+app.use(express.urlencoded({ extended: false }));
+app.use(cookieParser());
+app.use(express.static(path.join(__dirname, 'public')));
 
 // Use auth middleware
 app.use(auth)


### PR DESCRIPTION
This PR adds error handling for large payloads. In addition, it fixes a bug where errors thrown by the express json body parser would always result in a network error for the frontend. To be reviewed with PR #[289](https://github.com/isomerpages/isomercms-frontend/pull/289) on the isomercms-frontend repo.

The error handling for large payloads is different from the regular IsomerErrors, since this check is done by the express json body parser (`app.use(express.json({ limit: '5mb'}))`), it goes directly to our errorhandler before an IsomerError can be thrown. As such, a separate check in the error handler has been added.

For the network error, this was being caused by the cors middleware being initialised after the json body parser - this caused the response to not have the proper headers set, resulting in a network error always occurring. The initialisation of the cors middleware has been moved up to account for this.