### PR TITLE
feat: add whoami endpoint

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -39,6 +39,7 @@ const verifyJwt = (req, res, next) => {
 // Login and logout
 auth.get('/v1/auth', noVerify)
 auth.get('/v1/auth/logout', noVerify)
+auth.get('/v1/auth/whoami', verifyJwt)
 
 // Index
 auth.get('/v1', noVerify)

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -78,7 +78,25 @@ async function logout(req, res) {
   res.sendStatus(200)
 }
 
+async function whoami(req, res) {
+  const { accessToken } = req
+
+  // Make a call to github
+  const endpoint = 'https://api.github.com/user'
+
+  const resp = await axios.get(endpoint, {
+    headers: {
+      Authorization: `token ${accessToken}`,
+      "Content-Type": "application/json"
+    }
+  })
+
+  const { login: userId } = resp.data
+  res.status(200).json({ userId })
+}
+
 router.get('/', attachReadRouteHandlerWrapper(githubAuth));
 router.get('/logout', attachReadRouteHandlerWrapper(logout));
+router.get('/whoami', attachReadRouteHandlerWrapper(whoami));
 
 module.exports = router;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -66,7 +66,7 @@ async function githubAuth (req, res, next) {
 
   res.cookie(COOKIE_NAME, token, cookieSettings)
 
-  res.redirect(`${FRONTEND_URL}/auth#isomercms-${userId}`)
+  res.redirect(`${FRONTEND_URL}/sites`)
 }
 
 async function logout(req, res) {


### PR DESCRIPTION
This PR should be reviewed in conjunction with its [frontend PR](https://github.com/isomerpages/isomercms-frontend/pull/431). 

This PR adds an `/auth/whoami` endpoint that verifies the user's oauth token with GitHub and provides the CMS frontend with the `userId`.