### PR TITLE
Fix: position of newly created files

### DIFF
--- a/classes/Config.js
+++ b/classes/Config.js
@@ -123,20 +123,20 @@ class CollectionConfig extends Config {
     const collectionName = this.collectionName
     const { content, sha } = await this.read()
 
+    let newIndex = index
     if (index === undefined) {
-      let index
       if (item.split('/').length === 2) {
         // if file in subfolder, get index of last file in subfolder
-        index = _.findLastIndex(
+        newIndex = _.findLastIndex(
           content.collections[collectionName].order,
           (f) => f.split('/')[0] === item.split('/')[0]
         ) + 1
       } else {
         // get index of last file in collection
-        index = content.collections[collectionName].order.length
+        newIndex = content.collections[collectionName].order.length
       }
     }
-    content.collections[collectionName].order.splice(index, 0, item)
+    content.collections[collectionName].order.splice(newIndex, 0, item)
     const newContent = base64.encode(yaml.stringify(content))
     
     await this.update(newContent, sha)


### PR DESCRIPTION
This PR fixes a small bug when adding files to the order in `collection.yml`. Previously, as the variable `index` was not scoped properly, we always spliced newly created files into the first position in the `collection.yml` file. We have fixed the scoping in this PR.