### PR TITLE
chore: add `/v1` to all URI paths

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -213,7 +213,7 @@ components:
 
 
 paths:
-  /:
+  /v1:
     get:
       tags:
         - Authentication
@@ -225,7 +225,7 @@ paths:
             application/json:
               schema: 
                 $ref: "#/components/schemas/OAuthParams"
-  /sites/{siteName}/collections:
+  /v1/sites/{siteName}/collections:
     get:
       tags:
         - Collections
@@ -265,7 +265,7 @@ paths:
             application/json:
               schema: 
                 $ref: "#/components/schemas/CollectionNameResponse"
-  /sites/{siteName}/collections/{collectionName}:
+  /v1/sites/{siteName}/collections/{collectionName}:
     get:
       tags:
         - Collection Pages
@@ -310,7 +310,7 @@ paths:
             application/json:
               schema: 
                 $ref: "#/components/schemas/CollectionNameResponse"
-  /sites/{siteName}/collections/{collectionName}/rename/{newCollectionName}:
+  /v1/sites/{siteName}/collections/{collectionName}/rename/{newCollectionName}:
     post:
       tags:
         - Collections
@@ -343,7 +343,7 @@ paths:
             application/json:
               schema: 
                 $ref: "#/components/schemas/RenameCollection"
-  /sites/{siteName}/collections/{collectionName}/pages:
+  /v1/sites/{siteName}/collections/{collectionName}/pages:
     post:
       tags:
         - Collection Pages
@@ -371,7 +371,7 @@ paths:
             application/json:
               schema: 
                 $ref: "#/components/schemas/CollectionListResponse"
-  /sites/{siteName}/collections/{collectionName}/pages/{pageName}:
+  /v1/sites/{siteName}/collections/{collectionName}/pages/{pageName}:
     get:
       tags:
         - Collection Pages
@@ -459,7 +459,7 @@ paths:
       responses:
         200:
           description: Success
-  /sites/{siteName}/collections/{collectionName}/pages/{pageName}/rename/{newPageName}:
+  /v1/sites/{siteName}/collections/{collectionName}/pages/{pageName}/rename/{newPageName}:
     post:
       tags:
         - Collection Pages
@@ -498,7 +498,7 @@ paths:
               schema: 
                 $ref: "#/components/schemas/CollectionPageResponse"
                 
-  /sites/{siteName}/pages:
+  /v1/sites/{siteName}/pages:
     get:
       tags:
         - Pages
@@ -543,7 +543,7 @@ paths:
             application/json:
               schema: 
                 $ref: "#/components/schemas/PageResponse"
-  /sites/{siteName}/pages/{pageName}:
+  /v1/sites/{siteName}/pages/{pageName}:
     get:
       tags:
         - Pages
@@ -616,7 +616,7 @@ paths:
       responses:
         200:
           description: Success
-  /sites/{siteName}/pages/{pageName}/rename/{newPageName}:
+  /v1/sites/{siteName}/pages/{pageName}/rename/{newPageName}:
     post:
       tags:
         - Pages
@@ -650,7 +650,7 @@ paths:
               schema: 
                 $ref: "#/components/schemas/PageResponse"
                 
-  /sites/{siteName}/documents:
+  /v1/sites/{siteName}/documents:
     get:
       tags:
         - Documents
@@ -690,7 +690,7 @@ paths:
             application/json:
               schema: 
                 $ref: "#/components/schemas/DocumentResponse"
-  /sites/{siteName}/documents/{documentName}:
+  /v1/sites/{siteName}/documents/{documentName}:
     get:
       tags:
         - Documents
@@ -763,7 +763,7 @@ paths:
       responses:
         200:
           description: Success
-  /sites/{siteName}/documents/{documentName}/rename/{newDocumentName}:
+  /v1/sites/{siteName}/documents/{documentName}/rename/{newDocumentName}:
     post:
       tags:
         - Documents
@@ -797,7 +797,7 @@ paths:
               schema: 
                 $ref: "#/components/schemas/DocumentResponse"
                 
