### PR TITLE
Fix/delete collection conflict

### DIFF
--- a/classes/Collection.js
+++ b/classes/Collection.js
@@ -70,12 +70,14 @@ class Collection {
     }
   }
 
-  async delete(collectionName) {
+  async delete(collectionName, currentCommitSha, treeSha) {
     try {
-      // Delete collection config
-      const collectionConfig = new CollectionConfig(this.accessToken, this.siteName, collectionName)
-      const { sha } = await collectionConfig.read()
-      await collectionConfig.delete(sha)
+      const commitMessage = `Delete collection ${collectionName}`
+      const gitTree = await getTree(this.siteName, this.accessToken, treeSha)
+      const newGitTree = gitTree.filter(item => {
+        if (item.path !== `_${collectionName}`) return item
+      })
+      await sendTree(newGitTree, currentCommitSha, this.siteName, this.accessToken, commitMessage)
 
       // Delete collection in nav if it exists
       const nav = new File(this.accessToken, this.siteName)
@@ -91,21 +93,6 @@ class Collection {
       }
       const newNavContent = base64.encode(yaml.safeDump(newNavContentObject))
       await nav.update(NAV_FILE_NAME, newNavContent, navSha)
-
-      // Get all collectionPages
-      const IsomerFile = new File(this.accessToken, this.siteName)
-      const collectionPageType = new CollectionPageType(collectionName)
-      IsomerFile.setFileType(collectionPageType)
-      const collectionPages = await IsomerFile.list()
-
-      if (!_.isEmpty(collectionPages)) {
-        // Delete all collectionPages
-        await Bluebird.map(collectionPages, async(collectionPage) => {
-          let pageName = collectionPage.fileName
-          const { sha } = await IsomerFile.read(pageName)
-          return IsomerFile.delete(pageName, sha)
-        })
-      }
     } catch (err) {
       throw err
     }

--- a/classes/Collection.js
+++ b/classes/Collection.js
@@ -111,7 +111,7 @@ class Collection {
     }
   }
 
-  async rename(oldCollectionName, newCollectionName) {
+  async rename(oldCollectionName, newCollectionName, currentCommitSha, treeSha) {
     try {
       const commitMessage = `Rename collection from ${oldCollectionName} to ${newCollectionName}`
 
@@ -139,7 +139,6 @@ class Collection {
       const newNavContent = base64.encode(yaml.safeDump(newNavContentObject))
       await nav.update(NAV_FILE_NAME, newNavContent, navSha)
 
-      const { currentCommitSha, treeSha } = await getCommitAndTreeSha(this.siteName, this.accessToken)
       const gitTree = await getTree(this.siteName, this.accessToken, treeSha);
       const oldCollectionDirectoryName = `_${oldCollectionName}`
       const newCollectionDirectoryName = `_${newCollectionName}`

--- a/middleware/routeHandler.js
+++ b/middleware/routeHandler.js
@@ -29,7 +29,11 @@ const attachRollbackRouteHandlerWrapper = (routeHandler) => async (req, res, nex
 
   let originalCommitSha
   try {
-    const { currentCommitSha } = await getCommitAndTreeSha(siteName, accessToken)
+    const { currentCommitSha, treeSha } = await getCommitAndTreeSha(siteName, accessToken)
+
+    req.currentCommitSha = currentCommitSha
+    req.treeSha = treeSha
+
     originalCommitSha = currentCommitSha
   } catch (err) {
     await unlock(siteName)

--- a/routes/collectionPages.js
+++ b/routes/collectionPages.js
@@ -180,7 +180,7 @@ async function updateCollectionPage (req, res, next) {
 
 // Delete page in collection
 async function deleteCollectionPage (req, res, next) {
-  const { accessToken } = req
+  const { accessToken, currentCommitSha, treeSha } = req
 
   const { siteName, pageName, collectionName } = req.params
   const { sha } = req.body
@@ -195,9 +195,9 @@ async function deleteCollectionPage (req, res, next) {
 
   // Check if collection has any pages left, and delete if none left
   const collectionPages = await IsomerFile.list()
-  if (_.isEmpty(collectionPages)) {
+  if (collectionPages.length === 1 && collectionPages[0].fileName === 'collection.yml') {
     const IsomerCollection = new Collection(accessToken, siteName)
-    await IsomerCollection.delete(collectionName)
+    await IsomerCollection.delete(collectionName, currentCommitSha, treeSha)
   }
 
   res.status(200).send('OK')

--- a/routes/collections.js
+++ b/routes/collections.js
@@ -59,11 +59,11 @@ async function renameCollection (req, res, next) {
   // TO-DO: Verify that collection exists
 
   // Remove collection from config file
-  const { accessToken } = req
+  const { accessToken, currentCommitSha, treeSha } = req
   const { siteName, collectionName, newCollectionName } = req.params
 
   const IsomerCollection = new Collection(accessToken, siteName)
-  await IsomerCollection.rename(collectionName, newCollectionName)
+  await IsomerCollection.rename(collectionName, newCollectionName, currentCommitSha, treeSha)
 
   res.status(200).json({ collectionName, newCollectionName })
 }

--- a/routes/collections.js
+++ b/routes/collections.js
@@ -45,11 +45,11 @@ async function deleteCollection (req, res, next) {
   // TO-DO: Verify that collection exists
 
   // Remove collection from config file
-  const { accessToken } = req
+  const { accessToken, currentCommitSha, treeSha } = req
   const { siteName, collectionName } = req.params
 
   const IsomerCollection = new Collection(accessToken, siteName)
-  await IsomerCollection.delete(collectionName)
+  await IsomerCollection.delete(collectionName, currentCommitSha, treeSha)
 
   res.status(200).json({ collectionName })
 }


### PR DESCRIPTION
## Overview

Currently, when we attempt to delete an entire collection/folder using the `delete` method in the `Collection` class, the operation fails and GitHub returns a `409` error response when attempting to delete the files from the collection/folder. This PR fixes the `Collection` class' `delete` method by using updating the root Git trees to delete the entire collection/folder instead of deleting pages one-by-one.

Other changes introduced in this PR:
-  Refactor the `rename` method of the `Collection` class to reuse the `currentCommitSha` and `treeSha` obtained
when using the `attachRollbackRouteHandlerWrapper` function

### Explaining the `409` error response from GitHub

The source of the `409` error responses lies in our attempt to delete files from the collection/folder **concurrently** - when we use `Bluebird.each` instead of `Bluebird.map`, the deletion goes through with no issues. To explain why concurrent deletion is a problem, we need to understand the mechanism for file deletion on Git. 

When a file is deleted from a directory, a new tree object (sans the deleted file) is created, along with a new tree SHA. The parent tree then updates its records for the directory to point away from the existing tree SHA to this new tree SHA. The conflict arises because when we try to delete files concurrently because the outcome, or the resulting tree SHA of the directory, after each of the delete operations is different. Consider the following example:

```
base commit: abcde
- example_directory (tree SHA: 12345)
     - example_page_1
     - example_page_2

directory tree SHA after deleting example_page_1:
base commit: bcdef
- example_directory (tree SHA: 23456)
     - example_page_2

directory tree SHA after deleting example_page_2:
base commit: cdefg
- example_directory (tree SHA: 34567)
     - example_page_1
```

Here, we try to delete both `example_page_1` and `example_page_2` at the same time. The problem is that both deletion operations start from the same base commit, but produce conflicting Git trees. If the deletion of `example_page_1` goes through first, the base commit moves from `abcde` to `bcdef`. But when the deletion of `example_page_2` goes through, we can't go from the new base commit `bcdef` to `cdefg`, because the parent commit of `cdefg` is `abcde`.