### PR TITLE
fix/CollectionConfig `read` method output

### DIFF
--- a/classes/Config.js
+++ b/classes/Config.js
@@ -121,33 +121,33 @@ class CollectionConfig extends Config {
 
   async addItemToOrder(item, index) {
     const collectionName = this.collectionName
-    const { contentObject, sha } = await this.read()
+    const { content, sha } = await this.read()
 
     if (index === undefined) {
       let index
       if (item.split('/').length === 2) {
         // if file in subfolder, get index of last file in subfolder
         index = _.findLastIndex(
-          contentObject.collections[collectionName].order, 
+          content.collections[collectionName].order,
           (f) => f.split('/')[0] === item.split('/')[0]
         ) + 1
       } else {
         // get index of last file in collection
-        index = contentObject.collections[collectionName].order.length
+        index = content.collections[collectionName].order.length
       }
     }
-    contentObject.collections[collectionName].order.splice(index, 0, item)
-    const newContent = base64.encode(yaml.safeDump(contentObject))
+    content.collections[collectionName].order.splice(index, 0, item)
+    const newContent = base64.encode(yaml.safeDump(content))
     
     await this.update(newContent, sha)
   }
 
   async deleteItemFromOrder(item) {
     const collectionName = this.collectionName
-    const { contentObject, sha } = await this.read()
-    const index = contentObject.collections[collectionName].order.indexOf(item)
-    contentObject.collections[collectionName].order.splice(index, 1)
-    const newContent = base64.encode(yaml.safeDump(contentObject))
+    const { content, sha } = await this.read()
+    const index = content.collections[collectionName].order.indexOf(item)
+    content.collections[collectionName].order.splice(index, 1)
+    const newContent = base64.encode(yaml.safeDump(content))
     
     await this.update(newContent, sha)
     return { index, item }
@@ -155,11 +155,11 @@ class CollectionConfig extends Config {
 
   async updateItemInOrder(oldItem, newItem) {
     const collectionName = this.collectionName
-    const { contentObject, sha } = await this.read()
-    const index = contentObject.collections[collectionName].order.indexOf(oldItem)
-    contentObject.collections[collectionName].order.splice(index, 1)
-    contentObject.collections[collectionName].order.splice(index, 0, newItem)
-    const newContent = base64.encode(yaml.safeDump(contentObject))
+    const { content, sha } = await this.read()
+    const index = content.collections[collectionName].order.indexOf(oldItem)
+    content.collections[collectionName].order.splice(index, 1)
+    content.collections[collectionName].order.splice(index, 0, newItem)
+    const newContent = base64.encode(yaml.safeDump(content))
     
     await this.update(newContent, sha)
   }


### PR DESCRIPTION
PR #134 missed out on instances which attempted to destructure `contentObject` from the `read` method of the `CollectionConfig`, when we've actually changed the method to return `content` attribute. This PR fixes that.