### PR TITLE
style: use `prettier` plugin instead of `prettier-recommended`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
     },
     "extends": [
         "airbnb-base",
-        "plugin:prettier/recommended"
+        "prettier"
     ],
     "parserOptions": {
         "ecmaVersion": 12


### PR DESCRIPTION
## Overview
This PR replaces the `plugin:prettier-recommended` with the original `prettier` plugin. 

This is because our config does not work with `plugin:prettier-recommended`. As explained in #127, our linting process is split into two: first we lint for code bugs with eslint, and then we fix code formatting issues with prettier. This works through `eslint-config-prettier` and `eslint-plugin-prettier`, which switches off the eslint rules related to code formatting, reserving them for prettier to fix.

The desired behavior when we run `npx eslint --fix .` is that all linting bugs are fixed, but formatting issues are ignored. However, we discovered that when we ran `npx eslint --fix .` with the `prettier-recommended` plugin, formatting issues were beign corrected as well. This is easily fixed by using the `prettier` plugin instead.