### PR TITLE
Fix/collectionconfig read method

### DIFF
--- a/classes/Collection.js
+++ b/classes/Collection.js
@@ -143,8 +143,7 @@ class Collection {
 
       // Update collection.yml in newCollection with newCollection name
       const collectionConfig = new CollectionConfig(this.accessToken, this.siteName, newCollectionName)
-      const { content: configContent, sha: configSha } = await collectionConfig.read()
-      const configContentObject = yaml.safeLoad(base64.decode(configContent))
+      const { content: configContentObject, sha: configSha } = await collectionConfig.read()
       const newConfigContentObject = {
         collections: {
           [newCollectionName]: configContentObject.collections[oldCollectionName]

--- a/classes/Config.js
+++ b/classes/Config.js
@@ -116,7 +116,7 @@ class CollectionConfig extends Config {
   async read() {
     const { content, sha } = await super.read()
     const contentObject = yaml.safeLoad(base64.decode(content))
-    return { contentObject, sha }
+    return { content: contentObject, sha }
   }
 
   async addItemToOrder(item, index) {


### PR DESCRIPTION
This PR fixes a minor bug introduced in PR #133. 

The `Config` class' `read` method used to return an object with attributes `content` and `sha`, but with PR #133, the `CollectionConfig` class had a new `read` method which overrode the parent class' read method - this new `read` method returns an object with attributes `contentObject` and `sha`. 

This API change breaks the codebase in two parts:
1. `Collection` class' `rename` method which attempts to extract `content` after reading the `CollectionConfig`
2. `listAllFolderContent` route function, which does the same

The proposed fix is to return a `content` attribute instead of `contentObject` attribute in the `read` method of `CollectionConfig`