### PR TITLE
(hotfix to master) loosen request schema

### DIFF
--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -4,7 +4,7 @@ const FrontMatterSchema = Joi.object({
   title: Joi.string().required(),
   permalink: Joi.string().required(),
   third_nav_title: Joi.string(),
-})
+}).unknown(true)
 
 const ContentSchema = Joi.object({
   frontMatter: FrontMatterSchema.required(),


### PR DESCRIPTION
This PR fixes an issue with our existing schema for frontmatter - as we did not specify that unknown keys were allowed, existing pages which had additional parameters (e.g. breadcrumb) could not be modified. This PR fixes this issue by loosening our constraints on the frontmatter accepted.