### PR TITLE
test: e2e authentication scheme

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -11,6 +11,8 @@ export GITHUB_ORG_NAME="isomerpages"
 export GITHUB_BUILD_ORG_NAME="opengovsg"
 export GITHUB_BUILD_REPO_NAME="isomer-build"
 export MUTEX_TABLE_NAME=""
+export E2E_TEST_REPO="e2e-test-repo"
+export E2E_TEST_SECRET="blahblahblah"
 
 # Required to connect to DynamoDB
 export AWS_ACCESS_KEY_ID=""

--- a/.env-example
+++ b/.env-example
@@ -18,3 +18,8 @@ export E2E_TEST_GH_TOKEN=""
 # Required to connect to DynamoDB
 export AWS_ACCESS_KEY_ID=""
 export AWS_SECRET_ACCESS_KEY=""
+
+# Required to run end-to-end tests
+export E2E_TEST_REPO="e2e-test-repo"
+export E2E_TEST_SECRET=""
+export E2E_TEST_GH_TOKEN=""

--- a/.env-example
+++ b/.env-example
@@ -13,6 +13,7 @@ export GITHUB_BUILD_REPO_NAME="isomer-build"
 export MUTEX_TABLE_NAME=""
 export E2E_TEST_REPO="e2e-test-repo"
 export E2E_TEST_SECRET="blahblahblah"
+export E2E_TEST_GH_TOKEN=""
 
 # Required to connect to DynamoDB
 export AWS_ACCESS_KEY_ID=""

--- a/README
+++ b/README
@@ -1,0 +1,9 @@
+## E2E Tests
+To run the E2E tests successfully, you will need to define the following environment variables:
+```
+export E2E_TEST_REPO="e2e-test-repo"
+export E2E_TEST_SECRET="blahblahblah" // this should match the value of CYPRESS_COOKIE_VALUE on 
+// the frontend
+export E2E_TEST_GH_TOKEN="" // this can be your own personal GH access token, or  the token from our 
+// specialized E2E test user
+```

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -14,6 +14,7 @@ const auth = express.Router()
 
 const { E2E_TEST_REPO, E2E_TEST_SECRET, E2E_TEST_GH_TOKEN } = process.env
 const E2E_TEST_USER = "e2e-test"
+const ALLOWED_URLS = ["/v1/sites", "/v1/auth/whoami"]
 
 function noVerify(req, res, next) {
   next("router")
@@ -27,7 +28,7 @@ function verifyE2E(req) {
 
   if (isomercmsE2E) {
     if (isomercmsE2E !== E2E_TEST_SECRET) throw new AuthError(`Bad credentials`)
-    if (repo !== E2E_TEST_REPO || req.url === "/v1/sites")
+    if (!(repo === E2E_TEST_REPO || ALLOWED_URLS.includes(req.url)))
       throw new AuthError(`E2E tests can only access the ${E2E_TEST_REPO} repo`)
     isValidE2E = true
   }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -16,7 +16,7 @@ const auth = express.Router()
 
 const { E2E_TEST_REPO, E2E_TEST_SECRET, E2E_TEST_GH_TOKEN } = process.env
 const E2E_TEST_USER = "e2e-test"
-const ALLOWED_URLS = ["/v1/sites", "/v1/auth/whoami"]
+const GENERAL_ACCESS_PATHS = ["/v1/sites", "/v1/auth/whoami"]
 
 function noVerify(req, res, next) {
   next("router")
@@ -32,7 +32,7 @@ function verifyE2E(req) {
 
     // Throw an error if accessing a repo other than e2e-test-repo
     // Otherwise, allow access only to paths available to all users
-    if (!ALLOWED_URLS.includes(req.url)) {
+    if (!GENERAL_ACCESS_PATHS.includes(req.url)) {
       if (urlTokens.length >= 3) {
         const repo = urlTokens[3]
         if (repo !== E2E_TEST_REPO)


### PR DESCRIPTION
## Actionables
Add the following env vars for local testing:

```
export E2E_TEST_REPO="e2e-test-repo"
export E2E_TEST_SECRET="blahblahblah" // this should match the value of CYPRESS_COOKIE_VALUE on 
// the frontend
export E2E_TEST_GH_TOKEN="" // this can be your own personal GH access token, or  the token from our 
// specialized E2E test user
```

## Overview
Refer to PR #[600](https://github.com/isomerpages/isomercms-frontend/pull/600) on the backend for more details. 

This PR adds an alternative authentication scheme on the backend server by verifying a secret passed by the E2E frontend test user. This scheme also checks for the scope of the request to be the `e2e-test-repo` and a few whitelisted pages (`Sites`, `whoami`). If passed, the backend server attaches the `E2E_TEST_GH_TOKEN` to the request, and makes requests to GitHub using this user.