### PR TITLE
Feat: add staging url and last updated endpoints

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -142,6 +142,7 @@ auth.get('/v1/sites/:siteName/netlify-toml', verifyJwt)
 // Sites
 auth.get('/v1/sites', verifyJwt)
 auth.get('/v1/sites/:siteName', verifyJwt)
+auth.get('/v1/sites/:siteName/lastUpdated', verifyJwt)
 auth.get('/v1/sites/:siteName/stagingUrl', verifyJwt)
 
 auth.use((req, res, next) => {

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -142,6 +142,7 @@ auth.get('/v1/sites/:siteName/netlify-toml', verifyJwt)
 // Sites
 auth.get('/v1/sites', verifyJwt)
 auth.get('/v1/sites/:siteName', verifyJwt)
+auth.get('/v1/sites/:siteName/stagingUrl', verifyJwt)
 
 auth.use((req, res, next) => {
     if (!req.route) {

--- a/routes/sites.js
+++ b/routes/sites.js
@@ -118,6 +118,22 @@ async function checkHasAccess (req, res, next) {
   }
 }
 
+/* Gets the last updated time of the repo. */
+async function getLastUpdated (req, res, next) {
+  const { accessToken } = req
+  const { siteName } = req.params
+
+  const endpoint = `https://api.github.com/repos/${ISOMER_GITHUB_ORG_NAME}/${siteName}`
+  const resp = await axios.get(endpoint, {
+    headers: {
+      Authorization: `token ${accessToken}`,
+      "Content-Type": "application/json",
+    }
+  })
+  const { updated_at } = resp.data
+  res.status(200).json({ lastUpdated: timeDiff(updated_at)})
+}
+
 /* Gets the link to the staging site for a repo. */
 async function getStagingUrl (req, res, next) {
   // TODO: reconsider how we can retrieve url - we can store this in _config.yml or a dynamodb
@@ -147,6 +163,7 @@ async function getStagingUrl (req, res, next) {
 
 router.get('/', attachReadRouteHandlerWrapper(getSites));
 router.get('/:siteName', attachReadRouteHandlerWrapper(checkHasAccess));
+router.get('/:siteName/lastUpdated', attachReadRouteHandlerWrapper(getLastUpdated));
 router.get('/:siteName/stagingUrl', attachReadRouteHandlerWrapper(getStagingUrl));
 
 module.exports = router;

--- a/routes/sites.js
+++ b/routes/sites.js
@@ -155,7 +155,8 @@ async function getStagingUrl (req, res, next) {
   if (description) {
     // Retrieve the url from the description - repo descriptions have varying formats, so we look for the first link
     const descTokens = description.replace('/;/g', ' ').split(' ')
-    stagingUrl = descTokens.find(token => token.includes('http'))
+    // Staging urls also contain staging in their url
+    stagingUrl = descTokens.find(token => token.includes('http') && token.includes('staging'))
   }
 
   res.status(200).json({ stagingUrl })


### PR DESCRIPTION
This PR adds in 2 new endpoints, to retrieve the url of the staging site and the last updated time of the repo. To be reviewed in conjunction with PR #[394](https://github.com/isomerpages/isomercms-frontend/pull/394) on the isomercms-frontend.

We are adding an additional last updated endpoint as the existing one being used (`getSites`) retrieves the details of every single repo.

For the endpoint being used to retrieve the staging url, we currently retrieve this using the repo description, as the staging url is automatically populated upon creation of a site. However, we intend to replace this, as it is possible for users to modify the initial description. We can consider adding the staging/production urls into the `_config.yml` file, or in the long term, adding these details to a dynamodb for us to more easily reference the links to staging and production sites.