### PR TITLE
Fix/Return isPrivate property of repos in sites/route

### DIFF
--- a/routes/sites.js
+++ b/routes/sites.js
@@ -78,13 +78,15 @@ async function getSites (req, res, next) {
         const {
           updated_at,
           permissions,
-          name
+          name,
+          private
         } = repoData
 
         return {
           lastUpdated: timeDiff(updated_at),
           permissions,
           repoName: name,
+          isPrivate: private
         }
       }).filter((repoData) => repoData.permissions.push === true && !ISOMER_ADMIN_REPOS.includes(repoData.repoName))
   })


### PR DESCRIPTION
Allow front end to access isPrivate property of repo when calling sites/
Facilitate checking of whether raw image urls in public repos can be used instead of retrieving blob from backend