### PR TITLE
Fix: encode/decode homepage content

### DIFF
--- a/routes/homepage.js
+++ b/routes/homepage.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+const base64 = require('base-64')
 
 // Import middleware
 const { 
@@ -22,7 +23,8 @@ async function readHomepage (req, res, next) {
   const IsomerFile = new File(accessToken, siteName)
   const homepageType =  new HomepageType()
   IsomerFile.setFileType(homepageType)
-  const { sha, content } = await IsomerFile.read(HOMEPAGE_INDEX_PATH)
+  const { sha, content: encodedContent } = await IsomerFile.read(HOMEPAGE_INDEX_PATH)
+  const content = Base64.decode(encodedContent)
 
   // TO-DO:
   // Validate content
@@ -43,7 +45,7 @@ async function updateHomepage (req, res, next) {
   const IsomerFile = new File(accessToken, siteName)
   const homepageType =  new HomepageType()
   IsomerFile.setFileType(homepageType)
-  const { newSha } = await IsomerFile.update(HOMEPAGE_INDEX_PATH, content, sha)
+  const { newSha } = await IsomerFile.update(HOMEPAGE_INDEX_PATH, Base64.encode(content), sha)
 
   res.status(200).json({ content, sha: newSha })
 }


### PR DESCRIPTION
This PR changes the homepage endpoints to handle encoding/decoding, instead of performing this in the frontend, in line with our changes in https://github.com/isomerpages/isomercms-backend/pull/133. To be reviewed in conjunction with PR [#406](https://github.com/isomerpages/isomercms-frontend/pull/406) on the isomercms-frontend repo.