### PR TITLE
Fix/image endpoints for nested images

### DIFF
--- a/classes/ImageFile.js
+++ b/classes/ImageFile.js
@@ -17,8 +17,8 @@ class ImageFile {
     this.fileType = null
   }
 
-  setFileTypeToImage() {
-    this.fileType = new ImageType()
+  setFileTypeToImage(directory) {
+    this.fileType = new ImageType(directory)
     this.baseEndpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${this.siteName}/contents/${this.fileType.getFolderName()}`
     // Endpoint to retrieve files greater than 1MB
     this.baseBlobEndpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${this.siteName}/git/blobs`
@@ -161,8 +161,8 @@ class ImageFile {
 }
 
 class ImageType {
-  constructor() {
-    this.folderName = 'images'
+  constructor(directory) {
+    this.folderName = directory ? directory : 'images'
   }
   getFolderName() {
     return this.folderName

--- a/classes/ImageFile.js
+++ b/classes/ImageFile.js
@@ -24,8 +24,6 @@ class ImageFile {
     this.baseBlobEndpoint = `https://api.github.com/repos/${GITHUB_ORG_NAME}/${this.siteName}/git/blobs`
   }
 
-
-
   async list() {
     try {
       const endpoint = `${this.baseEndpoint}`

--- a/classes/MediaFile.js
+++ b/classes/MediaFile.js
@@ -8,7 +8,7 @@ const { NotFoundError  } = require('../errors/NotFoundError')
 // Constants
 const GITHUB_ORG_NAME = 'isomerpages'
 
-class ImageFile {
+class MediaFile {
   constructor(accessToken, siteName) {
     this.accessToken = accessToken
     this.siteName = siteName
@@ -166,4 +166,4 @@ class ImageType {
     return this.folderName
   }
 }
-module.exports = { ImageFile }
+module.exports = { MediaFile }

--- a/routes/images.js
+++ b/routes/images.js
@@ -9,7 +9,7 @@ const {
 
 // Import classes 
 const { File, ImageType } = require('../classes/File.js')
-const { ImageFile } = require('../classes/ImageFile.js');
+const { MediaFile } = require('../classes/MediaFile.js');
 
 const extractDirectoryAndFileName = (imageName) => {
   let imageDirectory, imageFileName
@@ -51,7 +51,7 @@ async function createNewImage (req, res, next) {
   // TO-DO:
   // Validate imageName and content
 
-  const IsomerImageFile = new ImageFile(accessToken, siteName)
+  const IsomerImageFile = new MediaFile(accessToken, siteName)
   IsomerImageFile.setFileTypeToImage(imageDirectory)
   const { sha } = await IsomerImageFile.create(imageName, content)
 
@@ -67,7 +67,7 @@ async function readImage (req, res, next) {
   // get image directory
   const { imageDirectory, imageFileName } = extractDirectoryAndFileName(imageName)
 
-  const IsomerImageFile = new ImageFile(accessToken, siteName)
+  const IsomerImageFile = new MediaFile(accessToken, siteName)
   IsomerImageFile.setFileTypeToImage(imageDirectory)
 
   const { sha, content } = await IsomerImageFile.read(imageFileName)
@@ -126,11 +126,11 @@ async function renameImage (req, res, next) {
   const { imageDirectory: oldImageDirectory, imageFileName: oldImageFileName } = extractDirectoryAndFileName(imageName)
   const { imageDirectory: newImageDirectory, imageFileName: newImageFileName } = extractDirectoryAndFileName(newImageName)
 
-  const newIsomerImageFile = new ImageFile(accessToken, siteName)
+  const newIsomerImageFile = new MediaFile(accessToken, siteName)
   newIsomerImageFile.setFileTypeToImage(newImageDirectory)
   const { sha: newSha } = await newIsomerImageFile.create(newImageFileName, content)
 
-  const oldIsomerImageFile = new ImageFile(accessToken, siteName)
+  const oldIsomerImageFile = new MediaFile(accessToken, siteName)
   oldIsomerImageFile.setFileTypeToImage(oldImageDirectory)
   await oldIsomerImageFile.delete(oldImageFileName, sha)
 

--- a/routes/images.js
+++ b/routes/images.js
@@ -29,15 +29,14 @@ async function createNewImage (req, res, next) {
   const { accessToken } = req
 
   const { siteName } = req.params
-  const { imageName, content } = req.body
+  const { imageName, imageDirectory, content } = req.body
 
   // TO-DO:
   // Validate imageName and content
 
-  const IsomerFile = new File(accessToken, siteName)
-  const imageType =  new ImageType()
-  IsomerFile.setFileType(imageType)
-  const { sha } = await IsomerFile.create(imageName, content)
+  const IsomerImageFile = new ImageFile(accessToken, siteName)
+  IsomerImageFile.setFileTypeToImage(imageDirectory)
+  const { sha } = await IsomerImageFile.create(imageName, content)
 
   res.status(200).json({ imageName, content, sha })
 }
@@ -61,6 +60,7 @@ async function readImage (req, res, next) {
 
   const IsomerImageFile = new ImageFile(accessToken, siteName)
   IsomerImageFile.setFileTypeToImage(imageDirectory)
+
   const { sha, content } = await IsomerImageFile.read(imageFileName)
 
   // TO-DO:

--- a/routes/images.js
+++ b/routes/images.js
@@ -10,7 +10,6 @@ const {
 // Import classes 
 const { File, ImageType } = require('../classes/File.js')
 const { ImageFile } = require('../classes/ImageFile.js');
-const { update } = require('lodash');
 
 // List images
 async function listImages (req, res, next) {
@@ -49,9 +48,20 @@ async function readImage (req, res, next) {
 
   const { siteName, imageName } = req.params
 
+  // get image directory
+  let imageDirectory, imageFileName
+  const pathArr = imageName.split('/')
+  if (pathArr.length === 1) {
+    imageDirectory = 'images'
+    imageFileName = imageName
+  } else if (pathArr.length > 1) {
+    imageDirectory = `images/${pathArr.slice(0, -1)}`
+    imageFileName = pathArr[pathArr.length - 1]
+  }
+
   const IsomerImageFile = new ImageFile(accessToken, siteName)
-  IsomerImageFile.setFileTypeToImage()
-  const { sha, content } = await IsomerImageFile.read(imageName)
+  IsomerImageFile.setFileTypeToImage(imageDirectory)
+  const { sha, content } = await IsomerImageFile.read(imageFileName)
 
   // TO-DO:
   // Validate content


### PR DESCRIPTION
## Overview

Currently, our backend endpoints for images cannot handle changes to images in nested directories. That's because the endpoints that we're hitting on GitHub assume that there is only one directory where we store all images: the `images` directory in the root of the repo.

This PR updates the following endpoints:
- POST `/:siteName/images`
- GET `/:siteName/images/:imageName`
- POST `/:siteName/images/:imageName/rename/:newImageName`
So that we can read, create, and rename individual images that are in nested directories. I also updated these endpoints to use the `MediaFile` (renamed from `ImageFile`) class instead of the `File` class that was being used before.

As part of this PR, changes were also made to the `MediaFile` class so that the `ImageType` class used accepts an argument in its constructor which determines the base API endpoint. This allows us to set the base endpoint to be a nested directory instead of the root `images` directory.

