### PR TITLE
fix: unlock site after successful API call for rollback route handler

### DIFF
--- a/middleware/routeHandler.js
+++ b/middleware/routeHandler.js
@@ -45,6 +45,8 @@ const attachRollbackRouteHandlerWrapper = (routeHandler) => async (req, res, nex
     await unlock(siteName)
     next(err)
   })
+
+  await unlock(siteName)
 }
   
 module.exports = {


### PR DESCRIPTION
@gweiying pointed out a bug in the transaction lock feature as well as a fix for it.

The bug was that a successful API call that used the rollback route handler did not unlock the repo because the handler was missing an `await unlock()` call after success.