### PR TITLE
Feat: create placeholder for empty subfolders

### DIFF
--- a/classes/Subfolder.js
+++ b/classes/Subfolder.js
@@ -1,0 +1,46 @@
+const { CollectionConfig } = require('./Config.js')
+const { File, CollectionPageType } = require('./File.js')
+const { Directory, FolderType } = require('./Directory.js')
+
+class Subfolder {
+  constructor(accessToken, siteName, collectionName) {
+    this.accessToken = accessToken
+    this.siteName = siteName
+    this.collectionName = collectionName
+  }
+
+  async list() {
+    const IsomerDirectory = new Directory(this.accessToken, this.siteName)
+    const folderType = new FolderType(`_${this.collectionName}`)
+    IsomerDirectory.setDirType(folderType)
+    const repoRootContent = await IsomerDirectory.list()
+
+    const allSubfolders = repoRootContent.reduce((acc, curr) => {
+        if (curr.type === 'dir') {
+          const pathTokens = curr.path.split('/')
+          acc.push(pathTokens.slice(1).join('/'))
+        }
+        return acc
+    }, [])
+    return allSubfolders
+  }
+
+  async create(subfolderName) {
+    try {
+      // Update collection.yml
+      const collectionConfig = new CollectionConfig(this.accessToken, this.siteName, this.collectionName)
+      await collectionConfig.addItemToOrder(`${subfolderName}/.keep`)
+
+      // Create placeholder file
+      const IsomerFile = new File(this.accessToken, this.siteName)
+      const dataType = new CollectionPageType(this.collectionName)
+      IsomerFile.setFileType(dataType)
+      await IsomerFile.create(`${subfolderName}/.keep`, '')
+
+    } catch (err) {
+      throw err
+    }
+  }
+}
+
+module.exports = { Subfolder }

--- a/routes/collectionPages.js
+++ b/routes/collectionPages.js
@@ -174,13 +174,6 @@ async function deleteCollectionPage (req, res, next) {
   const collectionConfig = new CollectionConfig(accessToken, siteName, collectionName)
   await collectionConfig.deleteItemFromOrder(pageName)
 
-  // Check if collection has any pages left, and delete if none left
-  const collectionPages = await IsomerFile.list()
-  if (collectionPages.length === 1 && collectionPages[0].fileName === 'collection.yml') {
-    const IsomerCollection = new Collection(accessToken, siteName)
-    await IsomerCollection.delete(collectionName, currentCommitSha, treeSha)
-  }
-
   res.status(200).send('OK')
 }
 

