### PR TITLE
refactor: unlinked pages

### DIFF
--- a/newroutes/__tests__/UnlinkedPages.spec.js
+++ b/newroutes/__tests__/UnlinkedPages.spec.js
@@ -1,0 +1,196 @@
+const express = require("express")
+const request = require("supertest")
+
+const { errorHandler } = require("@middleware/errorHandler")
+const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
+
+const { UnlinkedPagesRouter } = require("../unlinkedPages")
+
+describe("Unlinked Pages Router", () => {
+  const mockService = {
+    create: jest.fn(),
+    read: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    rename: jest.fn(),
+  }
+
+  const router = new UnlinkedPagesRouter({
+    unlinkedPageService: mockService,
+  })
+
+  const app = express()
+  app.use(express.json({ limit: "7mb" }))
+  app.use(express.urlencoded({ extended: false }))
+
+  // We can use read route handler here because we don't need to lock the repo
+  app.post(
+    "/:siteName/pages",
+    attachReadRouteHandlerWrapper(router.createUnlinkedPage)
+  )
+  app.get(
+    "/:siteName/pages/:pageName",
+    attachReadRouteHandlerWrapper(router.readUnlinkedPage)
+  )
+  app.post(
+    "/:siteName/pages/:pageName",
+    attachReadRouteHandlerWrapper(router.updateUnlinkedPage)
+  )
+  app.delete(
+    "/:siteName/pages/:pageName",
+    attachReadRouteHandlerWrapper(router.deleteUnlinkedPage)
+  )
+  app.use(errorHandler)
+
+  const siteName = "test-site"
+  const accessToken = undefined // Can't set request fields - will always be undefined
+  const fileName = "test-file"
+  const mockSha = "12345"
+  const mockContent = "mock-content"
+
+  const reqDetails = { siteName, accessToken }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("createUnlinkedPage", () => {
+    const createPageDetails = {
+      newFileName: "newFile",
+      content: {
+        pageBody: "test",
+        frontMatter: {
+          title: "fileTitle",
+          permalink: "file/permalink",
+        },
+      },
+    }
+
+    it("rejects create requests with invalid body", async () => {
+      await request(app).post(`/${siteName}/pages`).send({}).expect(400)
+    })
+
+    it("accepts valid unlinked page creation requests and returns the details of the file created", async () => {
+      const expectedServiceInput = {
+        fileName: createPageDetails.newFileName,
+        content: createPageDetails.content.pageBody,
+        frontMatter: createPageDetails.content.frontMatter,
+      }
+      await request(app)
+        .post(`/${siteName}/pages`)
+        .send(createPageDetails)
+        .expect(200)
+      expect(mockService.create).toHaveBeenCalledWith(
+        reqDetails,
+        expectedServiceInput
+      )
+    })
+  })
+
+  describe("readUnlinkedPage", () => {
+    mockService.read.mockResolvedValue({
+      sha: mockSha,
+      content: mockContent,
+    })
+
+    it("retrieves unlinked page details", async () => {
+      const expectedServiceInput = {
+        fileName,
+      }
+      await request(app).get(`/${siteName}/pages/${fileName}`).expect(200)
+      expect(mockService.read).toHaveBeenCalledWith(
+        reqDetails,
+        expectedServiceInput
+      )
+    })
+  })
+
+  describe("updateUnlinkedPage", () => {
+    const updatePageDetails = {
+      content: {
+        pageBody: "test",
+        frontMatter: {
+          title: "fileTitle",
+          permalink: "file/permalink",
+        },
+      },
+      sha: mockSha,
+    }
+    const renamePageDetails = {
+      ...updatePageDetails,
+      newFileName: "new-file",
+    }
+
+    it("rejects update requests with invalid body", async () => {
+      await request(app)
+        .post(`/${siteName}/pages/${fileName}`)
+        .send({})
+        .expect(400)
+    })
+
+    it("accepts valid unlinked page update requests and returns the details of the updated file", async () => {
+      const expectedServiceInput = {
+        fileName,
+        content: updatePageDetails.content.pageBody,
+        frontMatter: updatePageDetails.content.frontMatter,
+        sha: updatePageDetails.sha,
+      }
+      await request(app)
+        .post(`/${siteName}/pages/${fileName}`)
+        .send(updatePageDetails)
+        .expect(200)
+      expect(mockService.update).toHaveBeenCalledWith(
+        reqDetails,
+        expectedServiceInput
+      )
+    })
+
+    it("accepts valid unlinked page rename requests and returns the details of the renamed file", async () => {
+      const expectedServiceInput = {
+        oldFileName: fileName,
+        newFileName: renamePageDetails.newFileName,
+        content: renamePageDetails.content.pageBody,
+        frontMatter: renamePageDetails.content.frontMatter,
+        sha: renamePageDetails.sha,
+      }
+      await request(app)
+        .post(`/${siteName}/pages/${fileName}`)
+        .send(renamePageDetails)
+        .expect(200)
+      expect(mockService.rename).toHaveBeenCalledWith(
+        reqDetails,
+        expectedServiceInput
+      )
+    })
+  })
+
+  describe("deleteUnlinkedPage", () => {
+    const deletePageDetails = {
+      sha: mockSha,
+    }
+
+    it("rejects delete requests with invalid body", async () => {
+      await request(app)
+        .delete(`/${siteName}/pages/${fileName}`)
+        .send({})
+        .expect(400)
+    })
+
+    it("accepts valid unlinked page delete requests", async () => {
+      const expectedServiceInput = {
+        fileName,
+        sha: deletePageDetails.sha,
+      }
+      await request(app)
+        .delete(`/${siteName}/pages/${fileName}`)
+        .send(deletePageDetails)
+        .expect(200)
+      expect(mockService.delete).toHaveBeenCalledWith(
+        reqDetails,
+        expectedServiceInput
+      )
+    })
+  })
+
+  // TO-DO: Add listUnlinkedPages tests
+})

