### PR TITLE
fix: prevent sending of client id/secret when using Github APIs

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -39,7 +39,6 @@ async function githubAuth (req, res, next) {
   const endpoint = `https://api.github.com/user`
   const userResp = await axios.get(endpoint, {
     validateStatus,
-    params,
     headers: {
       Authorization: `token ${access_token}`,
       Accept: 'application/vnd.github.v3+json',


### PR DESCRIPTION
GitHub has deprecated the use of authentication via URL query params, but there is still one part of the codebase where we do that - when we retrieve user details via the following endpoint: `https://api.github.com/user`

This was the email from GitHub:
```
On February 2nd, 2021 at 07:50 (UTC) your application (IsomerCMS Local Dev) used its `client_id` and `client_secret` (with the User-Agent axios/0.19.0) as part of a set of query parameters to access an endpoint through the GitHub API:

https://api.github.com/user

Please use Basic Authentication instead as using OAuth credentials in query parameters has been deprecated.
```

This commit fixes that by removing the unnecessary query params that we currently attach to the request object.