### PR TITLE
Revert "vapt: pausing staging builds"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           prod = os.environ['PRODUCTION_BRANCH']
           staging = os.environ['STAGING_BRANCH']
           dev = os.environ['DEV_BRANCH']
-          if ref == prod:
+          if ref == prod or ref == staging or ref == dev:
             print('::set-output name=proceed::true')
           else:
             print('::set-output name=proceed::false')


### PR DESCRIPTION
This reverts commit 75ea6492d250cb9413bac6a1f6354a5e9afff571. This PR is a duplicate of #218, which was rested as I erroneously made a merge commit instead of a squash and merge.