### PR TITLE
fix: address bug in directory route

### DIFF
--- a/routes/directory.js
+++ b/routes/directory.js
@@ -18,7 +18,14 @@ async function listDirectoryContent(req, res) {
   const folderType = new FolderType(decodedPath)
   IsomerDirectory.setDirType(folderType)
   let directoryContents = []
-  directoryContents = await IsomerDirectory.list()
+
+  // try catch should be removed during refactor
+  // .list() should return an empty array instead of throwing error
+  try {
+    directoryContents = await IsomerDirectory.list()
+  } catch (e) { // directory does not exist, catch error
+    console.log(e)
+  }
   return res.status(200).json({ directoryContents })
 }
 


### PR DESCRIPTION
This is a temporary fix for #196, wrapping the `IsomerDirectory.list()` method in a try-catch to prevent a 404 error from bubbling up when the directory does not exist. 

This should be fixed in the upcoming refactor in one of the following ways:
1) `IsomerDirectory.list()` should either return an empty array when it does not exist
2) The frontend should not expect to receive an empty array if the directory does not exist