--- a/newroutes/unlinkedPages.js
+++ b/newroutes/unlinkedPages.js
@@ -1,0 +1,141 @@
+const autoBind = require("auto-bind")
+const express = require("express")
+
+// Import middleware
+const { BadRequestError } = require("@errors/BadRequestError")
+
+const {
+  attachReadRouteHandlerWrapper,
+  attachWriteRouteHandlerWrapper,
+  attachRollbackRouteHandlerWrapper,
+} = require("@middleware/routeHandler")
+
+const {
+  CreatePageRequestSchema,
+  UpdatePageRequestSchema,
+  DeletePageRequestSchema,
+} = require("@validators/RequestSchema")
+
+class UnlinkedPagesRouter {
+  constructor({ unlinkedPageService }) {
+    this.unlinkedPageService = unlinkedPageService
+    // We need to bind all methods because we don't invoke them from the class directly
+    autoBind(this)
+  }
+
+  async createUnlinkedPage(req, res) {
+    const { accessToken } = req
+
+    const { siteName } = req.params
+    const { error } = CreatePageRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error.message)
+    const {
+      content: { frontMatter, pageBody },
+      newFileName,
+    } = req.body
+    const createResp = await this.unlinkedPageService.create(
+      { siteName, accessToken },
+      {
+        fileName: newFileName,
+        content: pageBody,
+        frontMatter,
+      }
+    )
+
+    return res.status(200).json(createResp)
+  }
+
+  async readUnlinkedPage(req, res) {
+    const { accessToken } = req
+
+    const { siteName, pageName } = req.params
+    const { sha, content } = await this.unlinkedPageService.read(
+      { siteName, accessToken },
+      { fileName: pageName }
+    )
+
+    return res.status(200).json({ pageName, sha, content })
+  }
+
+  async updateUnlinkedPage(req, res) {
+    const { accessToken } = req
+
+    const { siteName, pageName } = req.params
+    const { error } = UpdatePageRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error)
+    const {
+      content: { frontMatter, pageBody },
+      sha,
+      newFileName,
+    } = req.body
+
+    let updateResp
+    if (newFileName) {
+      updateResp = await this.unlinkedPageService.rename(
+        { siteName, accessToken },
+        {
+          oldFileName: pageName,
+          newFileName,
+          content: pageBody,
+          frontMatter,
+          sha,
+        }
+      )
+    } else {
+      updateResp = await this.unlinkedPageService.update(
+        { siteName, accessToken },
+        {
+          fileName: pageName,
+          content: pageBody,
+          frontMatter,
+          sha,
+        }
+      )
+    }
+
+    return res.status(200).json(updateResp)
+  }
+
+  async deleteUnlinkedPage(req, res) {
+    const { accessToken } = req
+
+    const { siteName, pageName } = req.params
+    const { error } = DeletePageRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error)
+    const { sha } = req.body
+    await this.unlinkedPageService.delete(
+      { siteName, accessToken },
+      {
+        fileName: pageName,
+        sha,
+      }
+    )
+
+    return res.status(200).send("OK")
+  }
+
+  getRouter() {
+    const router = express.Router()
+
+    router.post(
+      "/:siteName/pages",
+      attachRollbackRouteHandlerWrapper(this.createUnlinkedPage)
+    )
+    router.get(
+      "/:siteName/pages/:pageName",
+      attachReadRouteHandlerWrapper(this.readUnlinkedPage)
+    )
+    router.post(
+      "/:siteName/pages/:pageName",
+      attachWriteRouteHandlerWrapper(this.updateUnlinkedPage)
+    )
+    router.delete(
+      "/:siteName/pages/:pageName",
+      attachRollbackRouteHandlerWrapper(this.deleteUnlinkedPage)
+    )
+
+    return router
+  }
+}
+
+module.exports = { UnlinkedPagesRouter }

