### PR TITLE
fix: throw NotFoundError if given path cannot be found on GitHub

### DIFF
--- a/classes/Directory.js
+++ b/classes/Directory.js
@@ -2,7 +2,8 @@ const axios = require('axios');
 const _ = require('lodash')
 const validateStatus = require('../utils/axios-utils')
 
-const { BadRequestError } = require('../errors/BadRequestError')
+const { BadRequestError } = require('../errors/BadRequestError');
+const { NotFoundError } = require('../errors/NotFoundError');
 
 const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
 const BRANCH_REF = process.env.BRANCH_REF
@@ -40,7 +41,10 @@ class Directory {
 
   
       if (resp.status !== 200) {
-        if (this.dirType instanceof FolderType) throw new BadRequestError(`Path ${this.dirType.getFolderName()} was invalid!`)
+        if (this.dirType instanceof FolderType) {
+          if (resp.status === 404) throw new NotFoundError(`Path ${this.dirType.getFolderName()} was not found!`)
+          throw new BadRequestError(`Path ${this.dirType.getFolderName()} was invalid!`)
+        }
         return {}
       }
 


### PR DESCRIPTION
## Overview

This PR fixes a minor bug in the `Directory` class' `list` method. When the path that we attempt to read from in the GET `/:siteName/files/:path` endpoint does not actually exist on GitHub, we currently throw a `400` error. Instead, we should be re-throwing the `404` error that GitHub responds with.