### PR TITLE
Fix: remove empty footer settings

### DIFF
--- a/classes/Settings.js
+++ b/classes/Settings.js
@@ -145,9 +145,29 @@ class Settings {
     }
 
     if (!_.isEmpty(footerSettings)) {
+      // We want to remove empty footer settings entirely so they don't show up in the actual site
+      const clonedFooterSettings = _.cloneDeep(footerSettings)
+      const clonedFooterContent = _.cloneDeep(footerContent)
+      Object.keys(footerSettings).forEach((setting) => {
+        if (setting === 'social_media') {
+          const socials = footerSettings[setting]
+          Object.keys(socials).forEach((social) => {
+            if (!socials[social]) {
+              delete clonedFooterSettings[setting][social]
+              delete clonedFooterContent[setting][social]
+            }
+          })
+        } else {
+          // Check for empty string because false value exists
+          if (footerSettings[setting] === '') {
+            delete clonedFooterSettings[setting]
+            delete clonedFooterContent[setting]
+          }
+        }
+      })
       settingsObj.footer = {
-        payload: footerSettings,
-        currentData: footerContent,
+        payload: clonedFooterSettings,
+        currentData: clonedFooterContent,
       }
     }
     

--- a/classes/Settings.js
+++ b/classes/Settings.js
@@ -94,6 +94,7 @@ class Settings {
       is_government: configContent.is_government,
       facebook_pixel: configContent['facebook-pixel'],
       google_analytics: configContent.google_analytics,
+      linkedin_insights: configContent['linkedin-insights'],
       resources_name: configContent.resources_name,
       colors: configContent.colors,
     }


### PR DESCRIPTION
This PR fixes an issue with the saving of empty fields. Currently, our template checks for the existence of fields in order to determine whether a certain part should be rendered, e.g. it checks for the existence of `feedback` to determine whether to render the feedback blurb inside contact-us. However, we are currently saving these fields as an empty string, which is interpreted as a valid link by our template. This PR fixes this by removing the relevant fields in the `footer.yml` file completely if they are updated to an empty string. 

Also, this PR additionally returns the value of the linkedin-insights for the settings endpoint.

To be reviewed in conjunction with PR#[496](https://github.com/isomerpages/isomercms-frontend/pull/496) on the isomercms frontend repo. Resolves https://github.com/isomerpages/isomercms-frontend/issues/486.