### PR TITLE
Feat/move files

### DIFF
--- a/classes/Collection.js
+++ b/classes/Collection.js
@@ -6,10 +6,12 @@ const _ = require('lodash')
 const { CollectionConfig } = require('./Config.js')
 const { File, CollectionPageType, DataType } = require('./File.js')
 const { Directory, RootType } = require('./Directory.js')
+const { ConflictError, protectedFolderConflictErrorMsg } = require('../errors/ConflictError')
 const { getCommitAndTreeSha, getTree, sendTree, deslugifyCollectionName } = require('../utils/utils.js')
 
 const NAV_FILE_NAME = 'navigation.yml'
 const ISOMER_TEMPLATE_DIRS = ['_data', '_includes', '_site', '_layouts']
+const ISOMER_TEMPLATE_PROTECTED_DIRS = ['data', 'includes', 'site', 'layouts', 'files', 'images', 'misc', 'pages']
 
 class Collection {
   constructor(accessToken, siteName) {
@@ -45,6 +47,7 @@ class Collection {
           },
         }
       }
+      if (ISOMER_TEMPLATE_PROTECTED_DIRS.includes(collectionName)) throw new ConflictError(protectedFolderConflictErrorMsg(collectionName))
       const newContent = base64.encode(yaml.safeDump(contentObject))
       await collectionConfig.create(newContent)
 

--- a/classes/Config.js
+++ b/classes/Config.js
@@ -8,7 +8,8 @@ const _ = require('lodash')
 const logger = require('../logger/logger');
 
 // Import error
-const { NotFoundError  } = require('../errors/NotFoundError')
+const { NotFoundError } = require('../errors/NotFoundError')
+const { ConflictError, inputNameConflictErrorMsg } = require('../errors/ConflictError')
 
 const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
 const BRANCH_REF = process.env.BRANCH_REF