--- a/routes/collections.js
+++ b/routes/collections.js
@@ -14,8 +14,9 @@ const {
 const { Collection } = require('../classes/Collection.js');
 const { CollectionConfig } = require('../classes/Config.js');
 const { File, CollectionPageType, PageType } = require('../classes/File');
+const { Subfolder } = require('../classes/Subfolder');
 
-const { deslugifyCollectionName } = require('../utils/utils')
+const { deslugifyCollectionName } = require('../utils/utils');
 
 // List collections
 async function listCollections (req, res, next) {
@@ -96,6 +97,13 @@ async function moveFiles (req, res, next) {
   newIsomerFile.setFileType(newCollectionPageType)
   const oldConfig = new CollectionConfig(accessToken, siteName, collectionName)
   const newConfig = targetCollectionName === 'pages' ? null : new CollectionConfig(accessToken, siteName, targetCollectionName)
+
+  if (newConfig && targetSubfolderName) {
+    // Check if subfolder exists
+    const IsomerSubfolder = new Subfolder(accessToken, siteName, targetCollectionName)
+    const subfolders = await IsomerSubfolder.list()
+    if (!subfolders.includes(targetSubfolderName)) IsomerSubfolder.create(targetSubfolderName)
+  }
 
   // We can't perform these operations concurrently because of conflict issues
   for (const fileName of files) {

--- a/routes/collections.js
+++ b/routes/collections.js
@@ -102,7 +102,7 @@ async function moveFiles (req, res, next) {
     // Check if subfolder exists
     const IsomerSubfolder = new Subfolder(accessToken, siteName, targetCollectionName)
     const subfolders = await IsomerSubfolder.list()
-    if (!subfolders.includes(targetSubfolderName)) IsomerSubfolder.create(targetSubfolderName)
+    if (!subfolders.includes(targetSubfolderName)) await IsomerSubfolder.create(targetSubfolderName)
   }
 
   // We can't perform these operations concurrently because of conflict issues

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -16,6 +16,7 @@ const {
 const { File, PageType, CollectionPageType } = require('../classes/File.js')
 const { Collection } = require('../classes/Collection.js');
 const { CollectionConfig } = require('../classes/Config');
+const { Subfolder } = require('../classes/Subfolder');
 
 const { deslugifyCollectionName } = require('../utils/utils')
 
@@ -176,6 +177,13 @@ async function moveUnlinkedPages (req, res, next) {
   oldIsomerFile.setFileType(oldPageType)
   newIsomerFile.setFileType(newCollectionPageType)
   const newConfig = new CollectionConfig(accessToken, siteName, targetCollectionName)
+
+  if (newConfig && targetSubfolderName) {
+    // Check if subfolder exists
+    const IsomerSubfolder = new Subfolder(accessToken, siteName, targetCollectionName)
+    const subfolders = await IsomerSubfolder.list()
+    if (!subfolders.includes(targetSubfolderName)) IsomerSubfolder.create(targetSubfolderName)
+  }
 
   // We can't perform these operations concurrently because of conflict issues
   for (const fileName of files) {

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -182,7 +182,7 @@ async function moveUnlinkedPages (req, res, next) {
     // Check if subfolder exists
     const IsomerSubfolder = new Subfolder(accessToken, siteName, targetCollectionName)
     const subfolders = await IsomerSubfolder.list()
-    if (!subfolders.includes(targetSubfolderName)) IsomerSubfolder.create(targetSubfolderName)
+    if (!subfolders.includes(targetSubfolderName)) await IsomerSubfolder.create(targetSubfolderName)
   }
 
   // We can't perform these operations concurrently because of conflict issues

--- a/routes/resourcePages.js
+++ b/routes/resourcePages.js
@@ -108,14 +108,7 @@ async function deleteResourcePage(req, res, next) {
   const IsomerFile = new File(accessToken, siteName)
   const resourcePageType = new ResourcePageType(resourceRoomName, resourceName)
   IsomerFile.setFileType(resourcePageType)
-  const resources = await IsomerFile.list()
-  if (resources.length === 1) {
-    // If there is only 1 page left, we can delete the entire category
-    const IsomerResource = new Resource(accessToken, siteName)
-    await IsomerResource.delete(resourceRoomName, resourceName)
-  } else {
-    await IsomerFile.delete(pageName, sha)
-  }
+  await IsomerFile.delete(pageName, sha)
 
   res.status(200).send('OK')
 }

--- a/routes/resourcePages.js
+++ b/routes/resourcePages.js
@@ -12,15 +12,22 @@ const {
 const { File, ResourcePageType } = require('../classes/File.js')
 const { ResourceRoom } = require('../classes/ResourceRoom.js')
 const { Resource } = require('../classes/Resource.js')
+const { NotFoundError } = require('../errors/NotFoundError');
 
 // List pages in resource
 async function listResourcePages (req, res, next) {
   const { accessToken } = req
   const { siteName, resourceName } = req.params
 
-  // TO-DO: Verify that resource exists
   const ResourceRoomInstance = new ResourceRoom(accessToken, siteName)
   const resourceRoomName = await ResourceRoomInstance.get()
+
+  // Check if resource category exists
+  const IsomerResource = new Resource(accessToken, siteName)
+  const resources = await IsomerResource.list(resourceRoomName)
+  const resourceCategories = resources.map(resource => resource.dirName)
+  if (!resourceCategories.includes(resourceName)) throw new NotFoundError(`Resource category ${resourceName} was not found!`)
+
   const IsomerFile = new File(accessToken, siteName)
   const resourcePageType = new ResourcePageType(resourceRoomName, resourceName)
   IsomerFile.setFileType(resourcePageType)


### PR DESCRIPTION
This PR adds functionality for adding empty subfolders into the CMS, as well as the associated changes required. To be reviewed in conjunction with PR #[384](https://github.com/isomerpages/isomercms-frontend/pull/384) on the isomercms frontend repo. A discussion of the reasoning behind this change can be found [here](https://docs.google.com/document/d/1EccpS_ATrfOe4DmU4ChXtU9kV6Jl1rFOdKqBLyG6ym8/edit#).

This PR introduces the following changes:

- The automatic deletion of empty folders, subfolders, and resources has been removed, in line with the ability to create empty folders.
- A new Subfolder class has been created for easier creation and management of subfolders, to automatically update the collection.yml file and handle placeholder file creation.
- An additional check for the existence of the resource category directory has been added when retrieving resource pages. This is to distinguish between empty categories and non-existent ones.