-  /sites/{siteName}/images:
+  /v1/sites/{siteName}/images:
     get:
       tags:
         - Images
@@ -837,7 +837,7 @@ paths:
             application/json:
               schema: 
                 $ref: "#/components/schemas/ImageResponse"
-  /sites/{siteName}/images/{imageName}:
+  /v1/sites/{siteName}/images/{imageName}:
     get:
       tags:
         - Images
@@ -910,7 +910,7 @@ paths:
       responses:
         200:
           description: Success
-  /sites/{siteName}/images/{imageName}/rename/{newImageName}:
+  /v1/sites/{siteName}/images/{imageName}/rename/{newImageName}:
     post:
       tags:
         - Images
@@ -943,7 +943,7 @@ paths:
             application/json:
               schema: 
                 $ref: "#/components/schemas/ImageResponse"
-  /sites:
+  /v1/sites:
     get:
       tags:
         - Sites
@@ -956,7 +956,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SiteListResponse"
                 
-  /sites/{siteName}/resource-room:
+  /v1/sites/{siteName}/resource-room:
     get:
       tags:
         - Resource Room
@@ -1009,7 +1009,7 @@ paths:
       responses:
         200:
           description: Success
-  /sites/{siteName}/resource-room/{resourceRoom}:
+  /v1/sites/{siteName}/resource-room/{resourceRoom}:
     post:
       tags:
         - Resource Room
@@ -1032,7 +1032,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResourceRoom"
-  /sites/{siteName}/resources:
+  /v1/sites/{siteName}/resources:
     get:
       tags:
         - Resources
@@ -1072,7 +1072,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResourceResponse"
-  /sites/{siteName}/resources/{resourceName}:
+  /v1/sites/{siteName}/resources/{resourceName}:
     get:
       tags:
         - Resource Pages
@@ -1113,7 +1113,7 @@ paths:
       responses:
         200:
           description: Success
-  /sites/{siteName}/resources/{resourceName}/rename/{newResourceName}:
+  /v1/sites/{siteName}/resources/{resourceName}/rename/{newResourceName}:
     post:
       tags:
         - Resources
@@ -1141,7 +1141,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RenameResource"
-  /sites/{siteName}/resources/{resourceName}/pages:
+  /v1/sites/{siteName}/resources/{resourceName}/pages:
     post:
       tags:
         - Resource Pages
@@ -1169,7 +1169,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResourcePageResponse"
-  /sites/{siteName}/resources/{resourceName}/pages/{pageName}:
+  /v1/sites/{siteName}/resources/{resourceName}/pages/{pageName}:
     get:
       tags:
         - Resource Pages
@@ -1257,7 +1257,7 @@ paths:
       responses:
         200:
           description: Success
-  /sites/{siteName}/resources/{resourceName}/pages/{pageName}/rename/{newPageName}:
+  /v1/sites/{siteName}/resources/{resourceName}/pages/{pageName}/rename/{newPageName}:
     post:
       tags:
         - Resource Pages
@@ -1295,7 +1295,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResourcePageResponse"
-  /sites/{siteName}/menus:
+  /v1/sites/{siteName}/menus:
     get:
       tags:
         - Menus
@@ -1313,7 +1313,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MenuListResponse"
-  /sites/{siteName}/menus/{menuName}:
+  /v1/sites/{siteName}/menus/{menuName}:
     get:
       tags:
         - Menus

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -37,94 +37,94 @@ const verifyJwt = (req, res, next) => {
 }
 
 // Login and logout
-auth.get('/auth', noVerify)
-auth.get('/auth/logout', noVerify)
+auth.get('/v1/auth', noVerify)
+auth.get('/v1/auth/logout', noVerify)
 
 // Index
-auth.get('/', noVerify)
+auth.get('/v1', noVerify)
 
 // Homepage
