### PR TITLE
Feat/delete rename subfolder

### DIFF
--- a/classes/Config.js
+++ b/classes/Config.js
@@ -166,9 +166,9 @@ class CollectionConfig extends Config {
 
   async deleteSubfolderFromOrder(subfolder) {
     const collectionName = this.collectionName
-    const { contentObject, sha } = await this.read()
-    const filteredOrder = contentObject.collections[collectionName].order.filter(item => !item.includes(`${subfolder}/`))
-    const newContentObject = _.cloneDeep(contentObject)
+    const { content, sha } = await this.read()
+    const filteredOrder = content.collections[collectionName].order.filter(item => !item.includes(`${subfolder}/`))
+    const newContentObject = _.cloneDeep(content)
     newContentObject.collections[collectionName].order = filteredOrder
     const newContent = base64.encode(yaml.safeDump(newContentObject))
 
@@ -177,12 +177,12 @@ class CollectionConfig extends Config {
 
   async renameSubfolderInOrder(subfolder, newSubfolderName) {
     const collectionName = this.collectionName
-    const { contentObject, sha } = await this.read()
-    const renamedOrder = contentObject.collections[collectionName].order.map(item => {
+    const { content, sha } = await this.read()
+    const renamedOrder = content.collections[collectionName].order.map(item => {
       if (item.includes(`${subfolder}/`)) return `${newSubfolderName}/${item.split('/')[1]}`
       return item
     })
-    const newContentObject = _.cloneDeep(contentObject)
+    const newContentObject = _.cloneDeep(content)
     newContentObject.collections[collectionName].order = renamedOrder
     const newContent = base64.encode(yaml.safeDump(newContentObject))
 

--- a/classes/Config.js
+++ b/classes/Config.js
@@ -163,6 +163,17 @@ class CollectionConfig extends Config {
     
     await this.update(newContent, sha)
   }
+
+  async deleteSubfolderFromOrder(subfolder) {
+    const collectionName = this.collectionName
+    const { contentObject, sha } = await this.read()
+    const filteredOrder = contentObject.collections[collectionName].order.filter(item => !item.includes(`${subfolder}/`))
+    const newContentObject = _.cloneDeep(contentObject)
+    newContentObject.collections[collectionName].order = filteredOrder
+    const newContent = base64.encode(yaml.safeDump(newContentObject))
+
+    await this.update(newContent, sha)
+  }
 }
 
 module.exports = { Config, CollectionConfig }

--- a/classes/Config.js
+++ b/classes/Config.js
@@ -174,6 +174,20 @@ class CollectionConfig extends Config {
 
     await this.update(newContent, sha)
   }
+
+  async renameSubfolderInOrder(subfolder, newSubfolderName) {
+    const collectionName = this.collectionName
+    const { contentObject, sha } = await this.read()
+    const renamedOrder = contentObject.collections[collectionName].order.map(item => {
+      if (item.includes(`${subfolder}/`)) return `${newSubfolderName}/${item.split('/')[1]}`
+      return item
+    })
+    const newContentObject = _.cloneDeep(contentObject)
+    newContentObject.collections[collectionName].order = renamedOrder
+    const newContent = base64.encode(yaml.safeDump(newContentObject))
+
+    await this.update(newContent, sha)
+  }
 }
 
 module.exports = { Config, CollectionConfig }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -53,6 +53,7 @@ auth.get('/v1/sites/:siteName/files/:path', verifyJwt)
 // Folder pages
 auth.get('/v1/sites/:siteName/folders/all', verifyJwt)
 auth.delete('/v1/sites/:siteName/folders/:folderName/subfolder/:subfolderName', verifyJwt)
+auth.post('/v1/sites/:siteName/folders/:folderName/subfolder/:subfolderName/rename/:newSubfolderName', verifyJwt)
 
 // Collection pages
 auth.get('/v1/sites/:siteName/collections/:collectionName', verifyJwt)

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -52,6 +52,7 @@ auth.get('/v1/sites/:siteName/files/:path', verifyJwt)
 
 // Folder pages
 auth.get('/v1/sites/:siteName/folders/all', verifyJwt)
+auth.delete('/v1/sites/:siteName/folders/:folderName/subfolder/:subfolderName', verifyJwt)
 
 // Collection pages
 auth.get('/v1/sites/:siteName/collections/:collectionName', verifyJwt)

--- a/routes/folders.js
+++ b/routes/folders.js
@@ -44,10 +44,13 @@ async function deleteSubfolder (req, res, next) {
        !item.path.includes('/') && item.path !== `_${folderName}`
     ))
     const folderTreeWithoutSubfolder = gitTree.filter(item => (
-        // get all folder items, except for the tree object of the folder itself (note the trailing /)
-        item.path.includes(`_${folderName}/`)
+        // get all folder items
+        item.path.includes(`_${folderName}`)
     )).filter(item => (
-        // exclude all subfolder items, including the tree object of the subfolder
+        // remove tree objects of folder and subfolder to be renamed
+        item.path !== `_${folderName}` && item.path !== `_${folderName}/${subfolderName}`
+    )).filter(item => (
+        // exclude all subfolder items
         !item.path.includes(`_${folderName}/${subfolderName}`)
     ))
 

--- a/routes/folders.js
+++ b/routes/folders.js
@@ -2,8 +2,10 @@ const express = require('express');
 const router = express.Router();
 const Bluebird = require('bluebird')
 
+const { getTree, sendTree } = require('../utils/utils.js')
+
 // Import middleware
-const { attachReadRouteHandlerWrapper } = require('../middleware/routeHandler')
+const { attachReadRouteHandlerWrapper, attachRollbackRouteHandlerWrapper } = require('../middleware/routeHandler')
 
 // Import classes
 const { CollectionConfig } = require('../classes/Config')
@@ -28,6 +30,32 @@ async function listAllFolderContent (req, res, next) {
     res.status(200).json({ allFolderContent })
 }
 
+// Delete subfolder
+async function deleteSubfolder (req, res, next) {
+    const { accessToken, currentCommitSha, treeSha } = req
+    const { siteName, folderName, subfolderName } = req.params
+
+    const commitMessage = `Delete subfolder ${folderName}/${subfolderName}`
+    const isRecursive = true
+    const gitTree = await getTree(siteName, accessToken, treeSha, isRecursive)
+    const baseTreeWithoutFolder = gitTree.filter(item => (
+        // keep all root-level items except for tree object of folder whose subfolder is to be deleted
+       !item.path.includes('/') && item.path !== `_${folderName}`
+    ))
+    const folderTreeWithoutSubfolder = gitTree.filter(item => (
+        // get all folder items, except for the tree object of the folder itself (note the trailing /)
+        item.path.includes(`_${folderName}/`)
+    )).filter(item => (
+        // exclude all subfolder items, including the tree object of the subfolder
+        !item.path.includes(`_${folderName}/${subfolderName}`)
+    ))
+
+    const newGitTree = [...baseTreeWithoutFolder, ...folderTreeWithoutSubfolder]
+    await sendTree(newGitTree, currentCommitSha, siteName, accessToken, commitMessage)
+    res.status(200).send('Ok')
+}
+
 router.get('/:siteName/folders/all', attachReadRouteHandlerWrapper(listAllFolderContent))
+router.delete('/:siteName/folders/:folderName/subfolder/:subfolderName', attachRollbackRouteHandlerWrapper(deleteSubfolder))
 
 module.exports = router;

--- a/routes/folders.js
+++ b/routes/folders.js
@@ -61,7 +61,50 @@ async function deleteSubfolder (req, res, next) {
     res.status(200).send('Ok')
 }
 
+// Rename subfolder
+async function renameSubfolder (req, res, next) {
+    const { accessToken, currentCommitSha, treeSha } = req
+    const { siteName, folderName, subfolderName, newSubfolderName } = req.params
+
+    // Rename subfolder
+    const commitMessage = `Rename subfolder ${folderName}/${subfolderName} to ${folderName}/${newSubfolderName}`
+    const isRecursive = true
+    const gitTree = await getTree(siteName, accessToken, treeSha, isRecursive)
+    const baseTreeWithoutFolder = gitTree.filter(item => (
+        // keep all root-level items except for tree object of folder whose subfolder is to be deleted
+       !item.path.includes('/') && item.path !== `_${folderName}`
+    ))
+    const folderTreeWithRenamedSubfolder= gitTree.filter(item => (
+        // get all folder items
+        item.path.includes(`_${folderName}`)
+    )).filter(item => (
+        // remove tree objects of folder and subfolder to be renamed
+        item.path !== `_${folderName}` && item.path !== `_${folderName}/${subfolderName}`
+    )).map(item => {
+        // rename all subfolder items
+        if (item.path.includes(`_${folderName}/${subfolderName}`)) {
+            const pathArr = item.path.split('/')
+            return {
+                ...item,
+                path: `_${folderName}/${newSubfolderName}/${pathArr[2]}`,
+            }
+        }
+        return item
+    })
+
+
+    const newGitTree = [...baseTreeWithoutFolder, ...folderTreeWithRenamedSubfolder]
+    await sendTree(newGitTree, currentCommitSha, siteName, accessToken, commitMessage)
+
+    // // Update collection config
+    const collectionConfig = new CollectionConfig(accessToken, siteName, folderName)
+    await collectionConfig.renameSubfolderInOrder(subfolderName, newSubfolderName)
+
+    res.status(200).send('Ok')
+}
+
 router.get('/:siteName/folders/all', attachReadRouteHandlerWrapper(listAllFolderContent))
 router.delete('/:siteName/folders/:folderName/subfolder/:subfolderName', attachRollbackRouteHandlerWrapper(deleteSubfolder))
+router.post('/:siteName/folders/:folderName/subfolder/:subfolderName/rename/:newSubfolderName', attachRollbackRouteHandlerWrapper(renameSubfolder))
 
 module.exports = router;

--- a/routes/folders.js
+++ b/routes/folders.js
@@ -35,6 +35,7 @@ async function deleteSubfolder (req, res, next) {
     const { accessToken, currentCommitSha, treeSha } = req
     const { siteName, folderName, subfolderName } = req.params
 
+    // Delete subfolder
     const commitMessage = `Delete subfolder ${folderName}/${subfolderName}`
     const isRecursive = true
     const gitTree = await getTree(siteName, accessToken, treeSha, isRecursive)
@@ -52,6 +53,11 @@ async function deleteSubfolder (req, res, next) {
 
     const newGitTree = [...baseTreeWithoutFolder, ...folderTreeWithoutSubfolder]
     await sendTree(newGitTree, currentCommitSha, siteName, accessToken, commitMessage)
+
+    // Update collection config
+    const collectionConfig = new CollectionConfig(accessToken, siteName, folderName)
+    await collectionConfig.deleteSubfolderFromOrder(subfolderName)
+
     res.status(200).send('Ok')
 }
 

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -51,17 +51,21 @@ async function getCommitAndTreeSha(repo, accessToken, branchRef='staging') {
 }
 
 // retrieve the tree from given tree sha
-async function getTree(repo, accessToken, treeSha, branchRef='staging') {
+async function getTree(repo, accessToken, treeSha, isRecursive, branchRef='staging') {
   try {
     const headers = {
       Authorization: `token ${accessToken}`,
       Accept: 'application/json',
     };
 
+    const params = {
+      ref: branchRef,
+    }
+
+    if (isRecursive) params.recursive = true
+
     const { data: { tree: gitTree } } = await axios.get(`https://api.github.com/repos/${GITHUB_ORG_NAME}/${repo}/git/trees/${treeSha}`, {
-      params: {
-        ref: branchRef,
-      },
+      params,
       headers,
     });
 


### PR DESCRIPTION
## Overview

This PR introduces new backend endpoints for renaming and deleting subfolders. The endpoints are:
- DELETE `/:siteName/folders/:folderName/subfolder/:subfolderName`
- POST `/:siteName/folders/:folderName/subfolder/:subfolderName/rename/:newSubfolderName`

Each endpoint performs two functions: firstly, it deletes/renames the subfolders and their children files using Git trees, and then it updates the subfolder's parent folder's collection config file.

As part of these changes, two new methods, `deleteSubfolderFromOrder` and `renameSubfolderInOrder`, were added to the `CollectionConfig` class. 

Note: the backend classes, on the whole, are due for refactoring. This will be looked at once we're done with v1 of the CMS - for now, the goal is to simply ensure that everything is working correctly. As such, any functionality that is needed (such as the `deleteSubfolderFromOrder` method) will simply be implemented naively for now. 

### Renaming and deleting subfolders with Git trees

We currently use the Git Contents API (https://docs.github.com/en/rest/reference/repos#contents) for creating, updating or deleting files using the CMS.  However, the Contents API is designed for individual file operations, which makes deleting, creating, or updating an existing file quick and easy, but much slower for bulk operations. This is because deleting or creating files in directories cannot occur concurrently due to the parent directory's tree object being updated (see PR #132 for more details). Therefore, it is fairly inefficient to delete subfolders (which may each contain many files) using the Contents API as we would need to delete the files in the subfolders serially. It is even worse for renaming, since there is no "rename" API, and we need to perform serial operations of deleting and re-creating each file for every file in the subfolder.

For bulk operations, it's a lot more efficient to modify the Git tree itself. For that, we would use the Git Data API, more specifically, the tree creation and updating API (https://docs.github.com/en/rest/reference/git#create-a-tree). The key caveat can be found in the documentation for the `base_tree` parameter:

> If you're creating new changes on a branch, then normally you'd set base_tree to the SHA1 of the Git tree object of the current latest commit on the branch you're working on. If not provided, GitHub will create a new Git tree object from only the entries defined in the tree parameter. If you create a new commit pointing to such a tree, then all files which were a part of the parent commit's tree and were not defined in the tree parameter will be listed as deleted by the new commit

Each directory is represented by a tree object in Git. However, the key to modifying a directory (whether at the top-level or nested) through the Git Data API is to **omit** the tree objects of the relevant directories, as well as any other objects you wish to delete, in the `tree` array that you send to the Create Tree API. The GitHub API will then create new tree objects for the modified directories. This will be easier to understand with the following example. Consider the following repo structure:

```
- folder A
    - collection.yml
    - example-page-1.md
    - example-page-2.md
    - subfolder A
       - subfolder-example-page-1.md
       - subfolder-example-page-2.md
- folder B
    - collection.yml
    - example-page-3.md
    - example-page-4.md
    - subfolder B
        - subfolder-example-page-3.md
        - subfolder-example-page-4.md
```

At the top-level, the tree (simplified) looks like this:
```
tree = [
  {
    path: 'folder A',
    type: 'tree',
    sha: <sha>
  }, 
  {
    path: 'folder B',
    type: 'tree',
    sha: <sha>
  }
]
```

If you wish to delete the page `example-page-1.md` from `folder A`, you would need to get the fully recursed tree and re-define the sub-tree for `folder A` **WITHOUT** the `folder A` tree.

```
tree = [
  {
    path: 'folder A/collection.yml',
    type: 'blob',
    sha: <sha>
  }, 
  {
    path: 'folder A/example-page-2.md',
    type: 'blob',
    sha: <sha>
  }, 
  {
    path: 'folder A/subfolder A',
    type: 'tree',
    sha: <sha>
  }, 
  {
    path: 'folder A/subfolder A/subfolder-example-page-1.md',
    type: 'blob',
    sha: <sha>
  }, 
  {
    path: 'folder A/subfolder A/subfolder-example-page-1.md',
    type: 'blob',
    sha: <sha>
  }, 
  {
    path: 'folder B',
    type: 'tree',
    sha: <sha>
  }
]
```

Finally, if you wish to delete the page `subfolder-example-page-1.md` from `subfolder A` in `folder A`, you would need to omit **BOTH** the tree objects for `folder A` and `subfolder A`. See the following tree:

```
tree = [
  {
    path: 'folder A/collection.yml',
    type: 'blob',
    sha: <sha>
  }, 
  {
    path: 'folder A/example-page-1.md',
    type: 'blob',
    sha: <sha>
  }, 
  {
    path: 'folder A/example-page-2.md',
    type: 'blob',
    sha: <sha>
  }, 
  {
    path: 'folder A/subfolder A/subfolder-example-page-1.md',
    type: 'blob',
    sha: <sha>
  }, 
  {
    path: 'folder B',
    type: 'tree',
    sha: <sha>
  }
]
```