--- a/classes/Config.js
+++ b/classes/Config.js
@@ -17,29 +17,29 @@ class Config {
   constructor(accessToken, siteName) {
     this.accessToken = accessToken
     this.siteName = siteName
-	this.endpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${this.siteName}/contents/_config.yml`
+    this.endpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${this.siteName}/contents/_config.yml`
   }
 
   async read() {
     try {
-		const params = {
-			"ref": BRANCH_REF,
-		}
-			
-	    const resp = await axios.get(this.endpoint, {
-			validateStatus,
-			params,
-			headers: {
-				Authorization: `token ${this.accessToken}`,
-				"Content-Type": "application/json"
-			}
-	    })
+    const params = {
+      "ref": BRANCH_REF,
+    }
+      
+      const resp = await axios.get(this.endpoint, {
+      validateStatus,
+      params,
+      headers: {
+        Authorization: `token ${this.accessToken}`,
+        "Content-Type": "application/json"
+      }
+      })
 
-	    if (resp.status === 404) throw new NotFoundError ('Config page does not exist')
+      if (resp.status === 404) throw new NotFoundError ('Config page does not exist')
 
-	    const { content, sha } = resp.data
+      const { content, sha } = resp.data
 
-	    return { content, sha }
+      return { content, sha }
 
     } catch (err) {
       throw err
@@ -47,112 +47,109 @@ class Config {
   }
 
   async update(newContent, sha) {
-	const params = {
-		"message": 'Edit config',
-		"content": newContent,
-		"branch": BRANCH_REF,
-		"sha": sha
-	}
+    const params = {
+      "message": 'Edit config',
+      "content": newContent,
+      "branch": BRANCH_REF,
+      "sha": sha
+    }
 
-	await axios.put(this.endpoint, params, {
-		headers: {
-			Authorization: `token ${this.accessToken}`,
-			"Content-Type": "application/json"
-		}
-	})
+    await axios.put(this.endpoint, params, {
+      headers: {
+        Authorization: `token ${this.accessToken}`,
+        "Content-Type": "application/json"
+      }
+    })
   }
 }
 
 class CollectionConfig extends Config {
-	constructor(accessToken, siteName, collectionName) {
-		super(accessToken, siteName)
-		this.collectionName = collectionName
-		this.endpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${siteName}/contents/_${collectionName}/collection.yml`
-	}
+  constructor(accessToken, siteName, collectionName) {
+    super(accessToken, siteName)
+    this.collectionName = collectionName
+    this.endpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${siteName}/contents/_${collectionName}/collection.yml`
+  }
 
-	async create(content) {
-      try {
-		const params = {
-		  "message": `Create file: _${this.collectionName}/collection.yml`,
-		  "content": content,
-		  "branch": BRANCH_REF,	
-		}
-		
-		const resp = await axios.put(this.endpoint, params, {
-	      headers: {
-		    Authorization: `token ${this.accessToken}`,
-			"Content-Type": "application/json"
-		  }
-		})
-	
-		return { sha: resp.data.content.sha }
-	  } catch (err) {
-        const { status } = err.response
-        if (status === 422 || status === 409) throw new ConflictError(inputNameConflictErrorMsg(fileName))
-        throw err.response
+  async create(content) {
+    try {
+      const params = {
+        "message": `Create file: _${this.collectionName}/collection.yml`,
+        "content": content,
+        "branch": BRANCH_REF,	
       }
-    }
-	
-
-    async delete (sha) {
-      try {
-        const params = {
-          "message": `Delete file: _${this.collectionName}/collection.yml`,
-          "branch": BRANCH_REF,
-          "sha": sha
-        }
-    
-        await axios.delete(this.endpoint, {
-          params,
+      
+      const resp = await axios.put(this.endpoint, params, {
           headers: {
-            Authorization: `token ${this.accessToken}`,
-            "Content-Type": "application/json"
-          }
-        })
-      } catch (err) {
-        const status = err.response.status
-        if (status === 404) throw new NotFoundError ('File does not exist')
-        throw err
-      }
+          Authorization: `token ${this.accessToken}`,
+        "Content-Type": "application/json"
+        }
+      })
+    
+      return { sha: resp.data.content.sha }
+    } catch (err) {
+      const { status } = err.response
+      if (status === 422 || status === 409) throw new ConflictError(inputNameConflictErrorMsg(fileName))
+      throw err.response
     }
+  }
+  
+  async delete (sha) {
+    try {
+      const params = {
+        "message": `Delete file: _${this.collectionName}/collection.yml`,
+        "branch": BRANCH_REF,
+        "sha": sha
+      }
+  
+      await axios.delete(this.endpoint, {
+        params,
+        headers: {
+          Authorization: `token ${this.accessToken}`,
+          "Content-Type": "application/json"
+        }
+      })
+    } catch (err) {
+      const status = err.response.status
+      if (status === 404) throw new NotFoundError ('File does not exist')
+      throw err
+    }
+  }
 
-	async addItemToOrder(item) {
-		const collectionName = this.collectionName
-		
-		const { content, sha } = await this.read()
-		const contentObject = yaml.safeLoad(base64.decode(content))
-		
-		let index
-		if (item.split('/').length === 2) {
-			// if file in subfolder, get index of last file in subfolder
-			index = _.findLastIndex(
-				contentObject.collections[collectionName].order, 
-				(f) => f.split('/')[0] === item.split('/')[0]
-			) + 1
-		} else {
-			// get index of last file in collection
-			index = contentObject.collections[collectionName].order.length
-		}
-		contentObject.collections[collectionName].order.splice(index, 0, item)
-		const newContent = base64.encode(yaml.safeDump(contentObject))
-		
-		await this.update(newContent, sha)
-	}
+  async addItemToOrder(item) {
+    const collectionName = this.collectionName
+    
+    const { content, sha } = await this.read()
+    const contentObject = yaml.safeLoad(base64.decode(content))
+    
+    let index
+    if (item.split('/').length === 2) {
+      // if file in subfolder, get index of last file in subfolder
+      index = _.findLastIndex(
+        contentObject.collections[collectionName].order, 
+        (f) => f.split('/')[0] === item.split('/')[0]
+      ) + 1
+    } else {
+      // get index of last file in collection
+      index = contentObject.collections[collectionName].order.length
+    }
+    contentObject.collections[collectionName].order.splice(index, 0, item)
+    const newContent = base64.encode(yaml.safeDump(contentObject))
+    
+    await this.update(newContent, sha)
+  }
 
-	async deleteItemFromOrder(item) {
-		const collectionName = this.collectionName
+  async deleteItemFromOrder(item) {
+    const collectionName = this.collectionName
 
-		const { content, sha } = await this.read()
-		const contentObject = yaml.safeLoad(base64.decode(content))
-		
-		const index = contentObject.collections[collectionName].order.indexOf(item);
-		contentObject.collections[collectionName].order.splice(index, 1)
-		const newContent = base64.encode(yaml.safeDump(contentObject))
-		
-		await this.update(newContent, sha)
-	}
+    const { content, sha } = await this.read()
+    const contentObject = yaml.safeLoad(base64.decode(content))
+    
+    const index = contentObject.collections[collectionName].order.indexOf(item);
+    contentObject.collections[collectionName].order.splice(index, 1)
+    const newContent = base64.encode(yaml.safeDump(contentObject))
+    
+    await this.update(newContent, sha)
+  }
 }
-
-
 
 module.exports = { Config, CollectionConfig }

--- a/errors/ConflictError.js
+++ b/errors/ConflictError.js
@@ -3,6 +3,8 @@ const { BaseIsomerError } = require('./BaseError')
 
 const inputNameConflictErrorMsg = (fileName) => `A file with ${fileName} already exists.`
 
+const protectedFolderConflictErrorMsg = (folderName) => `${folderName} is a protected folder name.`
+
 class ConflictError extends BaseIsomerError {
   constructor (message) {
     super(
@@ -14,4 +16,5 @@ class ConflictError extends BaseIsomerError {
 module.exports = {
   ConflictError,
   inputNameConflictErrorMsg,
+  protectedFolderConflictErrorMsg,
 }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -67,6 +67,7 @@ auth.get('/v1/sites/:siteName/collections', verifyJwt)
 auth.post('/v1/sites/:siteName/collections', verifyJwt)
 auth.delete('/v1/sites/:siteName/collections/:collectionName', verifyJwt)
 auth.post('/v1/sites/:siteName/collections/:collectionName/rename/:newCollectionName', verifyJwt)
+auth.post('/v1/sites/:siteName/collections/:collectionPath/move/:targetPath', verifyJwt)
 
 // Documents
 auth.get('/v1/sites/:siteName/documents', verifyJwt)
@@ -100,6 +101,7 @@ auth.get('/v1/sites/:siteName/pages/:pageName', verifyJwt)
 auth.post('/v1/sites/:siteName/pages/:pageName', verifyJwt)
 auth.delete('/v1/sites/:siteName/pages/:pageName', verifyJwt)
 auth.post('/v1/sites/:siteName/pages/:pageName/rename/:newPageName', verifyJwt)
+auth.post('/v1/sites/:siteName/pages/move/:newPagePath', verifyJwt)
 
 // Resource pages
 auth.get('/v1/sites/:siteName/resources/:resourceName', verifyJwt)

--- a/routes/collections.js
+++ b/routes/collections.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const Bluebird = require('bluebird')
+const yaml = require('js-yaml');
+const base64 = require('base-64');
 
 // Import middleware
 const { 
@@ -12,6 +14,8 @@ const {
 const { Collection } = require('../classes/Collection.js');
 const { CollectionConfig } = require('../classes/Config.js');
 const { File, CollectionPageType, PageType } = require('../classes/File');
+
+const { deslugifyCollectionName } = require('../utils/utils')
 
 // List collections
 async function listCollections (req, res, next) {
@@ -97,7 +101,18 @@ async function moveFiles (req, res, next) {
   for (const fileName of files) {
     const { content, sha } = await oldIsomerFile.read(fileName)
     await oldIsomerFile.delete(fileName, sha)
-    await newIsomerFile.create(fileName, content)
+    if (targetSubfolderName || collectionSubfolderName) {
+      // Modifying third nav in front matter, to be removed after template rewrite
+      const frontMatter = yaml.safeLoad(base64.decode(content).split('---')[1])
+      if (targetSubfolderName) frontMatter.third_nav_title = deslugifyCollectionName(targetSubfolderName)
+      else delete frontMatter.third_nav_title
+      const newFrontMatter = yaml.safeDump(frontMatter)
+      const newContent = ['---\n', newFrontMatter, '---'].join('')
+      const newEncodedContent = base64.encode(newContent)
+      await newIsomerFile.create(fileName, newEncodedContent)
+    } else {
+      await newIsomerFile.create(fileName, content)
+    }
 
     // Update collection.yml files
     await oldConfig.deleteItemFromOrder(`${collectionSubfolderName ? `${collectionSubfolderName}/` : ''}${fileName}`)

--- a/routes/collections.js
+++ b/routes/collections.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+const Bluebird = require('bluebird')
 
 // Import middleware
 const { 
@@ -8,7 +9,9 @@ const {
 } = require('../middleware/routeHandler')
 
 // Import classes 
-const { Collection } = require('../classes/Collection.js')
+const { Collection } = require('../classes/Collection.js');
+const { CollectionConfig } = require('../classes/Config.js');
+const { File, CollectionPageType, PageType } = require('../classes/File');
 
 // List collections
 async function listCollections (req, res, next) {
@@ -61,9 +64,54 @@ async function renameCollection (req, res, next) {
   res.status(200).json({ collectionName, newCollectionName })
 }
 
+// Move files in collection
+async function moveFiles (req, res, next) {
+  const { accessToken } = req
+  const { siteName, collectionPath, targetPath } = req.params
+  const { files } = req.body
+  const processedCollectionPathTokens = decodeURIComponent(collectionPath).split('/')
+  const collectionName = processedCollectionPathTokens[0]
+  const collectionSubfolderName = processedCollectionPathTokens[1]
+  const processedTargetPathTokens = decodeURIComponent(targetPath).split('/')
+  const targetCollectionName = processedTargetPathTokens[0]
+  const targetSubfolderName = processedTargetPathTokens[1]
+
+  const IsomerCollection = new Collection(accessToken, siteName)
+  const collections = await IsomerCollection.list()
+
+  // Check if collection already exists
+  if (!collections.includes(targetCollectionName) && targetCollectionName !== 'pages') {
+    await IsomerCollection.create(targetCollectionName)
+  }
+
+  const oldIsomerFile = new File(accessToken, siteName)
+  const newIsomerFile = new File(accessToken, siteName)
+  const oldCollectionPageType = new CollectionPageType(decodeURIComponent(collectionPath))
+  const newCollectionPageType = targetCollectionName === 'pages' ? new PageType() : new CollectionPageType(decodeURIComponent(targetPath))
+  oldIsomerFile.setFileType(oldCollectionPageType)
+  newIsomerFile.setFileType(newCollectionPageType)
+  const oldConfig = new CollectionConfig(accessToken, siteName, collectionName)
+  const newConfig = targetCollectionName === 'pages' ? null : new CollectionConfig(accessToken, siteName, targetCollectionName)
+
+  // We can't perform these operations concurrently because of conflict issues
+  for (const fileName of files) {
+    const { content, sha } = await oldIsomerFile.read(fileName)
+    await oldIsomerFile.delete(fileName, sha)
+    await newIsomerFile.create(fileName, content)
+
+    // Update collection.yml files
+    await oldConfig.deleteItemFromOrder(`${collectionSubfolderName ? `${collectionSubfolderName}/` : ''}${fileName}`)
+    if (newConfig) await newConfig.addItemToOrder(`${targetSubfolderName ? `${targetSubfolderName}/` : ''}${fileName}`)
+  }
+
+  res.status(200).send('OK')
+}
+
+
 router.get('/:siteName/collections', attachReadRouteHandlerWrapper(listCollections))
 router.post('/:siteName/collections', attachRollbackRouteHandlerWrapper(createNewCollection))
 router.delete('/:siteName/collections/:collectionName', attachRollbackRouteHandlerWrapper(deleteCollection))
 router.post('/:siteName/collections/:collectionName/rename/:newCollectionName', attachRollbackRouteHandlerWrapper(renameCollection))
+router.post('/:siteName/collections/:collectionPath/move/:targetPath', attachRollbackRouteHandlerWrapper(moveFiles))
 
 module.exports = router;

--- a/routes/folders.js
+++ b/routes/folders.js
@@ -7,7 +7,8 @@ const { attachReadRouteHandlerWrapper } = require('../middleware/routeHandler')
 
 // Import classes
 const { CollectionConfig } = require('../classes/Config')
-const { Directory, RootType } = require('../classes/Directory.js');
+const { Directory, FolderType, RootType } = require('../classes/Directory.js');
+const { Collection } = require('../classes/Collection');
 
 const ISOMER_TEMPLATE_DIRS = ['_data', '_includes', '_site', '_layouts']
 
@@ -16,22 +17,10 @@ async function listAllFolderContent (req, res, next) {
     const { accessToken } = req
     const { siteName } = req.params
 
-    const IsomerDirectory = new Directory(accessToken, siteName)
-    const folderType = new RootType()
-    IsomerDirectory.setDirType(folderType)
-    const repoRootContent = await IsomerDirectory.list()
+    const IsomerCollection = new Collection(accessToken, siteName)
+    const allFolders = IsomerCollection.list()
 
-    const allFolders = repoRootContent.reduce((acc, curr) => {
-        if (
-            curr.type === 'dir'
-            && !ISOMER_TEMPLATE_DIRS.includes(curr.name)
-            && curr.name.slice(0, 1) === '_'
-        ) acc.push(curr.path)
-        return acc
-    }, [])
-
-    const allFolderContent = await Bluebird.map(allFolders, async (folder) => {
-        const collectionName = folder.slice(1)
+    const allFolderContent = await Bluebird.map(allFolders, async (collectionName) => {
         const config = new CollectionConfig(accessToken, siteName, collectionName)
         const { sha, content } = await config.read()
         return { name: collectionName, sha, content }

--- a/routes/folders.js
+++ b/routes/folders.js
@@ -7,7 +7,6 @@ const { attachReadRouteHandlerWrapper } = require('../middleware/routeHandler')
 
 // Import classes
 const { CollectionConfig } = require('../classes/Config')
-const { Directory, FolderType, RootType } = require('../classes/Directory.js');
 const { Collection } = require('../classes/Collection');
 
 const ISOMER_TEMPLATE_DIRS = ['_data', '_includes', '_site', '_layouts']


### PR DESCRIPTION
This PR introduces new endpoints to handle the moving of multiple files from one folder to another. To be reviewed in conjunction with PR #[369](https://github.com/isomerpages/isomercms-frontend/pull/369) on the isomercms-frontend repo.

In addition, this PR also updates the existing list() method of collections to work with both the existing format as well as the file format post jekyll 4.0 update.

Resolves issues https://github.com/isomerpages/isomercms-backend/issues/116 and https://github.com/isomerpages/isomercms-backend/issues/120