-auth.get('/sites/:siteName/homepage', verifyJwt)
-auth.post('/sites/:siteName/homepage', verifyJwt)
+auth.get('/v1/sites/:siteName/homepage', verifyJwt)
+auth.post('/v1/sites/:siteName/homepage', verifyJwt)
 
 // Collection pages
-auth.get('/sites/:siteName/collections/:collectionName', verifyJwt)
-auth.get('/sites/:siteName/collections/:collectionName/pages', verifyJwt)
-auth.post('/sites/:siteName/collections/:collectionName/pages', verifyJwt)
-auth.get('/sites/:siteName/collections/:collectionName/pages/:pageName', verifyJwt)
-auth.post('/sites/:siteName/collections/:collectionName/pages/:pageName', verifyJwt)
-auth.delete('/sites/:siteName/collections/:collectionName/pages/:pageName', verifyJwt)
-auth.post('/sites/:siteName/collections/:collectionName/pages/:pageName/rename/:newPageName', verifyJwt)
+auth.get('/v1/sites/:siteName/collections/:collectionName', verifyJwt)
+auth.get('/v1/sites/:siteName/collections/:collectionName/pages', verifyJwt)
+auth.post('/v1/sites/:siteName/collections/:collectionName/pages', verifyJwt)
+auth.get('/v1/sites/:siteName/collections/:collectionName/pages/:pageName', verifyJwt)
+auth.post('/v1/sites/:siteName/collections/:collectionName/pages/:pageName', verifyJwt)
+auth.delete('/v1/sites/:siteName/collections/:collectionName/pages/:pageName', verifyJwt)
+auth.post('/v1/sites/:siteName/collections/:collectionName/pages/:pageName/rename/:newPageName', verifyJwt)
 
 // Collections
-auth.get('/sites/:siteName/collections', verifyJwt)
-auth.post('/sites/:siteName/collections', verifyJwt)
-auth.delete('/sites/:siteName/collections/:collectionName', verifyJwt)
-auth.post('/sites/:siteName/collections/:collectionName/rename/:newCollectionName', verifyJwt)
+auth.get('/v1/sites/:siteName/collections', verifyJwt)
+auth.post('/v1/sites/:siteName/collections', verifyJwt)
+auth.delete('/v1/sites/:siteName/collections/:collectionName', verifyJwt)
+auth.post('/v1/sites/:siteName/collections/:collectionName/rename/:newCollectionName', verifyJwt)
 
 // Documents
-auth.get('/sites/:siteName/documents', verifyJwt)
-auth.post('/sites/:siteName/documents', verifyJwt)
-auth.get('/sites/:siteName/documents/:documentName', verifyJwt)
-auth.post('/sites/:siteName/documents/:documentName', verifyJwt)
-auth.delete('/sites/:siteName/documents/:documentName', verifyJwt)
-auth.post('/sites/:siteName/documents/:documentName/rename/:newDocumentName', verifyJwt)
+auth.get('/v1/sites/:siteName/documents', verifyJwt)
+auth.post('/v1/sites/:siteName/documents', verifyJwt)
+auth.get('/v1/sites/:siteName/documents/:documentName', verifyJwt)
+auth.post('/v1/sites/:siteName/documents/:documentName', verifyJwt)
+auth.delete('/v1/sites/:siteName/documents/:documentName', verifyJwt)
+auth.post('/v1/sites/:siteName/documents/:documentName/rename/:newDocumentName', verifyJwt)
 
 // Images
-auth.get('/sites/:siteName/images', verifyJwt)
-auth.post('/sites/:siteName/images', verifyJwt)
-auth.get('/sites/:siteName/images/:imageName', verifyJwt)
-auth.post('/sites/:siteName/images/:imageName', verifyJwt)
-auth.delete('/sites/:siteName/images/:imageName', verifyJwt)
-auth.post('/sites/:siteName/images/:imageName/rename/:newImageName', verifyJwt)
+auth.get('/v1/sites/:siteName/images', verifyJwt)
+auth.post('v/sites/:siteName/images', verifyJwt)
+auth.get('/v1/sites/:siteName/images/:imageName', verifyJwt)
+auth.post('/v1/sites/:siteName/images/:imageName', verifyJwt)
+auth.delete('/v1/sites/:siteName/images/:imageName', verifyJwt)
+auth.post('/v1/sites/:siteName/images/:imageName/rename/:newImageName', verifyJwt)
 
 // Menu directory
