### PR TITLE
(hotfix to develop) misc bugs

### DIFF
--- a/classes/Collection.js
+++ b/classes/Collection.js
@@ -1,5 +1,4 @@
 const yaml = require('yaml')
-const base64 = require('base-64')
 const Bluebird = require('bluebird')
 const _ = require('lodash')
 
@@ -48,20 +47,20 @@ class Collection {
         }
       }
       if (ISOMER_TEMPLATE_PROTECTED_DIRS.includes(collectionName)) throw new ConflictError(protectedFolderConflictErrorMsg(collectionName))
-      const newContent = base64.encode(yaml.stringify(contentObject))
+      const newContent = Base64.encode(yaml.stringify(contentObject))
       await collectionConfig.create(newContent)
 
       const nav = new File(this.accessToken, this.siteName)
       const dataType = new DataType()
       nav.setFileType(dataType)
       const { content:navContent, sha:navSha } = await nav.read(NAV_FILE_NAME)
-      const navContentObject = yaml.parse(base64.decode(navContent))
+      const navContentObject = yaml.parse(Base64.decode(navContent))
 
       navContentObject.links.push({ 
         title: deslugifyCollectionName(collectionName),
         collection: collectionName 
       })
-      const newNavContent = base64.encode(yaml.stringify(navContentObject))
+      const newNavContent = Base64.encode(yaml.stringify(navContentObject))
 
       await nav.update(NAV_FILE_NAME, newNavContent, navSha)
 