--- a/server.js
+++ b/server.js
@@ -57,6 +57,9 @@ const {
   CollectionPageService,
 } = require("@services/fileServices/MdPageServices/CollectionPageService")
 const {
+  UnlinkedPageService,
+} = require("@services/fileServices/MdPageServices/UnlinkedPageService")
+const {
   CollectionYmlService,
 } = require("@services/fileServices/YmlFileServices/CollectionYmlService")
 const {
@@ -64,6 +67,7 @@ const {
 } = require("@services/fileServices/YmlFileServices/NavYmlService")
 
 const { CollectionPagesRouter } = require("./newroutes/collectionPages")
+const { UnlinkedPagesRouter } = require("./newroutes/unlinkedPages")
 
 const gitHubService = new GitHubService({ axiosInstance })
 const collectionYmlService = new CollectionYmlService({ gitHubService })
@@ -75,12 +79,17 @@ const subcollectionPageService = new SubcollectionPageService({
   gitHubService,
   collectionYmlService,
 })
+const unlinkedPageService = new UnlinkedPageService({ gitHubService })
+
 const collectionController = new CollectionController({
   collectionPageService,
   subcollectionPageService,
 })
 const collectionPagesV2Router = new CollectionPagesRouter({
   collectionController,
+})
+const unlinkedPagesRouter = new UnlinkedPagesRouter({
+  unlinkedPageService,
 })
 
 const app = express()
@@ -125,6 +134,7 @@ app.use("/v1/sites", navigationRouter)
 app.use("/v1/sites", netlifyTomlRouter)
 
 app.use("/v2/sites", collectionPagesV2Router.getRouter())
+app.use("/v2/sites", unlinkedPagesRouter.getRouter())
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => {

--- a/services/fileServices/MdPageServices/UnlinkedPageService.js
+++ b/services/fileServices/MdPageServices/UnlinkedPageService.js
@@ -1,0 +1,83 @@
+const {
+  retrieveDataFromMarkdown,
+  convertDataToMarkdown,
+} = require("@utils/markdown-utils")
+
+const UNLINKED_PAGES_DIRECTORY_NAME = "pages"
+
+class UnlinkedPageService {
+  constructor({ gitHubService }) {
+    this.gitHubService = gitHubService
+  }
+
+  async create(reqDetails, { fileName, content, frontMatter }) {
+    const newContent = convertDataToMarkdown(frontMatter, content)
+    const { sha } = await this.gitHubService.create(reqDetails, {
+      content: newContent,
+      fileName,
+      directoryName: UNLINKED_PAGES_DIRECTORY_NAME,
+    })
+    return { fileName, content: { frontMatter, pageBody: content }, sha }
+  }
+
+  async read(reqDetails, { fileName }) {
+    const { content: rawContent, sha } = await this.gitHubService.read(
+      reqDetails,
+      {
+        fileName,
+        directoryName: UNLINKED_PAGES_DIRECTORY_NAME,
+      }
+    )
+    const { frontMatter, pageContent } = retrieveDataFromMarkdown(rawContent)
+    return { fileName, content: { frontMatter, pageBody: pageContent }, sha }
+  }
+
+  async update(reqDetails, { fileName, content, frontMatter, sha }) {
+    const newContent = convertDataToMarkdown(frontMatter, content)
+    const { newSha } = await this.gitHubService.update(reqDetails, {
+      fileContent: newContent,
+      sha,
+      fileName,
+      directoryName: UNLINKED_PAGES_DIRECTORY_NAME,
+    })
+    return {
+      fileName,
+      content: { frontMatter, pageBody: content },
+      oldSha: sha,
+      newSha,
+    }
+  }
+
+  async delete(reqDetails, { fileName, sha }) {
+    return this.gitHubService.delete(reqDetails, {
+      sha,
+      fileName,
+      directoryName: UNLINKED_PAGES_DIRECTORY_NAME,
+    })
+  }
+
+  async rename(
+    reqDetails,
+    { oldFileName, newFileName, content, frontMatter, sha }
+  ) {
+    const newContent = convertDataToMarkdown(frontMatter, content)
+    await this.gitHubService.delete(reqDetails, {
+      sha,
+      fileName: oldFileName,
+      directoryName: UNLINKED_PAGES_DIRECTORY_NAME,
+    })
+    const { sha: newSha } = await this.gitHubService.create(reqDetails, {
+      content: newContent,
+      fileName: newFileName,
+      directoryName: UNLINKED_PAGES_DIRECTORY_NAME,
+    })
+    return {
+      fileName: newFileName,
+      content: { frontMatter, pageBody: content },
+      oldSha: sha,
+      newSha,
+    }
+  }
+}
+
+module.exports = { UnlinkedPageService }

--- a/services/fileServices/MdPageServices/UnlinkedPageService.js
+++ b/services/fileServices/MdPageServices/UnlinkedPageService.js
@@ -11,6 +11,8 @@ class UnlinkedPageService {
   }
 
   async create(reqDetails, { fileName, content, frontMatter }) {
+    // Ensure that third_nav_title is removed for files that are being moved from collections
+    delete frontMatter.third_nav_title
     const newContent = convertDataToMarkdown(frontMatter, content)
     const { sha } = await this.gitHubService.create(reqDetails, {
       content: newContent,

--- a/services/fileServices/MdPageServices/__tests__/UnlinkedPageService.spec.js
+++ b/services/fileServices/MdPageServices/__tests__/UnlinkedPageService.spec.js
@@ -1,0 +1,168 @@
+describe("Unlinked Page Service", () => {
+  const siteName = "test-site"
+  const accessToken = "test-token"
+  const fileName = "test-file"
+  const directoryName = "pages"
+  const mockContent = "test"
+  const mockMarkdownContent = "---test---"
+  const mockFrontMatter = {
+    title: "fileTitle",
+    permalink: "file/permalink",
+  }
+  const sha = "12345"
+
+  const reqDetails = { siteName, accessToken }
+
+  const mockGithubService = {
+    create: jest.fn(),
+    read: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  }
+
+  jest.mock("@utils/markdown-utils", () => ({
+    retrieveDataFromMarkdown: jest.fn().mockReturnValue({
+      frontMatter: mockFrontMatter,
+      pageContent: mockContent,
+    }),
+    convertDataToMarkdown: jest.fn().mockReturnValue(mockMarkdownContent),
+  }))
+  const {
+    UnlinkedPageService,
+  } = require("@services/fileServices/MdPageServices/UnlinkedPageService")
+  const service = new UnlinkedPageService({
+    gitHubService: mockGithubService,
+  })
+  const {
+    retrieveDataFromMarkdown,
+    convertDataToMarkdown,
+  } = require("@utils/markdown-utils")
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("Create", () => {
+    mockGithubService.create.mockReturnValue({ sha })
+    it("Creating pages works correctly", async () => {
+      await expect(
+        service.create(reqDetails, {
+          fileName,
+          content: mockContent,
+          frontMatter: mockFrontMatter,
+        })
+      ).resolves.toMatchObject({
+        fileName,
+        content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+        sha,
+      })
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        mockFrontMatter,
+        mockContent
+      )
+      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: mockMarkdownContent,
+        fileName,
+        directoryName,
+      })
+    })
+  })
+
+  describe("Read", () => {
+    mockGithubService.read.mockReturnValue({
+      content: mockMarkdownContent,
+      sha,
+    }),
+      it("Reading pages works correctly", async () => {
+        await expect(
+          service.read(reqDetails, { fileName })
+        ).resolves.toMatchObject({
+          fileName,
+          content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+          sha,
+        })
+        expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(
+          mockMarkdownContent
+        )
+        expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+          fileName,
+          directoryName,
+        })
+      })
+  })
+
+  describe("Update", () => {
+    const oldSha = "54321"
+    mockGithubService.update.mockReturnValue({ newSha: sha })
+    it("Updating page content works correctly", async () => {
+      await expect(
+        service.update(reqDetails, {
+          fileName,
+          content: mockContent,
+          frontMatter: mockFrontMatter,
+          sha: oldSha,
+        })
+      ).resolves.toMatchObject({
+        fileName,
+        content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+        oldSha,
+        newSha: sha,
+      })
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        mockFrontMatter,
+        mockContent
+      )
+      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+        fileName,
+        directoryName,
+        fileContent: mockMarkdownContent,
+        sha: oldSha,
+      })
+    })
+  })
+
+  describe("Delete", () => {
+    it("Deleting pages works correctly", async () => {
+      await expect(service.delete(reqDetails, { fileName, sha }))
+      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+        fileName,
+        directoryName,
+        sha,
+      })
+    })
+  })
+
+  describe("Rename", () => {
+    const oldSha = "54321"
+    const oldFileName = "test-old-file"
+    mockGithubService.create.mockReturnValue({ sha })
+    it("Renaming pages works correctly", async () => {
+      await expect(
+        service.rename(reqDetails, {
+          oldFileName,
+          newFileName: fileName,
+          content: mockContent,
+          frontMatter: mockFrontMatter,
+          sha: oldSha,
+        })
+      ).resolves.toMatchObject({
+        fileName,
+        content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+        oldSha,
+        newSha: sha,
+      })
+      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+        fileName: oldFileName,
+        directoryName,
+        sha: oldSha,
+      })
+      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: mockMarkdownContent,
+        fileName,
+        directoryName,
+      })
+    })
+  })
+
+  // TO-DO: Add tests for the list method
+})

