### PR TITLE
fix: add resourceRoomName to readResourcePage response

### DIFF
--- a/routes/resourcePages.js
+++ b/routes/resourcePages.js
@@ -83,7 +83,7 @@ async function readResourcePage (req, res, next) {
   // TO-DO:
   // Validate content
 
-  res.status(200).json({ resourceName, pageName, sha, content })
+  res.status(200).json({ resourceRoomName, resourceName, pageName, sha, content })
 }
 
 // Update page in resource


### PR DESCRIPTION
This PR sends the `resourceRoomName` as part of the API response when a resource page is retrieved. 