-auth.get('/sites/:siteName/tree', verifyJwt)
+auth.get('/v1/sites/:siteName/tree', verifyJwt)
 
 // Menu
-auth.get('/sites/:siteName/menus', verifyJwt)
-auth.get('/sites/:siteName/menus/:menuName', verifyJwt)
-auth.post('/sites/:siteName/menus/:menuName', verifyJwt)
+auth.get('/v1/sites/:siteName/menus', verifyJwt)
+auth.get('/v1/sites/:siteName/menus/:menuName', verifyJwt)
+auth.post('/v1/sites/:siteName/menus/:menuName', verifyJwt)
 
 // Pages
-auth.get('/sites/:siteName/pages', verifyJwt)
-auth.get('/sites/:siteName/unlinkedPages', verifyJwt)
-auth.post('/sites/:siteName/pages', verifyJwt)
-auth.get('/sites/:siteName/pages/:pageName', verifyJwt)
-auth.post('/sites/:siteName/pages/:pageName', verifyJwt)
-auth.delete('/sites/:siteName/pages/:pageName', verifyJwt)
-auth.post('/sites/:siteName/pages/:pageName/rename/:newPageName', verifyJwt)
+auth.get('/v1/sites/:siteName/pages', verifyJwt)
+auth.get('/v1/sites/:siteName/unlinkedPages', verifyJwt)
+auth.post('/v1/sites/:siteName/pages', verifyJwt)
+auth.get('/v1/sites/:siteName/pages/:pageName', verifyJwt)
+auth.post('/v1/sites/:siteName/pages/:pageName', verifyJwt)
+auth.delete('/v1/sites/:siteName/pages/:pageName', verifyJwt)
+auth.post('/v1/sites/:siteName/pages/:pageName/rename/:newPageName', verifyJwt)
 
 // Resource pages
-auth.get('/sites/:siteName/resources/:resourceName', verifyJwt)
-auth.post('/sites/:siteName/resources/:resourceName/pages', verifyJwt)
-auth.get('/sites/:siteName/resources/:resourceName/pages/:pageName', verifyJwt)
-auth.post('/sites/:siteName/resources/:resourceName/pages/:pageName', verifyJwt)
-auth.delete('/sites/:siteName/resources/:resourceName/pages/:pageName', verifyJwt)
-auth.post('/sites/:siteName/resources/:resourceName/pages/:pageName/rename/:newPageName', verifyJwt)
+auth.get('/v1/sites/:siteName/resources/:resourceName', verifyJwt)
+auth.post('/v1/sites/:siteName/resources/:resourceName/pages', verifyJwt)
+auth.get('/v1/sites/:siteName/resources/:resourceName/pages/:pageName', verifyJwt)
+auth.post('/v1/sites/:siteName/resources/:resourceName/pages/:pageName', verifyJwt)
+auth.delete('/v1/sites/:siteName/resources/:resourceName/pages/:pageName', verifyJwt)
+auth.post('/v1/sites/:siteName/resources/:resourceName/pages/:pageName/rename/:newPageName', verifyJwt)
 
 // Resource room
-auth.get('/sites/:siteName/resource-room', verifyJwt)
-auth.post('/sites/:siteName/resource-room', verifyJwt)
-auth.post('/sites/:siteName/resource-room/:resourceRoom', verifyJwt)
-auth.delete('/sites/:siteName/resource-room', verifyJwt)
+auth.get('/v1/sites/:siteName/resource-room', verifyJwt)
+auth.post('/v1/sites/:siteName/resource-room', verifyJwt)
+auth.post('/v1/sites/:siteName/resource-room/:resourceRoom', verifyJwt)
+auth.delete('/v1/sites/:siteName/resource-room', verifyJwt)
 
 // Resources
