### PR TITLE
Fix/increase nginx max body size

### DIFF
--- a/.ebextensions/nginx-max-body-size.config
+++ b/.ebextensions/nginx-max-body-size.config
@@ -1,0 +1,11 @@
+files:
+    "/etc/nginx/conf.d/proxy.conf" :
+        mode: "000755"
+        owner: root
+        group: root
+        content: |
+           client_max_body_size 10M;
+
+commands:
+  00_reload_nginx:
+    command: "service nginx reload"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         - name: Install NPM
           run: npm ci
         - name: Zip application
-          run: zip -r "deploy.zip" * -x .env-example .gitignore package-lock.json
+          run: zip -r "deploy.zip" * .ebextensions -x .env-example .gitignore package-lock.json
         - name: Get timestamp
           shell: bash
           run: echo "##[set-output name=timestamp;]$(env TZ=Asia/Singapore date '+%Y%m%d%H%M%S')"


### PR DESCRIPTION
## Overview
Even though we set a higher file size limit in our express app, we found that uploads exceeding 1mb were being rejected by our server. This was only occurring on the staging website, but not on local dev env, which implied a server config issue.

After reading the nginx error logs, we found that nginx was rejecting the requests because the body size of the request was too large.

```
2020/12/17 07:48:47 [error] 3685#0: *146 client intended to send too large body: 1266065 bytes, 
client: 172.31.37.251, server: , request: "POST /v1/sites/a-test/images HTTP/1.1", host: "staging-cms-api.isomer.gov.sg", 
referrer: "https://staging-cms.isomer.gov.sg/"
```

As a result, we are introducing an ebextension which increases the max body size (`client_max_body_size`) to `10mb` (a slight increase over the `7mb` limit we set for express, since we want to be conservative and allow for additional overhead).

Finally, the ebextension file includes a command to reload the nginx service so that the new configs are used.
