### PR TITLE
vapt: pausing staging builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           prod = os.environ['PRODUCTION_BRANCH']
           staging = os.environ['STAGING_BRANCH']
           dev = os.environ['DEV_BRANCH']
-          if ref == prod or ref == staging or ref == dev:
+          if ref == prod:
             print('::set-output name=proceed::true')
           else:
             print('::set-output name=proceed::false')


### PR DESCRIPTION
This PR comments out the .github/workflow `ci.yml`'s instructions to build changes pushed to the staging branch.

This PR will be reverted at the end of VAPT. 