### PR TITLE
Feat: read from nested files and update page endpoints for nested files

### DIFF
--- a/classes/File.js
+++ b/classes/File.js
@@ -87,11 +87,7 @@ class File {
 
   async read(fileName) {
     try {
-      const files = await this.list()
-      if (_.isEmpty(files)) throw new NotFoundError ('File does not exist')
-      const fileToRead = files.filter((file) => file.fileName === fileName)[0]
-      if (fileToRead === undefined) throw new NotFoundError ('File does not exist')
-      const endpoint = `${this.baseBlobEndpoint}/${fileToRead.sha}`
+      const endpoint = `${this.baseEndpoint}/${fileName}`
 
       const params = {
         "ref": BRANCH_REF,
@@ -105,6 +101,7 @@ class File {
           "Content-Type": "application/json"
         }
       })
+      if (resp.status === 404) throw new NotFoundError ('File does not exist')
 
       const { content, sha } = resp.data
   

--- a/routes/collectionPages.js
+++ b/routes/collectionPages.js
@@ -147,7 +147,8 @@ async function createCollectionPage (req, res, next) {
 async function readCollectionPage(req, res, next) {
   const { accessToken } = req
 
-  const { siteName, pageName, collectionName } = req.params
+  const { siteName, pageName: encodedPageName, collectionName } = req.params
+  const pageName = decodeURIComponent(encodedPageName)
 
   const IsomerFile = new File(accessToken, siteName)
   const collectionPageType = new CollectionPageType(collectionName)
@@ -164,8 +165,11 @@ async function readCollectionPage(req, res, next) {
 async function updateCollectionPage (req, res, next) {
   const { accessToken } = req
 
-  const { siteName, pageName, collectionName } = req.params
-  const { content, sha } = req.body
+  const { siteName, pageName: encodedPageName, collectionName } = req.params
+  const { content: unencodedContent, sha } = req.body
+  const pageName = decodeURIComponent(encodedPageName)
+  
+  const content = base64.encode(unencodedContent)
 
   // TO-DO:
   // Validate pageName and content
@@ -182,9 +186,9 @@ async function updateCollectionPage (req, res, next) {
 async function deleteCollectionPage (req, res, next) {
   const { accessToken } = req
 
-  const { siteName, pageName, collectionName } = req.params
+  const { siteName, pageName: encodedPageName, collectionName } = req.params
   const { sha } = req.body
-
+  const pageName = decodeURIComponent(encodedPageName)
   // TO-DO:
   // Validate that collection exists
 
@@ -207,8 +211,9 @@ async function deleteCollectionPage (req, res, next) {
 async function renameCollectionPage (req, res, next) {
   const { accessToken } = req
 
-  const { siteName, pageName, collectionName, newPageName } = req.params
+  const { siteName, pageName: encodedPageName, collectionName, newPageName } = req.params
   const { sha, content } = req.body
+  const pageName = decodeURIComponent(encodedPageName)
 
   // TO-DO:
   // Validate that collection exists

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -118,7 +118,8 @@ async function updatePage(req, res, next) {
   const { accessToken } = req
 
   const { siteName, pageName } = req.params
-  const { content, sha } = req.body
+  const { content: unencodedContent, sha } = req.body
+  const content = base64.encode(unencodedContent)
 
   // TO-DO:
   // Validate pageName and content


### PR DESCRIPTION
This PR is to be reviewed together with PR #[379](https://github.com/isomerpages/isomercms-frontend/pull/379) on the isomercms-frontend repo. It accomplishes several things:

- It fixes an existing issue when attempting to read nested files. The previous endpoint being used required the requested file to be in the first level of the folder provided. Instead we now attempt to retrieve the file and throw a NotFoundError if we receive a 404 status.
- It also changes the existing page and collectionPage endpoints for updating pages to receive unencoded content, and handle the encoding here in the backend rather than the frontend.
- The collectionPage endpoints have also been updated to expect an encodedURIComponent for the pageName, to account for subfolder pages.