-auth.get('/sites/:siteName/resources', verifyJwt)
-auth.post('/sites/:siteName/resources', verifyJwt)
-auth.delete('/sites/:siteName/resources/:resourceName', verifyJwt)
-auth.post('/sites/:siteName/resources/:resourceName/rename/:newResourceName', verifyJwt)
+auth.get('/v1/sites/:siteName/resources', verifyJwt)
+auth.post('/v1/sites/:siteName/resources', verifyJwt)
+auth.delete('/v1/sites/:siteName/resources/:resourceName', verifyJwt)
+auth.post('/v1/sites/:siteName/resources/:resourceName/rename/:newResourceName', verifyJwt)
 
 // Settings
-auth.get('/sites/:siteName/settings', verifyJwt)
-auth.post('/sites/:siteName/settings', verifyJwt)
+auth.get('/v1/sites/:siteName/settings', verifyJwt)
+auth.post('/v1/sites/:siteName/settings', verifyJwt)
 
 // Netlify toml
-auth.get('/sites/:siteName/netlify-toml', verifyJwt)
+auth.get('/v1/sites/:siteName/netlify-toml', verifyJwt)
 
 // Sites
-auth.get('/sites', verifyJwt)
-auth.get('/sites/:siteName', verifyJwt)
+auth.get('/v1/sites', verifyJwt)
+auth.get('/v1/sites/:siteName', verifyJwt)
 
 auth.use((req, res, next) => {
     if (!req.route) {

--- a/server.js
+++ b/server.js
@@ -51,22 +51,22 @@ app.use(auth)
 app.use(apiLogger)
 
 // Routes layer setup
-app.use('/', indexRouter);
-app.use('/auth', authRouter);
-app.use('/sites', sitesRouter)
-app.use('/sites', pagesRouter)
-app.use('/sites', collectionsRouter)
-app.use('/sites', collectionPagesRouter)
-app.use('/sites', resourceRoomRouter)
-app.use('/sites', resourcesRouter)
-app.use('/sites', resourcePagesRouter)
-app.use('/sites', imagesRouter)
-app.use('/sites', documentsRouter)
-app.use('/sites', menuRouter)
-app.use('/sites', homepageRouter)
-app.use('/sites', menuDirectoryRouter)
-app.use('/sites', settingsRouter)
-app.use('/sites', netlifyTomlRouter)
+app.use('/v1', indexRouter);
+app.use('/v1/auth', authRouter);
+app.use('/v1/sites', sitesRouter)
+app.use('/v1/sites', pagesRouter)
+app.use('/v1/sites', collectionsRouter)
+app.use('/v1/sites', collectionPagesRouter)
+app.use('/v1/sites', resourceRoomRouter)
+app.use('/v1/sites', resourcesRouter)
+app.use('/v1/sites', resourcePagesRouter)
+app.use('/v1/sites', imagesRouter)
+app.use('/v1/sites', documentsRouter)
+app.use('/v1/sites', menuRouter)
+app.use('/v1/sites', homepageRouter)
+app.use('/v1/sites', menuDirectoryRouter)
+app.use('/v1/sites', settingsRouter)
+app.use('/v1/sites', netlifyTomlRouter)
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {


### PR DESCRIPTION
## Overview

This PR adds a `/v1` prefix to all URI paths to version our API. This will be useful for several reasons:
- allows us to gracefully accommodate a v2 api which uses github's graphql API
- allows us to craft tight firewall rules (currently, we search for whether a
URI path contains `/sites` or `/auth`, which would allow nonsense URI paths like
`/authors`)

**Note**: things which we need to do before we merge the PR:
- ~Change the `REDIRECT_URI` env var on backend to include `/v1`~ (if the `REDIRECT_URI` is unspecified it will use the callback URL from the GitHub app)
- Update the `REACT_APP_BACKEND_URL` env var on frontend to include `/v1`
- Update the callback URL for the staging app (and eventually the production app) to include `/v1`