--- a/services/fileServices/MdPageServices/__tests__/UnlinkedPageService.spec.js
+++ b/services/fileServices/MdPageServices/__tests__/UnlinkedPageService.spec.js
@@ -43,7 +43,7 @@ describe("Unlinked Page Service", () => {
   })
 
   describe("Create", () => {
-    mockGithubService.create.mockReturnValue({ sha })
+    mockGithubService.create.mockResolvedValue({ sha })
     it("Creating pages works correctly", async () => {
       await expect(
         service.create(reqDetails, {
@@ -69,7 +69,7 @@ describe("Unlinked Page Service", () => {
   })
 
   describe("Read", () => {
-    mockGithubService.read.mockReturnValue({
+    mockGithubService.read.mockResolvedValue({
       content: mockMarkdownContent,
       sha,
     }),
@@ -93,7 +93,7 @@ describe("Unlinked Page Service", () => {
 
   describe("Update", () => {
     const oldSha = "54321"
-    mockGithubService.update.mockReturnValue({ newSha: sha })
+    mockGithubService.update.mockResolvedValue({ newSha: sha })
     it("Updating page content works correctly", async () => {
       await expect(
         service.update(reqDetails, {
@@ -135,7 +135,7 @@ describe("Unlinked Page Service", () => {
   describe("Rename", () => {
     const oldSha = "54321"
     const oldFileName = "test-old-file"
-    mockGithubService.create.mockReturnValue({ sha })
+    mockGithubService.create.mockResolvedValue({ sha })
     it("Renaming pages works correctly", async () => {
       await expect(
         service.rename(reqDetails, {


### PR DESCRIPTION
This PR refactors the unlinked pages flow. 

It adds two main files and their tests:
- unlinked pages router
- unlinked pages service

### Details
The router contains the following endpoints:
 - POST `/sites/:siteName/pages` - create unlinked page
 - GET `/sites/:siteName/pages/:pageName` - read unlinked page
 - POST `/sites/:siteName/pages/:pageName` - update or rename unlinked page
 - DELETE `/sites/:siteName/pages/:pageName` - delete unlinked page

The service instance contains the following methods:
- create
- read
- update
- rename
- delete

### Note
The list method will be added in a subsequent PR because we will create a new UnlinkedDirectory service class for that.