### PR TITLE
fix: handles media folders not found error

### DIFF
--- a/routes/directory.js
+++ b/routes/directory.js
@@ -16,7 +16,12 @@ async function listDirectoryContent (req, res, next) {
     const IsomerDirectory = new Directory(accessToken, siteName)
     const folderType = new FolderType(decodedPath)
     IsomerDirectory.setDirType(folderType)
-    const directoryContents = await IsomerDirectory.list()
+    let directoryContents = []
+    try {
+        directoryContents = await IsomerDirectory.list()
+    } catch (err) {
+        console.log(err)
+    }
     res.status(200).json({ directoryContents })
 }
 


### PR DESCRIPTION
Currently, if a repo has no images and files folder, a 404 is thrown and the frontend is redirected. This PR catches the 404 and sends an empty directoryContent response to the frontend.