### PR TITLE
Fix: update path to netlify.toml

### DIFF
--- a/classes/NetlifyToml.js
+++ b/classes/NetlifyToml.js
@@ -16,7 +16,7 @@ class NetlifyToml {
   }
 
   async read() {
-    const endpoint = `https://api.github.com/repos/${GITHUB_BUILD_ORG_NAME}/${GITHUB_BUILD_REPO_NAME}/contents/netlify.toml`
+    const endpoint = `https://api.github.com/repos/${GITHUB_BUILD_ORG_NAME}/${GITHUB_BUILD_REPO_NAME}/contents/overrides/netlify.toml`
 
     const resp = await axios.get(endpoint, {
       validateStatus,


### PR DESCRIPTION
This PR fixes a bug where the netlify.toml file could not be found on our build repo, after the changes to the location of the build file.