@@ -84,14 +83,14 @@ class Collection {
       const dataType = new DataType()
       nav.setFileType(dataType)
       const { content:navContent, sha:navSha } = await nav.read(NAV_FILE_NAME)
-      const navContentObject = yaml.parse(base64.decode(navContent))
+      const navContentObject = yaml.parse(Base64.decode(navContent))
 
       const newNavLinks = navContentObject.links.filter(link => link.collection !== collectionName)
       const newNavContentObject = {
         ...navContentObject,
         links: newNavLinks,
       }
-      const newNavContent = base64.encode(yaml.stringify(newNavContentObject))
+      const newNavContent = Base64.encode(yaml.stringify(newNavContentObject))
       await nav.update(NAV_FILE_NAME, newNavContent, navSha)
     } catch (err) {
       throw err
@@ -107,7 +106,7 @@ class Collection {
       const dataType = new DataType()
       nav.setFileType(dataType)
       const { content:navContent, sha:navSha } = await nav.read(NAV_FILE_NAME)
-      const navContentObject = yaml.parse(base64.decode(navContent))
+      const navContentObject = yaml.parse(Base64.decode(navContent))
 
       const newNavLinks = navContentObject.links.map(link => {
         if (link.collection === oldCollectionName) {
@@ -123,7 +122,7 @@ class Collection {
         ...navContentObject,
         links: newNavLinks,
       }
-      const newNavContent = base64.encode(yaml.stringify(newNavContentObject))
+      const newNavContent = Base64.encode(yaml.stringify(newNavContentObject))
       await nav.update(NAV_FILE_NAME, newNavContent, navSha)
 
       const gitTree = await getTree(this.siteName, this.accessToken, treeSha);
@@ -149,7 +148,7 @@ class Collection {
           [newCollectionName]: configContentObject.collections[oldCollectionName]
         }
       }
-      const newConfigContent = base64.encode(yaml.stringify(newConfigContentObject))
+      const newConfigContent = Base64.encode(yaml.stringify(newConfigContentObject))
       await collectionConfig.update(newConfigContent, configSha)
 
     } catch (err) {

--- a/classes/Config.js
+++ b/classes/Config.js
@@ -1,7 +1,6 @@
 const axios = require('axios');
 const validateStatus = require('../utils/axios-utils')
 const yaml = require('yaml')
-const base64 = require('base-64')
 const _ = require('lodash')
 
 // Import error
@@ -115,7 +114,7 @@ class CollectionConfig extends Config {
 
   async read() {
     const { content, sha } = await super.read()
-    const contentObject = yaml.parse(base64.decode(content))
+    const contentObject = yaml.parse(Base64.decode(content))
     return { content: contentObject, sha }
   }
 
@@ -137,7 +136,7 @@ class CollectionConfig extends Config {
       }
     }
     content.collections[collectionName].order.splice(newIndex, 0, item)
-    const newContent = base64.encode(yaml.stringify(content))
+    const newContent = Base64.encode(yaml.stringify(content))
     
     await this.update(newContent, sha)
   }
@@ -147,7 +146,7 @@ class CollectionConfig extends Config {
     const { content, sha } = await this.read()
     const index = content.collections[collectionName].order.indexOf(item)
     content.collections[collectionName].order.splice(index, 1)
-    const newContent = base64.encode(yaml.stringify(content))
+    const newContent = Base64.encode(yaml.stringify(content))
     
     await this.update(newContent, sha)
     return { index, item }
@@ -159,7 +158,7 @@ class CollectionConfig extends Config {
     const index = content.collections[collectionName].order.indexOf(oldItem)
     content.collections[collectionName].order.splice(index, 1)
     content.collections[collectionName].order.splice(index, 0, newItem)
-    const newContent = base64.encode(yaml.stringify(content))
+    const newContent = Base64.encode(yaml.stringify(content))
     
     await this.update(newContent, sha)
   }
@@ -170,7 +169,7 @@ class CollectionConfig extends Config {
     const filteredOrder = content.collections[collectionName].order.filter(item => !item.includes(`${subfolder}/`))
     const newContentObject = _.cloneDeep(content)
     newContentObject.collections[collectionName].order = filteredOrder
-    const newContent = base64.encode(yaml.stringify(newContentObject))
+    const newContent = Base64.encode(yaml.stringify(newContentObject))
 
     await this.update(newContent, sha)
   }
@@ -184,7 +183,7 @@ class CollectionConfig extends Config {
     })
     const newContentObject = _.cloneDeep(content)
     newContentObject.collections[collectionName].order = renamedOrder
-    const newContent = base64.encode(yaml.stringify(newContentObject))
+    const newContent = Base64.encode(yaml.stringify(newContentObject))
 
     await this.update(newContent, sha)
   }

--- a/classes/ResourceRoom.js
+++ b/classes/ResourceRoom.js
@@ -1,5 +1,4 @@
 const yaml = require('yaml')
-const base64 = require('base-64')
 const Bluebird = require('bluebird')
 const _ = require('lodash')
 
@@ -24,7 +23,7 @@ class ResourceRoom {
     try {
     	const config = new Config(this.accessToken, this.siteName)
     	const { content } = await config.read()
-    	const contentObject = yaml.parse(base64.decode(content))
+    	const contentObject = yaml.parse(Base64.decode(content))
 
     	return contentObject.resources_name
     } catch (err) {
@@ -36,11 +35,11 @@ class ResourceRoom {
     try {
     	const config = new Config(this.accessToken, this.siteName)
     	const { content, sha } = await config.read()
-    	const contentObject = yaml.parse(base64.decode(content))
+    	const contentObject = yaml.parse(Base64.decode(content))
 
       contentObject.resources_name = resourceRoom
 
-    	const newContent = base64.encode(yaml.stringify(contentObject))
+    	const newContent = Base64.encode(yaml.stringify(contentObject))
 
       // Create index file in resourceRoom
       const IsomerIndexFile = new File(this.accessToken, this.siteName)
@@ -54,13 +53,13 @@ class ResourceRoom {
       const dataType = new DataType()
       nav.setFileType(dataType)
       const { content:navContent, sha:navSha } = await nav.read(NAV_FILE_NAME)
-      const navContentObject = yaml.parse(base64.decode(navContent))
+      const navContentObject = yaml.parse(Base64.decode(navContent))
 
       navContentObject.links.push({ 
         title: deslugifyCollectionName(resourceRoom),
         resource_room: true 
       })
-      const newNavContent = base64.encode(yaml.stringify(navContentObject))
+      const newNavContent = Base64.encode(yaml.stringify(navContentObject))
 
       await nav.update(NAV_FILE_NAME, newNavContent, navSha)
 
@@ -76,19 +75,19 @@ class ResourceRoom {
       // Add resource room to config
     	const config = new Config(this.accessToken, this.siteName)
     	const { content, sha } = await config.read()
-    	const contentObject = yaml.parse(base64.decode(content))
+    	const contentObject = yaml.parse(Base64.decode(content))
 
       // Obtain existing resourceRoomName
       const resourceRoomName = contentObject.resources_name
       contentObject.resources_name = newResourceRoom
-      const newContent = base64.encode(yaml.stringify(contentObject))
+      const newContent = Base64.encode(yaml.stringify(contentObject))
       
       // Rename resource room in nav if it exists
       const nav = new File(this.accessToken, this.siteName)
       const dataType = new DataType()
       nav.setFileType(dataType)
       const { content:navContent, sha:navSha } = await nav.read(NAV_FILE_NAME)
-      const navContentObject = yaml.parse(base64.decode(navContent))
+      const navContentObject = yaml.parse(Base64.decode(navContent))
 
       const newNavLinks = navContentObject.links.map(link => {
         if (link.resource_room === true) {
@@ -104,7 +103,7 @@ class ResourceRoom {
         ...navContentObject,
         links: newNavLinks,
       }
-      const newNavContent = base64.encode(yaml.stringify(newNavContentObject))
+      const newNavContent = Base64.encode(yaml.stringify(newNavContentObject))
       await nav.update(NAV_FILE_NAME, newNavContent, navSha)
 
       const { currentCommitSha, treeSha } = await getCommitAndTreeSha(this.siteName, this.accessToken)
@@ -134,21 +133,21 @@ class ResourceRoom {
     	// Delete resource in config
     	const config = new Config(this.accessToken, this.siteName)
     	const { content, sha } = await config.read()
-    	const contentObject = yaml.parse(base64.decode(content))
+    	const contentObject = yaml.parse(Base64.decode(content))
 
       // Obtain resourceRoomName
       const resourceRoomName = contentObject.resources_name
 
       // Delete resourcses_name from Config
     	delete contentObject.resources_name
-      const newContent = base64.encode(yaml.stringify(contentObject))
+      const newContent = Base64.encode(yaml.stringify(contentObject))
       
       // Delete resource room in nav if it exists
       const nav = new File(this.accessToken, this.siteName)
       const dataType = new DataType()
       nav.setFileType(dataType)
       const { content:navContent, sha:navSha } = await nav.read(NAV_FILE_NAME)
-      const navContentObject = yaml.parse(base64.decode(navContent))
+      const navContentObject = yaml.parse(Base64.decode(navContent))
 
       // Assumption: only a single resource room exists
       const newNavLinks = navContentObject.links.filter(link => link.resource_room !== true)
@@ -156,7 +155,7 @@ class ResourceRoom {
         ...navContentObject,
         links: newNavLinks,
       }
-      const newNavContent = base64.encode(yaml.stringify(newNavContentObject))
+      const newNavContent = Base64.encode(yaml.stringify(newNavContentObject))
       await nav.update(NAV_FILE_NAME, newNavContent, navSha)
 
       // Delete all resources and resourcePages

--- a/classes/Tree.js
+++ b/classes/Tree.js
@@ -1,6 +1,5 @@
 const Bluebird = require('bluebird')
 const yaml = require('yaml')
-const base64 = require('base-64')
 const _ = require('lodash')
 
 
@@ -33,7 +32,7 @@ class Tree {
             const IsomerNavFile = new File(this.accessToken, this.siteName)
             IsomerNavFile.setFileType(new DataType())
             const { content } = await IsomerNavFile.read('navigation.yml')
-            const navItems = yaml.parse(base64.decode(content)).links;
+            const navItems = yaml.parse(Base64.decode(content)).links;
 
             /**
              * The following function tokenizes the items 

--- a/routes/collectionPages.js
+++ b/routes/collectionPages.js
@@ -2,7 +2,6 @@ const express = require('express');
 const router = express.Router();
 const Bluebird = require('bluebird');
 const yaml = require('yaml');
-const base64 = require('base-64');
 const _ = require('lodash');
 
 // Import middleware
@@ -52,7 +51,7 @@ async function listCollectionPagesDetails(req, res, next) {
   const collectionPages = await CollectionPage.list()
   const collectionPagesMetadata = await Bluebird.map(collectionPages, async (page) => {
     const { content } = await readCollectionPageUtilFunc(accessToken, siteName, collectionName, page.fileName)
-    const frontMatter = yaml.parse(base64.decode(content).split('---')[1])
+    const frontMatter = yaml.parse(Base64.decode(content).split('---')[1])
     return {
       fileName: page.fileName,
       title: frontMatter.title,

--- a/routes/collections.js
+++ b/routes/collections.js
@@ -110,12 +110,13 @@ async function moveFiles (req, res, next) {
     await oldIsomerFile.delete(fileName, sha)
     if (targetSubfolderName || collectionSubfolderName) {
       // Modifying third nav in front matter, to be removed after template rewrite
-      const frontMatter = yaml.parse(base64.decode(content).split('---')[1])
+      const [ _, encodedFrontMatter, pageContent ] = Base64.decode(content).split('---')
+      const frontMatter = yaml.parse(encodedFrontMatter)
       if (targetSubfolderName) frontMatter.third_nav_title = deslugifyCollectionName(targetSubfolderName)
       else delete frontMatter.third_nav_title
       const newFrontMatter = yaml.stringify(frontMatter)
-      const newContent = ['---\n', newFrontMatter, '---'].join('')
-      const newEncodedContent = base64.encode(newContent)
+      const newContent = ['---\n', newFrontMatter, '---', pageContent].join('')
+      const newEncodedContent = Base64.encode(newContent)
       await newIsomerFile.create(fileName, newEncodedContent)
     } else {
       await newIsomerFile.create(fileName, content)

--- a/routes/collections.js
+++ b/routes/collections.js
@@ -2,7 +2,6 @@ const express = require('express');
 const router = express.Router();
 const Bluebird = require('bluebird')
 const yaml = require('yaml');
-const base64 = require('base-64');
 
 // Import middleware
 const { 

--- a/routes/homepage.js
+++ b/routes/homepage.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const router = express.Router();
-const base64 = require('base-64')
 
 // Import middleware
 const { 

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -3,7 +3,6 @@ const router = express.Router();
 const Bluebird = require('bluebird')
 const _ = require('lodash')
 const yaml = require('yaml')
-const base64 = require('base-64')
 
 // Import middleware
 const {   

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -160,11 +160,12 @@ async function moveUnlinkedPages (req, res, next) {
     await oldIsomerFile.delete(fileName, sha)
     if (targetSubfolderName) {
       // Adding third nav to front matter, to be removed after template rewrite
-      const frontMatter = yaml.parse(base64.decode(content).split('---')[1])
+      const [ _, encodedFrontMatter, pageContent ] = Base64.decode(content).split('---')
+      const frontMatter = yaml.parse(encodedFrontMatter)
       frontMatter.third_nav_title = deslugifyCollectionName(targetSubfolderName)
       const newFrontMatter = yaml.stringify(frontMatter)
-      const newContent = ['---\n', newFrontMatter, '---'].join('')
-      const newEncodedContent = base64.encode(newContent)
+      const newContent = ['---\n', newFrontMatter, '---', pageContent].join('')
+      const newEncodedContent = Base64.encode(newContent)
       await newIsomerFile.create(fileName, newEncodedContent)
     } else {
       await newIsomerFile.create(fileName, content)

--- a/routes/resourcePages.js
+++ b/routes/resourcePages.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const router = express.Router();
-const base64 = require('base-64');
 
 // Import middleware
 const {   
@@ -78,7 +77,7 @@ async function readResourcePage (req, res, next) {
   const resourcePageType = new ResourcePageType(resourceRoomName, resourceName)
   IsomerFile.setFileType(resourcePageType)
   const { sha, content: encodedContent } = await IsomerFile.read(pageName)
-  const content = base64.decode(encodedContent)
+  const content = Base64.decode(encodedContent)
 
   // TO-DO:
   // Validate content
@@ -101,7 +100,7 @@ async function updateResourcePage (req, res, next) {
     const IsomerFile = new File(accessToken, siteName)
     const resourcePageType = new ResourcePageType(resourceRoomName, resourceName)
     IsomerFile.setFileType(resourcePageType)
-    const { newSha } = await IsomerFile.update(pageName, base64.encode(pageContent), sha)
+    const { newSha } = await IsomerFile.update(pageName, Base64.encode(pageContent), sha)
 
     res.status(200).json({ resourceName, pageName, pageContent, sha: newSha })
 }
@@ -141,7 +140,7 @@ async function renameResourcePage (req, res, next) {
   const IsomerFile = new File(accessToken, siteName)
   const resourcePageType = new ResourcePageType(resourceRoomName, resourceName)
   IsomerFile.setFileType(resourcePageType)
-  const { sha: newSha } = await IsomerFile.create(newPageName, base64.encode(pageContent))
+  const { sha: newSha } = await IsomerFile.create(newPageName, Base64.encode(pageContent))
   await IsomerFile.delete(pageName, sha)
 
   res.status(200).json({ resourceName, pageName: newPageName, pageContent, sha: newSha })

--- a/utils/menu-utils.js
+++ b/utils/menu-utils.js
@@ -1,6 +1,5 @@
 const Bluebird = require('bluebird')
 const yaml = require('yaml')
-const base64 = require('base-64')
 const { File, CollectionPageType } = require('../classes/File')
 const { deslugifyCollectionPage } = require('./utils')
 
@@ -67,7 +66,7 @@ const thirdNavAggregator = async (collectionPages, CollectionFile, item) => {
     if (canCreateThirdnav) {
       // Retrieve third_nav_title from frontmatter in the thirdnav page - this is slow
       const { content } = await CollectionFile.read(collectionPage.fileName);
-      const frontMatter = yaml.parse(base64.decode(content).split('---')[1]);
+      const frontMatter = yaml.parse(Base64.decode(content).split('---')[1]);
       accumulator.push({
         title: frontMatter.third_nav_title,
         type: "thirdnav",


### PR DESCRIPTION
This PR changes the library used for encoding on the backend, standardising it on the `Base64` library. The other library used, `base-64` does not support encoding foreign language, hence users were experiencing difficulty saving resource files containing foreign language characters, as they were being encoded with `base-64`. 

Error message on backend logs:
<img width="1172" alt="Screenshot 2021-04-22 at 6 13 32 PM" src="https://user-images.githubusercontent.com/39231249/115827295-af3efb00-a43e-11eb-93ff-f10746197812.png">


Separately, this PR also fixes a bug where page content is not added to files moved to/ out of subfolders, which causes pages to appear blank after moving out of/ to a subfolder.

