### PR TITLE
Feat/get all collections directories

### DIFF
--- a/classes/Directory.js
+++ b/classes/Directory.js
@@ -98,6 +98,16 @@ class Directory {
   }
 }
 
+class RootType {
+  constructor() {
+    this.folderName = ''
+  }
+
+  getFolderName() {
+    return this.folderName
+  }
+}
+
 class FolderType {
   constructor(folderPath) {
     this.folderName = folderPath
@@ -118,4 +128,9 @@ class ResourceRoomType {
   }
 }
 
-module.exports = { Directory, FolderType, ResourceRoomType }
+module.exports = {
+  Directory,
+  RootType,
+  FolderType,
+  ResourceRoomType,
+}

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -49,6 +49,7 @@ auth.post('/v1/sites/:siteName/homepage', verifyJwt)
 
 // Folder pages
 auth.get('/v1/sites/:siteName/folders', verifyJwt)
+auth.get('/v1/sites/:siteName/folders/all', verifyJwt)
 
 // Collection pages
 auth.get('/v1/sites/:siteName/collections/:collectionName', verifyJwt)

--- a/routes/folders.js
+++ b/routes/folders.js
@@ -1,11 +1,15 @@
 const express = require('express');
 const router = express.Router();
+const Bluebird = require('bluebird')
 
 // Import middleware
 const { attachReadRouteHandlerWrapper } = require('../middleware/routeHandler')
 
-// Import classes 
-const { Directory, FolderType } = require('../classes/Directory.js');
+// Import classes
+const { File, CollectionPageType } = require('../classes/File.js');
+const { Directory, RootType, FolderType } = require('../classes/Directory.js');
+
+const ISOMER_TEMPLATE_DIRS = ['_data', '_includes', '_site', '_layouts']
 
 // List pages and directories in folder
 async function listFolderContent (req, res, next) {
@@ -20,6 +24,37 @@ async function listFolderContent (req, res, next) {
     res.status(200).json({ folderPages })
 }
 
-router.get('/:siteName/folders', attachReadRouteHandlerWrapper(listFolderContent))
+// List pages and directories from all folders
+async function listAllFolderContent (req, res, next) {
+    const { accessToken } = req
+    const { siteName } = req.params
+
+    const IsomerDirectory = new Directory(accessToken, siteName)
+    const folderType = new RootType()
+    IsomerDirectory.setDirType(folderType)
+    const repoRootContent = await IsomerDirectory.list()
+
+    const allFolders = repoRootContent.reduce((acc, curr) => {
+        if (
+            curr.type === 'dir'
+            && !ISOMER_TEMPLATE_DIRS.includes(curr.name)
+            && curr.name.slice(0, 1) === '_'
+        ) acc.push(curr.path)
+        return acc
+    }, [])
+
+    const allFolderContent = await Bluebird.map(allFolders, async (folder) => {
+        const IsomerFile = new File(accessToken, siteName)
+        const collectionPageType = new CollectionPageType(folder.slice(1))
+        IsomerFile.setFileType(collectionPageType)
+        const { sha, content } = await IsomerFile.read('collection.yml')
+        return { name: folder, sha, content }
+    })
+
+    res.status(200).json({ allFolderContent })
+}
+
+router.get('/:siteName/folders', attachRouteHandlerWrapper(listFolderContent))
+router.get('/:siteName/folders/all', attachRouteHandlerWrapper(listAllFolderContent))
 
 module.exports = router;

--- a/routes/folders.js
+++ b/routes/folders.js
@@ -48,7 +48,7 @@ async function listAllFolderContent (req, res, next) {
         const collectionPageType = new CollectionPageType(folder.slice(1))
         IsomerFile.setFileType(collectionPageType)
         const { sha, content } = await IsomerFile.read('collection.yml')
-        return { name: folder, sha, content }
+        return { name: folder.slice(1), sha, content }
     })
 
     res.status(200).json({ allFolderContent })


### PR DESCRIPTION
## Overview

Note: this PR is to be reviewed in conjunction with PR #[362](https://github.com/isomerpages/isomercms-frontend/pull/362) on the frontend. 

It adds a new GET `/:siteName/folders/all` endpoint which returns the `collection.yml` directory config file for all collections/folders in the requested repo.