### PR TITLE
Fix: add check for files in directory when reading file

### DIFF
--- a/classes/File.js
+++ b/classes/File.js
@@ -88,6 +88,7 @@ class File {
   async read(fileName) {
     try {
       const files = await this.list()
+      if (_.isEmpty(files)) throw new NotFoundError ('File does not exist')
       const fileToRead = files.filter((file) => file.fileName === fileName)[0]
       if (fileToRead === undefined) throw new NotFoundError ('File does not exist')
       const endpoint = `${this.baseBlobEndpoint}/${fileToRead.sha}`


### PR DESCRIPTION
This PR fixes a bug where certain File types would not throw the proper error if they failed to be read. Certain specified File types have a default `folderName`, which `read` attempts to read from initially, however, this would result in an empty object if the appropriate directory did not exist. An additional check has been added to ensure that the directory exists, and to throw a NotFoundError if it does not.