### PR TITLE
Fix: move auth out of query param

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -21,16 +21,18 @@ const COOKIE_NAME = 'isomercms'
 
 async function githubAuth (req, res, next) {
   const { code, state } = req.query
-
   const params = {
-    client_id: CLIENT_ID,
-    client_secret: CLIENT_SECRET,
     code: code,
     redirect_uri: REDIRECT_URI,
     state: state
   }
 
-  const resp = await axios.post('https://github.com/login/oauth/access_token', params)
+  const resp = await axios.post('https://github.com/login/oauth/access_token', params, {
+    auth: {
+      username: CLIENT_ID,
+      password: CLIENT_SECRET,
+    },
+  })
 
   const access_token = queryString.parse(resp.data).access_token
   if (!access_token) throw new AuthError ('Access token not found')


### PR DESCRIPTION
This PR fixes our retrieval of the github access token, in line with github's deprecation of auth through query params ([link](https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/)). We instead specify the username and password in a separate auth object.