### PR TITLE
style: add require path aliases to vscode

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+      "target": "es2017",
+      "allowSyntheticDefaultImports": false,
+      "jsx": "react",
+      "baseUrl": "./",
+      "paths": {
+        "@root/*": ["./*"],
+        "@classes/*": ["./classes/*"],
+        "@errors/*": ["./errors/*"],
+        "@logger/*": ["./logger/*"],
+        "@middleware/*": ["./middleware/*"],
+        "@routes/*": ["./routes/*"],
+        "@utils/*": ["./utils/*"]
+      }
+    },
+    "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
This PR adds path aliases to the jsconfig.json so that VS Code can understand our aliases and help us to autocomplete them.