### PR TITLE
refactor: settings v2 (BREAKING CHANGE)

### DIFF
--- a/fixtures/config.js
+++ b/fixtures/config.js
@@ -56,7 +56,21 @@ const configContent = {
 
 const configSha = "configsha"
 
+const configResponse = {
+  url: configContent.url,
+  title: configContent.title,
+  favicon: configContent.favicon,
+  shareicon: configContent.shareicon,
+  is_government: configContent.is_government,
+  facebook_pixel: configContent["facebook-pixel"],
+  google_analytics: configContent.google_analytics,
+  linkedin_insights: configContent["linkedin-insights"],
+  resources_name: configContent.resources_name,
+  colors: configContent.colors,
+}
+
 module.exports = {
   configContent,
   configSha,
+  configResponse,
 }

--- a/fixtures/config.js
+++ b/fixtures/config.js
@@ -1,6 +1,6 @@
 const configContent = {
   title: "abcdefg",
-  url: "",
+  url: "https://abc.gov.sg",
   favicon: "/images/isomer-logo.svg",
   colors: {
     "primary-color": "#d10404",

--- a/fixtures/config.js
+++ b/fixtures/config.js
@@ -120,6 +120,7 @@ const configSha = "configsha"
 const configResponse = {
   url: configContent.url,
   title: configContent.title,
+  description: configContent.description,
   favicon: configContent.favicon,
   shareicon: configContent.shareicon,
   is_government: configContent.is_government,

--- a/fixtures/config.js
+++ b/fixtures/config.js
@@ -1,4 +1,5 @@
 const rawConfigContent = `title: abcdefg
+description: "Brief site description here"
 url: https://abc.gov.sg
 favicon: /images/isomer-logo.svg
 colors:
@@ -61,6 +62,7 @@ linkedin-insights: "12345"
 
 const configContent = {
   title: "abcdefg",
+  description: "Brief site description here",
   url: "https://abc.gov.sg",
   favicon: "/images/isomer-logo.svg",
   colors: {

--- a/fixtures/config.js
+++ b/fixtures/config.js
@@ -16,7 +16,6 @@ colors:
       color: "#22b0c3"
     - title: media-color-five
       color: "#0b3033"
-description: An Isomer site of the Singapore Government
 permalink: none
 baseurl: ""
 exclude:
@@ -76,7 +75,6 @@ const configContent = {
       { title: "media-color-five", color: "#0b3033" },
     ],
   },
-  description: "An Isomer site of the Singapore Government",
   permalink: "none",
   baseurl: "",
   exclude: [

--- a/fixtures/config.js
+++ b/fixtures/config.js
@@ -1,0 +1,62 @@
+const configContent = {
+  title: "abcdefg",
+  url: "",
+  favicon: "/images/isomer-logo.svg",
+  colors: {
+    "primary-color": "#d10404",
+    "secondary-color": "#09b709",
+    "media-colors": [
+      { title: "media-color-one", color: "#162938" },
+      { title: "media-color-two", color: "#8a3ce0" },
+      { title: "media-color-three", color: "#18808d" },
+      { title: "media-color-four", color: "#22b0c3" },
+      { title: "media-color-five", color: "#0b3033" },
+    ],
+  },
+  description: "An Isomer site of the Singapore Government",
+  permalink: "none",
+  baseurl: "",
+  exclude: [
+    "travis-script.js",
+    ".travis.yml",
+    "README.md",
+    "package.json",
+    "package-lock.json",
+    "node_modules",
+    "vendor/bundle/",
+    "vendor/cache/",
+    "vendor/gems/",
+    "vendor/ruby/",
+    "Gemfile",
+    "Gemfile.lock",
+  ],
+  include: ["_redirects"],
+  defaults: [{ scope: { path: "" }, values: { layout: "page" } }],
+  custom_css_path: "/misc/custom.css",
+  custom_print_css_path: "/assets/css/print.css",
+  paginate: 12,
+  remote_theme: "isomerpages/isomerpages-template@next-gen",
+  safe: false,
+  plugins: [
+    "jekyll-feed",
+    "jekyll-assets",
+    "jekyll-paginate",
+    "jekyll-sitemap",
+    "jekyll-remote-theme",
+  ],
+  staging: "https://e2e-test-repo-staging.netlify.app",
+  prod: "https://e2e-test-repo-prod.netlify.app",
+  resources_name: "resources",
+  is_government: false,
+  shareicon: "/images/isomer-logo.svg",
+  "facebook-pixel": "true",
+  google_analytics: "UA-39345131-33",
+  "linkedin-insights": "12345",
+}
+
+const configSha = "configsha"
+
+module.exports = {
+  configContent,
+  configSha,
+}

--- a/fixtures/config.js
+++ b/fixtures/config.js
@@ -1,3 +1,64 @@
+const rawConfigContent = `title: abcdefg
+url: https://abc.gov.sg
+favicon: /images/isomer-logo.svg
+colors:
+  primary-color: "#d10404"
+  secondary-color: "#09b709"
+  media-colors:
+    - title: media-color-one
+      color: "#162938"
+    - title: media-color-two
+      color: "#8a3ce0"
+    - title: media-color-three
+      color: "#18808d"
+    - title: media-color-four
+      color: "#22b0c3"
+    - title: media-color-five
+      color: "#0b3033"
+description: An Isomer site of the Singapore Government
+permalink: none
+baseurl: ""
+exclude:
+  - travis-script.js
+  - .travis.yml
+  - README.md
+  - package.json
+  - package-lock.json
+  - node_modules
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  - Gemfile
+  - Gemfile.lock
+include:
+  - _redirects
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: page
+custom_css_path: /misc/custom.css
+custom_print_css_path: /assets/css/print.css
+paginate: 12
+remote_theme: isomerpages/isomerpages-template@next-gen
+safe: false
+plugins:
+  - jekyll-feed
+  - jekyll-assets
+  - jekyll-paginate
+  - jekyll-sitemap
+  - jekyll-remote-theme
+staging: https://e2e-test-repo-staging.netlify.app
+prod: https://e2e-test-repo-prod.netlify.app
+resources_name: resources
+is_government: false
+shareicon: /images/isomer-logo.svg
+facebook-pixel: "true"
+google_analytics: UA-39345131-33
+linkedin-insights: "12345"
+`
+
 const configContent = {
   title: "abcdefg",
   url: "https://abc.gov.sg",
@@ -73,4 +134,5 @@ module.exports = {
   configContent,
   configSha,
   configResponse,
+  rawConfigContent,
 }

--- a/fixtures/config.js
+++ b/fixtures/config.js
@@ -1,5 +1,5 @@
 const rawConfigContent = `title: abcdefg
-description: "Brief site description here"
+description: Brief site description here
 url: https://abc.gov.sg
 favicon: /images/isomer-logo.svg
 colors:

--- a/fixtures/footer.js
+++ b/fixtures/footer.js
@@ -1,3 +1,15 @@
+const rawFooterContent = `show_reach: true
+feedback: www.feedbacktest.com/hihi
+faq: /faqpagetest/hihi
+social_media:
+  facebook: https://www.facebook.com/testfbnow
+  twitter: https://www.twitter.com/testtwitternow
+  youtube: https://www.youtube.com/testyoutubenow
+  instagram: https://www.instagram.com/testinstanow
+  linkedin: https://www.linkedin.com/company/testagencynow
+contact_us: astast
+`
+
 const footerContent = {
   show_reach: true,
   feedback: "www.feedbacktest.com/hihi",
@@ -22,4 +34,5 @@ module.exports = {
   footerContent,
   footerSha,
   footerResponse,
+  rawFooterContent,
 }

--- a/fixtures/footer.js
+++ b/fixtures/footer.js
@@ -14,7 +14,12 @@ const footerContent = {
 
 const footerSha = "footerSha"
 
+const footerResponse = {
+  ...footerContent,
+}
+
 module.exports = {
   footerContent,
   footerSha,
+  footerResponse,
 }

--- a/fixtures/footer.js
+++ b/fixtures/footer.js
@@ -1,0 +1,20 @@
+const footerContent = {
+  show_reach: true,
+  feedback: "www.feedbacktest.com/hihi",
+  faq: "/faqpagetest/hihi",
+  social_media: {
+    facebook: "https://www.facebook.com/testfbnow",
+    twitter: "https://www.twitter.com/testtwitternow",
+    youtube: "https://www.youtube.com/testyoutubenow",
+    instagram: "https://www.instagram.com/testinstanow",
+    linkedin: "https://www.linkedin.com/company/testagencynow",
+  },
+  contact_us: "astast",
+}
+
+const footerSha = "footerSha"
+
+module.exports = {
+  footerContent,
+  footerSha,
+}

--- a/fixtures/homepage.js
+++ b/fixtures/homepage.js
@@ -1,3 +1,36 @@
+const rawHomepageContent = `---
+layout: homepage
+title: abcdefg
+description: Brief site description here
+image: /images/isomer-logo.svg
+permalink: /
+notification: Here's a notification bar you can use!
+sections:
+  - hero:
+      title: Hero titlZZZZ
+      subtitle: Hero subtitle
+      background: /images/hero-banner.png
+      button: Contact Us
+      url: /contact-us/
+      key_highlights:
+        - title: Highlight A
+          description: Important highlight A is important
+          url: https://google.com
+        - title: Highlight B
+          description: Important highlight B is equally important
+          url: https://gmail.com
+        - title: Page A
+          description: Page A is important too
+          url: /privacy/
+  - infobar:
+      title: Infobar title
+      subtitle: Subtitle
+      description: About a sentence worth of description here
+      button: Button text
+      url: /faq/
+---
+`
+
 const homepageContent = {
   frontMatter: {
     layout: "homepage",
@@ -44,7 +77,7 @@ const homepageContent = {
       },
     ],
   },
-  pageBody: "\n\n\n\n\n\n\n\n\n\n\n\n",
+  pageBody: "\n",
 }
 
 const homepageSha = "homepageSha"
@@ -52,4 +85,5 @@ const homepageSha = "homepageSha"
 module.exports = {
   homepageContent,
   homepageSha,
+  rawHomepageContent,
 }

--- a/fixtures/homepage.js
+++ b/fixtures/homepage.js
@@ -1,0 +1,55 @@
+const homepageContent = {
+  frontMatter: {
+    layout: "homepage",
+    title: "abcdefg",
+    description: "Brief site description here",
+    image: "/images/isomer-logo.svg",
+    permalink: "/",
+    notification: "Here's a notification bar you can use!",
+    sections: [
+      {
+        hero: {
+          title: "Hero titlZZZZ",
+          subtitle: "Hero subtitle",
+          background: "/images/hero-banner.png",
+          button: "Contact Us",
+          url: "/contact-us/",
+          key_highlights: [
+            {
+              title: "Highlight A",
+              description: "Important highlight A is important",
+              url: "https://google.com",
+            },
+            {
+              title: "Highlight B",
+              description: "Important highlight B is equally important",
+              url: "https://gmail.com",
+            },
+            {
+              title: "Page A",
+              description: "Page A is important too",
+              url: "/privacy/",
+            },
+          ],
+        },
+      },
+      {
+        infobar: {
+          title: "Infobar title",
+          subtitle: "Subtitle",
+          description: "About a sentence worth of description here",
+          button: "Button text",
+          url: "/faq/",
+        },
+      },
+    ],
+  },
+  pageBody: "\n\n\n\n\n\n\n\n\n\n\n\n",
+}
+
+const homepageSha = "homepageSha"
+
+module.exports = {
+  homepageContent,
+  homepageSha,
+}

--- a/fixtures/navigation.js
+++ b/fixtures/navigation.js
@@ -13,7 +13,12 @@ const navigationContent = {
 
 const navigationSha = "navigationSha"
 
+const navigationResponse = {
+  logo: navigationContent.logo,
+}
+
 module.exports = {
   navigationContent,
   navigationSha,
+  navigationResponse,
 }

--- a/fixtures/navigation.js
+++ b/fixtures/navigation.js
@@ -1,0 +1,19 @@
+const navigationContent = {
+  logo: "/images/favicon-isomer.ico",
+  links: [
+    { title: "Contact Us", url: "/contact-us/" },
+    { title: "Test", url: "/Test/" },
+    { title: "Resources", resource_room: true },
+    {
+      title: "Test Folder Title No Pages",
+      collection: "test-folder-title-no-pages",
+    },
+  ],
+}
+
+const navigationSha = "navigationSha"
+
+module.exports = {
+  navigationContent,
+  navigationSha,
+}

--- a/fixtures/navigation.js
+++ b/fixtures/navigation.js
@@ -1,3 +1,15 @@
+const rawNavigationContent = `logo: /images/favicon-isomer.ico
+links:
+  - title: Contact Us
+    url: /contact-us/
+  - title: Test
+    url: /Test/
+  - title: Resources
+    resource_room: true
+  - title: Test Folder Title No Pages
+    collection: test-folder-title-no-pages
+`
+
 const navigationContent = {
   logo: "/images/favicon-isomer.ico",
   links: [
@@ -21,4 +33,5 @@ module.exports = {
   navigationContent,
   navigationSha,
   navigationResponse,
+  rawNavigationContent,
 }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -270,6 +270,10 @@ auth.post(
 auth.get("/v1/sites/:siteName/settings", verifyJwt)
 auth.post("/v1/sites/:siteName/settings", verifyJwt)
 
+// New settings
+auth.get("/v2/sites/:siteName/settings", verifyJwt)
+auth.post("/v2/sites/:siteName/settings", verifyJwt)
+
 // Navigation
 auth.get("/v1/sites/:siteName/navigation", verifyJwt)
 auth.post("/v1/sites/:siteName/navigation", verifyJwt)

--- a/newroutes/__tests__/Settings.spec.js
+++ b/newroutes/__tests__/Settings.spec.js
@@ -1,0 +1,133 @@
+const express = require("express")
+const request = require("supertest")
+
+const { errorHandler } = require("@middleware/errorHandler")
+const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
+
+const { configContent, configSha } = require("../../fixtures/config")
+const { footerContent, footerSha } = require("../../fixtures/footer")
+const { homepageContent, homepageSha } = require("../../fixtures/homepage")
+const {
+  navigationContent,
+  navigationSha,
+} = require("../../fixtures/navigation")
+const { SettingsRouter } = require("../settings.js")
+
+describe("Settings Router", () => {
+  const mockConfigYmlService = {
+    read: jest.fn(),
+    update: jest.fn(),
+  }
+
+  const mockFooterYmlService = {
+    read: jest.fn(),
+    update: jest.fn(),
+  }
+
+  const mockNavYmlService = {
+    read: jest.fn(),
+    update: jest.fn(),
+  }
+
+  const mockHomepagePageService = {
+    read: jest.fn(),
+    update: jest.fn(),
+  }
+
+  const router = new SettingsRouter({
+    homepagePageService: mockHomepagePageService,
+    configYmlService: mockConfigYmlService,
+    footerYmlService: mockFooterYmlService,
+    navYmlService: mockNavYmlService,
+  })
+
+  const app = express()
+  app.use(express.json({ limit: "7mb" }))
+  app.use(express.urlencoded({ extended: false }))
+  app.get(
+    "/:siteName/settings",
+    attachReadRouteHandlerWrapper(router.readSettingsPage)
+  )
+  app.post(
+    "/:siteName/settings",
+    attachReadRouteHandlerWrapper(router.updateSettingsPage)
+  )
+  app.use(errorHandler)
+
+  const siteName = "test-site"
+
+  const config = {
+    content: configContent,
+    sha: configSha,
+  }
+  const footer = {
+    content: footerContent,
+    sha: footerSha,
+  }
+  const navigation = {
+    content: navigationContent,
+    sha: navigationSha,
+  }
+  const homepage = {
+    content: homepageContent,
+    sha: homepageSha,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("readSettingsPage", () => {
+    mockConfigYmlService.read.mockResolvedValue(config)
+    mockFooterYmlService.read.mockResolvedValue(footer)
+    mockNavYmlService.read.mockResolvedValue(navigation)
+
+    it("retrieves settings data", async () => {
+      const resp = await request(app).get(`/${siteName}/settings`).expect(200)
+    })
+  })
+
+  describe("updateSettingsPage", () => {
+    mockConfigYmlService.read.mockResolvedValue(config)
+    mockFooterYmlService.read.mockResolvedValue(footer)
+    mockNavYmlService.read.mockResolvedValue(navigation)
+    mockHomepagePageService.read.mockResolvedValue(homepage)
+
+    // come up with merged data - for e.g. expect the navYmlService to not be called at all
+    // if no  changes to nav
+    it("updates only config data if non-title config field is updated", async () => {
+      const resp = await request(app)
+        .post(`/${siteName}/settings`)
+        .send()
+        .expect(200)
+    })
+
+    it("updates both homepage and config data when only title field is updated", async () => {
+      const resp = await request(app)
+        .post(`/${siteName}/settings`)
+        .send()
+        .expect(200)
+    })
+
+    it("updates only footer data when only footer fields are updated", async () => {
+      const resp = await request(app)
+        .post(`/${siteName}/settings`)
+        .send()
+        .expect(200)
+    })
+
+    it("updates only navigation data when only navigation fields are updated", async () => {
+      const resp = await request(app)
+        .post(`/${siteName}/settings`)
+        .send()
+        .expect(200)
+    })
+
+    it("updates config, homepage, navigation, and footer data when all fields are updated", async () => {
+      const resp = await request(app)
+        .post(`/${siteName}/settings`)
+        .send()
+        .expect(200)
+    })
+  })
+})

--- a/newroutes/__tests__/Settings.spec.js
+++ b/newroutes/__tests__/Settings.spec.js
@@ -4,12 +4,21 @@ const request = require("supertest")
 const { errorHandler } = require("@middleware/errorHandler")
 const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
 
-const { configContent, configSha } = require("../../fixtures/config")
-const { footerContent, footerSha } = require("../../fixtures/footer")
+const {
+  configContent,
+  configSha,
+  configResponse,
+} = require("../../fixtures/config")
+const {
+  footerContent,
+  footerSha,
+  footerResponse,
+} = require("../../fixtures/footer")
 const { homepageContent, homepageSha } = require("../../fixtures/homepage")
 const {
   navigationContent,
   navigationSha,
+  navigationResponse,
 } = require("../../fixtures/navigation")
 const { SettingsRouter } = require("../settings.js")
 
@@ -83,7 +92,16 @@ describe("Settings Router", () => {
     mockNavYmlService.read.mockResolvedValue(navigation)
 
     it("retrieves settings data", async () => {
+      const expectedResponse = {
+        configSettings: configResponse,
+        footerSettings: footerContent,
+        navigationSettings: navigationResponse,
+      }
       const resp = await request(app).get(`/${siteName}/settings`).expect(200)
+      expect(resp.body).toStrictEqual(expectedResponse)
+      expect(mockConfigYmlService.read).toHaveBeenCalled()
+      expect(mockFooterYmlService.read).toHaveBeenCalled()
+      expect(mockNavYmlService.read).toHaveBeenCalled()
     })
   })
 
@@ -95,39 +113,39 @@ describe("Settings Router", () => {
 
     // come up with merged data - for e.g. expect the navYmlService to not be called at all
     // if no  changes to nav
-    it("updates only config data if non-title config field is updated", async () => {
-      const resp = await request(app)
-        .post(`/${siteName}/settings`)
-        .send()
-        .expect(200)
-    })
+    // it("updates only config data if non-title config field is updated", async () => {
+    //   const resp = await request(app)
+    //     .post(`/${siteName}/settings`)
+    //     .send()
+    //     .expect(200)
+    // })
 
-    it("updates both homepage and config data when only title field is updated", async () => {
-      const resp = await request(app)
-        .post(`/${siteName}/settings`)
-        .send()
-        .expect(200)
-    })
+    // it("updates both homepage and config data when only title field is updated", async () => {
+    //   const resp = await request(app)
+    //     .post(`/${siteName}/settings`)
+    //     .send()
+    //     .expect(200)
+    // })
 
-    it("updates only footer data when only footer fields are updated", async () => {
-      const resp = await request(app)
-        .post(`/${siteName}/settings`)
-        .send()
-        .expect(200)
-    })
+    // it("updates only footer data when only footer fields are updated", async () => {
+    //   const resp = await request(app)
+    //     .post(`/${siteName}/settings`)
+    //     .send()
+    //     .expect(200)
+    // })
 
-    it("updates only navigation data when only navigation fields are updated", async () => {
-      const resp = await request(app)
-        .post(`/${siteName}/settings`)
-        .send()
-        .expect(200)
-    })
+    // it("updates only navigation data when only navigation fields are updated", async () => {
+    //   const resp = await request(app)
+    //     .post(`/${siteName}/settings`)
+    //     .send()
+    //     .expect(200)
+    // })
 
-    it("updates config, homepage, navigation, and footer data when all fields are updated", async () => {
-      const resp = await request(app)
-        .post(`/${siteName}/settings`)
-        .send()
-        .expect(200)
-    })
+    // it("updates config, homepage, navigation, and footer data when all fields are updated", async () => {
+    //   const resp = await request(app)
+    //     .post(`/${siteName}/settings`)
+    //     .send()
+    //     .expect(200)
+    // })
   })
 })

--- a/newroutes/__tests__/Settings.spec.js
+++ b/newroutes/__tests__/Settings.spec.js
@@ -85,9 +85,9 @@ describe("Settings Router", () => {
 
     it("retrieves settings data", async () => {
       const expectedResponse = {
-        configSettings: configResponse,
-        footerSettings: footerResponse,
-        navigationSettings: navigationResponse,
+        ...configResponse,
+        ...footerResponse,
+        ...navigationResponse,
       }
       const resp = await request(app).get(`/${siteName}/settings`).expect(200)
       expect(resp.body).toStrictEqual(expectedResponse)
@@ -108,18 +108,12 @@ describe("Settings Router", () => {
     const updatedFaq = `${footerContent.faq}test`
     const updatedLogo = `${navigationContent.logo}test`
 
-    it("rejects requests with invalid body", async () => {
-      await request(app).post(`/${siteName}/settings`).send({}).expect(400)
-    })
-
     it("successfully updates settings", async () => {
       const requestObject = {
-        configSettings: {
-          title: updatedTitleValue,
-          "facebook-pixel": updatedFbPixelValue,
-        },
-        footerSettings: { faq: updatedFaq },
-        navigationSettings: { logo: updatedLogo },
+        title: updatedTitleValue,
+        "facebook-pixel": updatedFbPixelValue,
+        faq: updatedFaq,
+        logo: updatedLogo,
       }
 
       await request(app)

--- a/newroutes/settings.js
+++ b/newroutes/settings.js
@@ -35,9 +35,9 @@ class SettingsRouter {
     } = await this.settingsService.retrieveSettingsFiles(reqDetails)
 
     return res.status(200).json({
-      configSettings: SettingsService.extractConfigFields(config),
-      footerSettings: SettingsService.extractFooterFields(footer),
-      navigationSettings: SettingsService.extractNavFields(navigation),
+      ...SettingsService.extractConfigFields(config),
+      ...SettingsService.extractFooterFields(footer),
+      ...SettingsService.extractNavFields(navigation),
     })
   }
 
@@ -58,11 +58,12 @@ class SettingsRouter {
     } = await this.settingsService.retrieveSettingsFiles(reqDetails, true)
 
     // extract data
+    const settings = body
     const {
-      configSettings: updatedConfigContent,
-      footerSettings: updatedFooterContent,
-      navigationSettings: updatedNavigationContent,
-    } = body
+      configContent: updatedConfigContent,
+      footerContent: updatedFooterContent,
+      navigationContent: updatedNavigationContent,
+    } = SettingsService.retrieveSettingsFields(settings)
 
     await this.settingsService.updateSettingsFiles({
       reqDetails,

--- a/newroutes/settings.js
+++ b/newroutes/settings.js
@@ -103,7 +103,10 @@ class SettingsRouter {
       })
 
       // update homepage title only if necessary
-      if (config.content.title !== updatedConfigContent.title) {
+      if (
+        updatedConfigContent.title &&
+        config.content.title !== updatedConfigContent.title
+      ) {
         const updatedHomepageFrontMatter = _.cloneDeep(
           homepage.content.frontMatter
         )

--- a/newroutes/settings.js
+++ b/newroutes/settings.js
@@ -1,0 +1,83 @@
+const autoBind = require("auto-bind")
+const Bluebird = require("bluebird")
+const express = require("express")
+
+const { BadRequestError } = require("@errors/BadRequestError")
+
+// Import middleware
+const {
+  attachReadRouteHandlerWrapper,
+  attachRollbackRouteHandlerWrapper,
+} = require("@middleware/routeHandler")
+
+const extractRequiredConfigFields = (config) => ({
+  url: config.url,
+  title: config.title,
+  favicon: config.favicon,
+  shareicon: config.shareicon,
+  is_government: config.is_government,
+  facebook_pixel: config["facebook-pixel"],
+  google_analytics: config.google_analytics,
+  linkedin_insights: config["linkedin-insights"],
+  resources_name: config.resources_name,
+  colors: config.colors,
+})
+
+class SettingsRouter {
+  constructor({ configYmlService, footerYmlService, navYmlService }) {
+    this.configYmlService = configYmlService
+    this.footerYmlService = footerYmlService
+    this.navYmlService = navYmlService
+    // We need to bind all methods because we don't invoke them from the class directly
+    autoBind(this)
+  }
+
+  async readSettingsPage(req, res) {
+    const { accessToken } = req
+    const { siteName } = req.params
+    const reqDetails = { siteName, accessToken }
+
+    const [config, footer, navigation] = await Bluebird.map(
+      [
+        this.configYmlService.read(reqDetails),
+        this.footerYmlService.read(reqDetails),
+        this.navYmlService.read(reqDetails),
+      ],
+      async (fileOp) => await fileOp
+    )
+
+    // retrieve only the relevant config and index fields
+    const configFieldsRequired = extractRequiredConfigFields(config.content)
+
+    // retrieve footer sha since we are sending the footer object wholesale
+    const footerSha = footer.sha
+
+    return res.status(200).json({
+      settings: {
+        configFieldsRequired,
+        footerContent: footer.content,
+        navigationContent: { logo: navigation.content.logo },
+        footerSha,
+      },
+    })
+  }
+
+  async updateSettingsPage(req, res) {}
+
+  getRouter() {
+    const router = express.Router()
+
+    router.get(
+      "/:siteName/settings",
+      attachReadRouteHandlerWrapper(this.readSettingsPage)
+    )
+    router.post(
+      "/:siteName/settings",
+      attachRollbackRouteHandlerWrapper(this.updateSettingsPage)
+    )
+
+    return router
+  }
+}
+
+module.exports = { SettingsRouter }

--- a/newroutes/settings.js
+++ b/newroutes/settings.js
@@ -1,5 +1,4 @@
 const autoBind = require("auto-bind")
-const Bluebird = require("bluebird")
 const express = require("express")
 const _ = require("lodash")
 
@@ -13,53 +12,9 @@ const {
 
 const { UpdateSettingsRequestSchema } = require("@validators/RequestSchema")
 
-const shouldUpdateHomepage = (updatedConfigContent, configContent) => {
-  if (
-    (updatedConfigContent.title &&
-      configContent.title !== updatedConfigContent.title) ||
-    (updatedConfigContent.description &&
-      configContent.description !== updatedConfigContent.description)
-  )
-    return true
-  return false
-}
-const extractConfigFields = (config) => ({
-  url: config.content.url,
-  description: config.content.description,
-  title: config.content.title,
-  favicon: config.content.favicon,
-  shareicon: config.content.shareicon,
-  is_government: config.content.is_government,
-  facebook_pixel: config.content["facebook-pixel"],
-  google_analytics: config.content.google_analytics,
-  linkedin_insights: config.content["linkedin-insights"],
-  resources_name: config.content.resources_name,
-  colors: config.content.colors,
-})
-const extractFooterFields = (footer) => footer.content
-const extractNavFields = (navigation) => ({
-  logo: navigation.content.logo,
-})
-
-const mergeUpdatedData = (currentData, updatedData) => {
-  const clonedCurrentData = _.cloneDeep(currentData)
-  Object.keys(updatedData).forEach((field) => {
-    clonedCurrentData[field] = updatedData[field]
-  })
-  return clonedCurrentData
-}
-
 class SettingsRouter {
-  constructor({
-    configYmlService,
-    footerYmlService,
-    navYmlService,
-    homepagePageService,
-  }) {
-    this.configYmlService = configYmlService
-    this.footerYmlService = footerYmlService
-    this.navYmlService = navYmlService
-    this.homepagePageService = homepagePageService
+  constructor({ settingsService }) {
+    this.settingsService = settingsService
     // We need to bind all methods because we don't invoke them from the class directly
     autoBind(this)
   }
@@ -69,14 +24,16 @@ class SettingsRouter {
     const { siteName } = req.params
     const reqDetails = { siteName, accessToken }
 
-    const { config, footer, navigation } = await this.retrieveSettingsFiles(
-      reqDetails
-    )
+    const {
+      config,
+      footer,
+      navigation,
+    } = await this.settingsService.retrieveSettingsFiles(reqDetails)
 
     return res.status(200).json({
-      configSettings: extractConfigFields(config),
-      footerSettings: extractFooterFields(footer),
-      navigationSettings: extractNavFields(navigation),
+      configSettings: this.settingsService.extractConfigFields(config),
+      footerSettings: this.settingsService.extractFooterFields(footer),
+      navigationSettings: this.settingsService.extractNavFields(navigation),
     })
   }
 
@@ -94,7 +51,7 @@ class SettingsRouter {
       footer,
       navigation,
       homepage,
-    } = await this.retrieveSettingsFiles(reqDetails, true)
+    } = await this.settingsService.retrieveSettingsFiles(reqDetails, true)
 
     // extract data
     const {
@@ -103,81 +60,17 @@ class SettingsRouter {
       navigationSettings: updatedNavigationContent,
     } = body
 
-    if (!_.isEmpty(updatedConfigContent)) {
-      const mergedConfigContent = mergeUpdatedData(
-        config.content,
-        updatedConfigContent
-      )
-      await this.configYmlService.update(reqDetails, {
-        fileContent: mergedConfigContent,
-        sha: config.sha,
-      })
-
-      // update homepage title only if necessary
-      if (shouldUpdateHomepage(updatedConfigContent, config.content)) {
-        const updatedHomepageFrontMatter = _.cloneDeep(
-          homepage.content.frontMatter
-        )
-        updatedHomepageFrontMatter.title = updatedConfigContent.title
-        updatedHomepageFrontMatter.description =
-          updatedConfigContent.description
-        await this.homepagePageService.update(reqDetails, {
-          content: homepage.content.pageBody,
-          frontMatter: updatedHomepageFrontMatter,
-          sha: homepage.sha,
-        })
-      }
-    }
-
-    if (!_.isEmpty(updatedFooterContent)) {
-      const mergedFooterContent = mergeUpdatedData(
-        footer.content,
-        updatedFooterContent
-      )
-      await this.footerYmlService.update(reqDetails, {
-        fileContent: mergedFooterContent,
-        sha: footer.sha,
-      })
-    }
-
-    if (!_.isEmpty(updatedNavigationContent)) {
-      const mergedNavigationContent = mergeUpdatedData(
-        navigation.content,
-        updatedNavigationContent
-      )
-      await this.navYmlService.update(reqDetails, {
-        fileContent: mergedNavigationContent,
-        sha: navigation.sha,
-      })
-    }
-
-    return res.status(200).send("OK")
-  }
-
-  async retrieveSettingsFiles(reqDetails, shouldRetrieveHomepage) {
-    const fileRetrievalObj = {
-      config: this.configYmlService.read(reqDetails),
-      footer: this.footerYmlService.read(reqDetails),
-      navigation: this.navYmlService.read(reqDetails),
-      homepage: this.homepagePageService.read(reqDetails),
-    }
-
-    const [config, footer, navigation, homepage] = await Bluebird.map(
-      Object.keys(fileRetrievalObj),
-      async (fileOpKey) => {
-        if (fileOpKey === "homepage" && !shouldRetrieveHomepage) {
-          return
-        }
-        return await fileRetrievalObj[fileOpKey]
-      }
-    )
-
-    return {
+    await this.settingsService.updateSettingsFiles({
+      reqDetails,
       config,
+      homepage,
       footer,
       navigation,
-      homepage,
-    }
+      updatedConfigContent,
+      updatedFooterContent,
+      updatedNavigationContent,
+    })
+    return res.status(200).send("OK")
   }
 
   getRouter() {

--- a/newroutes/settings.js
+++ b/newroutes/settings.js
@@ -120,27 +120,9 @@ class SettingsRouter {
     }
 
     if (!_.isEmpty(updatedFooterContent)) {
-      const clonedFooterContent = _.cloneDeep(footer.content)
-      const clonedUpdatedFooterContent = _.cloneDeep(updatedFooterContent)
-      Object.keys(updatedFooterContent).forEach((field) => {
-        if (field === "social_media") {
-          const socials = updatedFooterContent[field]
-          Object.keys(socials).forEach((social) => {
-            if (!socials[social]) {
-              delete clonedFooterContent[field][social]
-              delete clonedUpdatedFooterContent[field][social]
-            }
-          })
-        } else if (updatedFooterContent[field] === "") {
-          // Check for empty string because false value exists
-          delete clonedFooterContent[field]
-          delete clonedUpdatedFooterContent[field]
-        }
-      })
-
       const mergedFooterContent = mergeUpdatedData(
-        clonedFooterContent,
-        clonedUpdatedFooterContent
+        footer.content,
+        updatedFooterContent
       )
       await this.footerYmlService.update(reqDetails, {
         fileContent: mergedFooterContent,

--- a/newroutes/settings.js
+++ b/newroutes/settings.js
@@ -13,8 +13,19 @@ const {
 
 const { UpdateSettingsRequestSchema } = require("@validators/RequestSchema")
 
+const shouldUpdateHomepage = (updatedConfigContent, configContent) => {
+  if (
+    (updatedConfigContent.title &&
+      configContent.title !== updatedConfigContent.title) ||
+    (updatedConfigContent.description &&
+      configContent.description !== updatedConfigContent.description)
+  )
+    return true
+  return false
+}
 const extractConfigFields = (config) => ({
   url: config.content.url,
+  description: config.content.description,
   title: config.content.title,
   favicon: config.content.favicon,
   shareicon: config.content.shareicon,
@@ -103,14 +114,13 @@ class SettingsRouter {
       })
 
       // update homepage title only if necessary
-      if (
-        updatedConfigContent.title &&
-        config.content.title !== updatedConfigContent.title
-      ) {
+      if (shouldUpdateHomepage(updatedConfigContent, config.content)) {
         const updatedHomepageFrontMatter = _.cloneDeep(
           homepage.content.frontMatter
         )
         updatedHomepageFrontMatter.title = updatedConfigContent.title
+        updatedHomepageFrontMatter.description =
+          updatedConfigContent.description
         await this.homepagePageService.update(reqDetails, {
           content: homepage.content.pageBody,
           frontMatter: updatedHomepageFrontMatter,

--- a/newroutes/settings.js
+++ b/newroutes/settings.js
@@ -12,6 +12,10 @@ const {
 
 const { UpdateSettingsRequestSchema } = require("@validators/RequestSchema")
 
+const {
+  SettingsService,
+} = require("../services/configServices/SettingsService")
+
 class SettingsRouter {
   constructor({ settingsService }) {
     this.settingsService = settingsService
@@ -31,9 +35,9 @@ class SettingsRouter {
     } = await this.settingsService.retrieveSettingsFiles(reqDetails)
 
     return res.status(200).json({
-      configSettings: this.settingsService.extractConfigFields(config),
-      footerSettings: this.settingsService.extractFooterFields(footer),
-      navigationSettings: this.settingsService.extractNavFields(navigation),
+      configSettings: SettingsService.extractConfigFields(config),
+      footerSettings: SettingsService.extractFooterFields(footer),
+      navigationSettings: SettingsService.extractNavFields(navigation),
     })
   }
 

--- a/newroutes/settings.js
+++ b/newroutes/settings.js
@@ -14,6 +14,7 @@ const {
 const { UpdateSettingsRequestSchema } = require("@validators/RequestSchema")
 
 const extractConfigFields = (config) => ({
+  url: config.content.url,
   title: config.content.title,
   favicon: config.content.favicon,
   shareicon: config.content.shareicon,

--- a/newroutes/settings.js
+++ b/newroutes/settings.js
@@ -11,6 +11,8 @@ const {
   attachRollbackRouteHandlerWrapper,
 } = require("@middleware/routeHandler")
 
+const { UpdateSettingsRequestSchema } = require("@validators/RequestSchema")
+
 const extractRequiredConfigFields = (config) => ({
   url: config.url,
   title: config.title,
@@ -74,6 +76,10 @@ class SettingsRouter {
   async updateSettingsPage(req, res) {
     const { accessToken, body } = req
     const { siteName } = req.params
+
+    const { error } = UpdateSettingsRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error)
+
     const reqDetails = { siteName, accessToken }
 
     const {

--- a/newroutes/settings.js
+++ b/newroutes/settings.js
@@ -13,17 +13,20 @@ const {
 
 const { UpdateSettingsRequestSchema } = require("@validators/RequestSchema")
 
-const extractRequiredConfigFields = (config) => ({
-  url: config.url,
-  title: config.title,
-  favicon: config.favicon,
-  shareicon: config.shareicon,
-  is_government: config.is_government,
-  facebook_pixel: config["facebook-pixel"],
-  google_analytics: config.google_analytics,
-  linkedin_insights: config["linkedin-insights"],
-  resources_name: config.resources_name,
-  colors: config.colors,
+const extractConfigFields = (config) => ({
+  title: config.content.title,
+  favicon: config.content.favicon,
+  shareicon: config.content.shareicon,
+  is_government: config.content.is_government,
+  facebook_pixel: config.content["facebook-pixel"],
+  google_analytics: config.content.google_analytics,
+  linkedin_insights: config.content["linkedin-insights"],
+  resources_name: config.content.resources_name,
+  colors: config.content.colors,
+})
+const extractFooterFields = (footer) => footer.content
+const extractNavFields = (navigation) => ({
+  logo: navigation.content.logo,
 })
 
 const mergeUpdatedData = (currentData, updatedData) => {
@@ -58,19 +61,11 @@ class SettingsRouter {
       reqDetails
     )
 
-    // retrieve only the relevant config and index fields
-    const configFieldsRequired = extractRequiredConfigFields(config.content)
-
-    // retrieve footer sha since we are sending the footer object wholesale
-    const footerSha = footer.sha
-
-    const settings = {
-      configFieldsRequired,
-      footerContent: footer.content,
-      navigationContent: { logo: navigation.content.logo },
-      footerSha,
-    }
-    return res.status(200).json({ settings })
+    return res.status(200).json({
+      configSettings: extractConfigFields(config),
+      footerSettings: extractFooterFields(footer),
+      navigationSettings: extractNavFields(navigation),
+    })
   }
 
   async updateSettingsPage(req, res) {

--- a/server.js
+++ b/server.js
@@ -51,6 +51,12 @@ axiosInstance.interceptors.request.use((config) => ({
 const {
   SubcollectionPageService,
 } = require("@root/services/fileServices/MdPageServices/SubcollectionPageService")
+const {
+  ConfigYmlService,
+} = require("@root/services/fileServices/YmlFileServices/ConfigYmlService")
+const {
+  FooterYmlService,
+} = require("@root/services/fileServices/YmlFileServices/FooterYmlService")
 const { GitHubService } = require("@services/db/GitHubService")
 const {
   BaseDirectoryService,
@@ -74,6 +80,9 @@ const {
   ResourcePageService,
 } = require("@services/fileServices/MdPageServices/ResourcePageService")
 const {
+  HomepagePageService,
+} = require("@services/fileServices/MdPageServices/HomepagePageService")
+const {
   UnlinkedPageService,
 } = require("@services/fileServices/MdPageServices/UnlinkedPageService")
 const {
@@ -88,6 +97,7 @@ const { CollectionPagesRouter } = require("./newroutes/collectionPages")
 const { CollectionsRouter } = require("./newroutes/collections")
 const { ResourceCategoriesRouter } = require("./newroutes/resourceCategories")
 const { ResourcePagesRouter } = require("./newroutes/resourcePages")
+const { SettingsRouter } = require("./newroutes/settings")
 const { UnlinkedPagesRouter } = require("./newroutes/unlinkedPages")
 
 const gitHubService = new GitHubService({ axiosInstance })
@@ -130,6 +140,10 @@ const resourceDirectoryService = new ResourceDirectoryService({
   baseDirectoryService,
   gitHubService,
 })
+const homepagePageService = new HomepagePageService({ gitHubService })
+const configYmlService = new ConfigYmlService({ gitHubService })
+const footerYmlService = new FooterYmlService({ gitHubService })
+const navYmlService = new NavYmlService({ gitHubService })
 
 const unlinkedPagesRouter = new UnlinkedPagesRouter({
   unlinkedPageService,
@@ -148,6 +162,12 @@ const resourcePagesV2Router = new ResourcePagesRouter({
 })
 const resourceDirectoryV2Router = new ResourceCategoriesRouter({
   resourceDirectoryService,
+})
+const settingsV2Router = new SettingsRouter({
+  homepagePageService,
+  configYmlService,
+  footerYmlService,
+  navYmlService,
 })
 
 const app = express()
@@ -196,6 +216,7 @@ app.use("/v2/sites", unlinkedPagesRouter.getRouter())
 app.use("/v2/sites", collectionsV2Router.getRouter())
 app.use("/v2/sites", resourcePagesV2Router.getRouter())
 app.use("/v2/sites", resourceDirectoryV2Router.getRouter())
+app.use("/v2/sites", settingsV2Router.getRouter())
 
 app.use("/v2/ping", (req, res, next) => res.status(200).send("Ok"))
 

--- a/server.js
+++ b/server.js
@@ -103,6 +103,9 @@ const { SettingsService } = require("./services/configServices/settingsService")
 
 const gitHubService = new GitHubService({ axiosInstance })
 const collectionYmlService = new CollectionYmlService({ gitHubService })
+const homepagePageService = new HomepagePageService({ gitHubService })
+const configYmlService = new ConfigYmlService({ gitHubService })
+const footerYmlService = new FooterYmlService({ gitHubService })
 const navYmlService = new NavYmlService({ gitHubService })
 const collectionPageService = new CollectionPageService({
   gitHubService,

--- a/server.js
+++ b/server.js
@@ -77,11 +77,11 @@ const {
   CollectionPageService,
 } = require("@services/fileServices/MdPageServices/CollectionPageService")
 const {
-  ResourcePageService,
-} = require("@services/fileServices/MdPageServices/ResourcePageService")
-const {
   HomepagePageService,
 } = require("@services/fileServices/MdPageServices/HomepagePageService")
+const {
+  ResourcePageService,
+} = require("@services/fileServices/MdPageServices/ResourcePageService")
 const {
   UnlinkedPageService,
 } = require("@services/fileServices/MdPageServices/UnlinkedPageService")
@@ -144,10 +144,6 @@ const resourceDirectoryService = new ResourceDirectoryService({
   baseDirectoryService,
   gitHubService,
 })
-const homepagePageService = new HomepagePageService({ gitHubService })
-const configYmlService = new ConfigYmlService({ gitHubService })
-const footerYmlService = new FooterYmlService({ gitHubService })
-const navYmlService = new NavYmlService({ gitHubService })
 
 const settingsService = new SettingsService({
   homepagePageService,

--- a/server.js
+++ b/server.js
@@ -99,6 +99,7 @@ const { ResourceCategoriesRouter } = require("./newroutes/resourceCategories")
 const { ResourcePagesRouter } = require("./newroutes/resourcePages")
 const { SettingsRouter } = require("./newroutes/settings")
 const { UnlinkedPagesRouter } = require("./newroutes/unlinkedPages")
+const { SettingsService } = require("./services/configServices/settingsService")
 
 const gitHubService = new GitHubService({ axiosInstance })
 const collectionYmlService = new CollectionYmlService({ gitHubService })
@@ -145,6 +146,13 @@ const configYmlService = new ConfigYmlService({ gitHubService })
 const footerYmlService = new FooterYmlService({ gitHubService })
 const navYmlService = new NavYmlService({ gitHubService })
 
+const settingsService = new SettingsService({
+  homepagePageService,
+  configYmlService,
+  footerYmlService,
+  navYmlService,
+})
+
 const unlinkedPagesRouter = new UnlinkedPagesRouter({
   unlinkedPageService,
   unlinkedPagesDirectoryService,
@@ -163,12 +171,7 @@ const resourcePagesV2Router = new ResourcePagesRouter({
 const resourceDirectoryV2Router = new ResourceCategoriesRouter({
   resourceDirectoryService,
 })
-const settingsV2Router = new SettingsRouter({
-  homepagePageService,
-  configYmlService,
-  footerYmlService,
-  navYmlService,
-})
+const settingsV2Router = new SettingsRouter({ settingsService })
 
 const app = express()
 app.use(helmet())

--- a/services/configServices/SettingsService.js
+++ b/services/configServices/SettingsService.js
@@ -115,7 +115,15 @@ class SettingsService {
     return false
   }
 
-  extractConfigFields(config) {
+  mergeUpdatedData(currentData, updatedData) {
+    const clonedCurrentData = _.cloneDeep(currentData)
+    Object.keys(updatedData).forEach((field) => {
+      clonedCurrentData[field] = updatedData[field]
+    })
+    return clonedCurrentData
+  }
+
+  static extractConfigFields(config) {
     return {
       url: config.content.url,
       description: config.content.description,
@@ -131,22 +139,14 @@ class SettingsService {
     }
   }
 
-  extractFooterFields(footer) {
+  static extractFooterFields(footer) {
     return footer.content
   }
 
-  extractNavFields(navigation) {
+  static extractNavFields(navigation) {
     return {
       logo: navigation.content.logo,
     }
-  }
-
-  mergeUpdatedData(currentData, updatedData) {
-    const clonedCurrentData = _.cloneDeep(currentData)
-    Object.keys(updatedData).forEach((field) => {
-      clonedCurrentData[field] = updatedData[field]
-    })
-    return clonedCurrentData
   }
 }
 

--- a/services/configServices/SettingsService.js
+++ b/services/configServices/SettingsService.js
@@ -1,0 +1,151 @@
+const autoBind = require("auto-bind")
+const Bluebird = require("bluebird")
+const _ = require("lodash")
+
+class SettingsService {
+  constructor({
+    configYmlService,
+    footerYmlService,
+    navYmlService,
+    homepagePageService,
+  }) {
+    this.configYmlService = configYmlService
+    this.footerYmlService = footerYmlService
+    this.navYmlService = navYmlService
+    this.homepagePageService = homepagePageService
+    // We need to bind all methods because we don't invoke them from the class directly
+    autoBind(this)
+  }
+
+  async retrieveSettingsFiles(reqDetails, shouldRetrieveHomepage) {
+    const fileRetrievalObj = {
+      config: this.configYmlService.read(reqDetails),
+      footer: this.footerYmlService.read(reqDetails),
+      navigation: this.navYmlService.read(reqDetails),
+      homepage: this.homepagePageService.read(reqDetails),
+    }
+
+    const [config, footer, navigation, homepage] = await Bluebird.map(
+      Object.keys(fileRetrievalObj),
+      async (fileOpKey) => {
+        if (fileOpKey === "homepage" && !shouldRetrieveHomepage) {
+          return
+        }
+        return await fileRetrievalObj[fileOpKey]
+      }
+    )
+
+    return {
+      config,
+      footer,
+      navigation,
+      homepage,
+    }
+  }
+
+  async updateSettingsFiles({
+    reqDetails,
+    config,
+    homepage,
+    footer,
+    navigation,
+    updatedConfigContent,
+    updatedFooterContent,
+    updatedNavigationContent,
+  }) {
+    if (!_.isEmpty(updatedConfigContent)) {
+      const mergedConfigContent = this.mergeUpdatedData(
+        config.content,
+        updatedConfigContent
+      )
+      await this.configYmlService.update(reqDetails, {
+        fileContent: mergedConfigContent,
+        sha: config.sha,
+      })
+
+      // update homepage title only if necessary
+      if (this.shouldUpdateHomepage(updatedConfigContent, config.content)) {
+        const updatedHomepageFrontMatter = _.cloneDeep(
+          homepage.content.frontMatter
+        )
+        updatedHomepageFrontMatter.title = updatedConfigContent.title
+        updatedHomepageFrontMatter.description =
+          updatedConfigContent.description
+        await this.homepagePageService.update(reqDetails, {
+          content: homepage.content.pageBody,
+          frontMatter: updatedHomepageFrontMatter,
+          sha: homepage.sha,
+        })
+      }
+    }
+
+    if (!_.isEmpty(updatedFooterContent)) {
+      const mergedFooterContent = this.mergeUpdatedData(
+        footer.content,
+        updatedFooterContent
+      )
+      await this.footerYmlService.update(reqDetails, {
+        fileContent: mergedFooterContent,
+        sha: footer.sha,
+      })
+    }
+
+    if (!_.isEmpty(updatedNavigationContent)) {
+      const mergedNavigationContent = this.mergeUpdatedData(
+        navigation.content,
+        updatedNavigationContent
+      )
+      await this.navYmlService.update(reqDetails, {
+        fileContent: mergedNavigationContent,
+        sha: navigation.sha,
+      })
+    }
+  }
+
+  shouldUpdateHomepage(updatedConfigContent, configContent) {
+    if (
+      (updatedConfigContent.title &&
+        configContent.title !== updatedConfigContent.title) ||
+      (updatedConfigContent.description &&
+        configContent.description !== updatedConfigContent.description)
+    )
+      return true
+    return false
+  }
+
+  extractConfigFields(config) {
+    return {
+      url: config.content.url,
+      description: config.content.description,
+      title: config.content.title,
+      favicon: config.content.favicon,
+      shareicon: config.content.shareicon,
+      is_government: config.content.is_government,
+      facebook_pixel: config.content["facebook-pixel"],
+      google_analytics: config.content.google_analytics,
+      linkedin_insights: config.content["linkedin-insights"],
+      resources_name: config.content.resources_name,
+      colors: config.content.colors,
+    }
+  }
+
+  extractFooterFields(footer) {
+    return footer.content
+  }
+
+  extractNavFields(navigation) {
+    return {
+      logo: navigation.content.logo,
+    }
+  }
+
+  mergeUpdatedData(currentData, updatedData) {
+    const clonedCurrentData = _.cloneDeep(currentData)
+    Object.keys(updatedData).forEach((field) => {
+      clonedCurrentData[field] = updatedData[field]
+    })
+    return clonedCurrentData
+  }
+}
+
+module.exports = { SettingsService }

--- a/services/configServices/SettingsService.js
+++ b/services/configServices/SettingsService.js
@@ -68,9 +68,11 @@ class SettingsService {
         const updatedHomepageFrontMatter = _.cloneDeep(
           homepage.content.frontMatter
         )
-        updatedHomepageFrontMatter.title = updatedConfigContent.title
-        updatedHomepageFrontMatter.description =
-          updatedConfigContent.description
+        if (updatedConfigContent.title)
+          updatedHomepageFrontMatter.title = updatedConfigContent.title
+        if (updatedConfigContent.description)
+          updatedHomepageFrontMatter.description =
+            updatedConfigContent.description
         await this.homepagePageService.update(reqDetails, {
           content: homepage.content.pageBody,
           frontMatter: updatedHomepageFrontMatter,

--- a/services/configServices/SettingsService.js
+++ b/services/configServices/SettingsService.js
@@ -148,6 +148,57 @@ class SettingsService {
       logo: navigation.content.logo,
     }
   }
+
+  static retrieveSettingsFields(settings) {
+    const configParams = [
+      "url",
+      "description",
+      "title",
+      "favicon",
+      "shareicon",
+      "is_government",
+      "facebook-pixel",
+      "google_analytics",
+      "linkedin-insights",
+      "resources_name",
+      "colors",
+    ]
+    const footerParams = [
+      "contact_us",
+      "show_reach",
+      "feedback",
+      "faq",
+      "social_media",
+    ]
+    const navigationParams = ["logo"]
+
+    const configContent = configParams.reduce(
+      (acc, curr) => ({
+        ...acc,
+        ...(curr in settings && { [curr]: settings[curr] }),
+      }),
+      {}
+    )
+    const footerContent = footerParams.reduce(
+      (acc, curr) => ({
+        ...acc,
+        ...(curr in settings && { [curr]: settings[curr] }),
+      }),
+      {}
+    )
+    const navigationContent = navigationParams.reduce(
+      (acc, curr) => ({
+        ...acc,
+        ...(curr in settings && { [curr]: settings[curr] }),
+      }),
+      {}
+    )
+    return {
+      configContent,
+      footerContent,
+      navigationContent,
+    }
+  }
 }
 
 module.exports = { SettingsService }

--- a/services/configServices/__tests__/SettingsService.spec.js
+++ b/services/configServices/__tests__/SettingsService.spec.js
@@ -1,0 +1,387 @@
+const { configContent, configSha } = require("../../../fixtures/config")
+const { footerContent, footerSha } = require("../../../fixtures/footer")
+const { homepageContent, homepageSha } = require("../../../fixtures/homepage")
+const {
+  navigationContent,
+  navigationSha,
+} = require("../../../fixtures/navigation")
+const { SettingsService } = require("../SettingsService")
+
+describe("Settings Service", () => {
+  const siteName = "test-site"
+  const accessToken = "test-token"
+  const reqDetails = { siteName, accessToken }
+
+  const config = {
+    content: configContent,
+    sha: configSha,
+  }
+  const footer = {
+    content: footerContent,
+    sha: footerSha,
+  }
+  const navigation = {
+    content: navigationContent,
+    sha: navigationSha,
+  }
+  const homepage = {
+    content: homepageContent,
+    sha: homepageSha,
+  }
+
+  const mockConfigYmlService = {
+    read: jest.fn(),
+    update: jest.fn(),
+  }
+
+  const mockFooterYmlService = {
+    read: jest.fn(),
+    update: jest.fn(),
+  }
+
+  const mockNavYmlService = {
+    read: jest.fn(),
+    update: jest.fn(),
+  }
+
+  const mockHomepagePageService = {
+    read: jest.fn(),
+    update: jest.fn(),
+  }
+
+  const service = new SettingsService({
+    configYmlService: mockConfigYmlService,
+    homepagePageService: mockHomepagePageService,
+    footerYmlService: mockFooterYmlService,
+    navYmlService: mockNavYmlService,
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("Retrieve settings files", () => {
+    mockConfigYmlService.read.mockResolvedValue(config)
+    mockFooterYmlService.read.mockResolvedValue(footer)
+    mockNavYmlService.read.mockResolvedValue(navigation)
+    mockHomepagePageService.read.mockResolvedValue(homepage)
+
+    it("retrieves settings data without homepage", async () => {
+      await expect(
+        service.retrieveSettingsFiles(reqDetails)
+      ).resolves.toMatchObject({
+        config,
+        footer,
+        navigation,
+        homepage: undefined,
+      })
+      expect(mockConfigYmlService.read).toHaveBeenCalled()
+      expect(mockFooterYmlService.read).toHaveBeenCalled()
+      expect(mockNavYmlService.read).toHaveBeenCalled()
+    })
+
+    it("retrieves settings data with homepage", async () => {
+      await expect(
+        service.retrieveSettingsFiles(reqDetails, true)
+      ).resolves.toMatchObject({
+        config,
+        footer,
+        navigation,
+        homepage,
+      })
+      expect(mockConfigYmlService.read).toHaveBeenCalled()
+      expect(mockFooterYmlService.read).toHaveBeenCalled()
+      expect(mockNavYmlService.read).toHaveBeenCalled()
+      expect(mockHomepagePageService.read).toHaveBeenCalled()
+    })
+  })
+
+  describe("Update settings files", () => {
+    mockConfigYmlService.read.mockResolvedValue(config)
+    mockFooterYmlService.read.mockResolvedValue(footer)
+    mockNavYmlService.read.mockResolvedValue(navigation)
+    mockHomepagePageService.read.mockResolvedValue(homepage)
+
+    const updatedFbPixelValue = `${configContent["facebook-pixel"]}test`
+    const updatedTitleValue = `${configContent.title}test`
+    const updatedDescriptionValue = `${configContent.description}test`
+    const updatedFaq = `${footerContent.faq}test`
+    const updatedLogo = `${navigationContent.logo}test`
+
+    it("updates only config data if non-title, non-description config field is updated", async () => {
+      const updatedContent = {
+        configSettings: { "facebook-pixel": updatedFbPixelValue },
+        footerSettings: {},
+        navigationSettings: {},
+      }
+      const expectedConfigServiceInput = {
+        fileContent: {
+          ...configContent,
+          "facebook-pixel": updatedFbPixelValue,
+        },
+        sha: configSha,
+      }
+
+      await expect(
+        service.updateSettingsFiles({
+          reqDetails,
+          config,
+          homepage,
+          footer,
+          navigation,
+          updatedConfigContent: updatedContent.configSettings,
+          updatedFooterContent: updatedContent.footerSettings,
+          updatedNavigationContent: updatedContent.navigationSettings,
+        })
+      )
+
+      expect(mockConfigYmlService.update).toHaveBeenLastCalledWith(
+        reqDetails,
+        expectedConfigServiceInput
+      )
+      expect(mockFooterYmlService.update).not.toHaveBeenCalled()
+      expect(mockNavYmlService.update).not.toHaveBeenCalled()
+      expect(mockHomepagePageService.update).not.toHaveBeenCalled()
+    })
+
+    it("updates both homepage and config data when only title field is updated", async () => {
+      const updatedContent = {
+        configSettings: { title: updatedTitleValue },
+        footerSettings: {},
+        navigationSettings: {},
+      }
+      const expectedConfigServiceInput = {
+        fileContent: {
+          ...configContent,
+          title: updatedTitleValue,
+        },
+        sha: configSha,
+      }
+      const expectedHomepageServiceInput = {
+        content: homepageContent.pageBody,
+        frontMatter: {
+          ...homepageContent.frontMatter,
+          title: updatedTitleValue,
+        },
+        sha: homepage.sha,
+      }
+
+      await expect(
+        service.updateSettingsFiles({
+          reqDetails,
+          config,
+          homepage,
+          footer,
+          navigation,
+          updatedConfigContent: updatedContent.configSettings,
+          updatedFooterContent: updatedContent.footerSettings,
+          updatedNavigationContent: updatedContent.navigationSettings,
+        })
+      )
+
+      expect(mockConfigYmlService.update).toHaveBeenLastCalledWith(
+        reqDetails,
+        expectedConfigServiceInput
+      )
+      expect(mockFooterYmlService.update).not.toHaveBeenCalled()
+      expect(mockNavYmlService.update).not.toHaveBeenCalled()
+      expect(mockHomepagePageService.update).toHaveBeenLastCalledWith(
+        reqDetails,
+        expectedHomepageServiceInput
+      )
+    })
+
+    it("updates both homepage and config data when only description field is updated", async () => {
+      const updatedContent = {
+        configSettings: { description: updatedDescriptionValue },
+        footerSettings: {},
+        navigationSettings: {},
+      }
+      const expectedConfigServiceInput = {
+        fileContent: {
+          ...configContent,
+          description: updatedDescriptionValue,
+        },
+        sha: configSha,
+      }
+      const expectedHomepageServiceInput = {
+        content: homepageContent.pageBody,
+        frontMatter: {
+          ...homepageContent.frontMatter,
+          description: updatedDescriptionValue,
+        },
+        sha: homepage.sha,
+      }
+
+      await expect(
+        service.updateSettingsFiles({
+          reqDetails,
+          config,
+          homepage,
+          footer,
+          navigation,
+          updatedConfigContent: updatedContent.configSettings,
+          updatedFooterContent: updatedContent.footerSettings,
+          updatedNavigationContent: updatedContent.navigationSettings,
+        })
+      )
+
+      expect(mockConfigYmlService.update).toHaveBeenLastCalledWith(
+        reqDetails,
+        expectedConfigServiceInput
+      )
+      expect(mockFooterYmlService.update).not.toHaveBeenCalled()
+      expect(mockNavYmlService.update).not.toHaveBeenCalled()
+      expect(mockHomepagePageService.update).toHaveBeenLastCalledWith(
+        reqDetails,
+        expectedHomepageServiceInput
+      )
+    })
+
+    it("updates only footer data when only footer fields are updated", async () => {
+      const updatedContent = {
+        configSettings: {},
+        footerSettings: { faq: updatedFaq },
+        navigationSettings: {},
+      }
+      const expectedFooterServiceInput = {
+        fileContent: {
+          ...footerContent,
+          faq: updatedFaq,
+        },
+        sha: footerSha,
+      }
+
+      await expect(
+        service.updateSettingsFiles({
+          reqDetails,
+          config,
+          homepage,
+          footer,
+          navigation,
+          updatedConfigContent: updatedContent.configSettings,
+          updatedFooterContent: updatedContent.footerSettings,
+          updatedNavigationContent: updatedContent.navigationSettings,
+        })
+      )
+
+      expect(mockConfigYmlService.update).toHaveBeenCalledTimes(0)
+      expect(mockFooterYmlService.update).toHaveBeenLastCalledWith(
+        reqDetails,
+        expectedFooterServiceInput
+      )
+      expect(mockNavYmlService.update).toHaveBeenCalledTimes(0)
+      expect(mockHomepagePageService.update).toHaveBeenCalledTimes(0)
+    })
+
+    it("updates only navigation data when only navigation fields are updated", async () => {
+      const updatedContent = {
+        configSettings: {},
+        footerSettings: {},
+        navigationSettings: { logo: updatedLogo },
+      }
+      const expectedNavigationServiceInput = {
+        fileContent: {
+          ...navigationContent,
+          logo: updatedLogo,
+        },
+        sha: navigationSha,
+      }
+
+      await expect(
+        service.updateSettingsFiles({
+          reqDetails,
+          config,
+          homepage,
+          footer,
+          navigation,
+          updatedConfigContent: updatedContent.configSettings,
+          updatedFooterContent: updatedContent.footerSettings,
+          updatedNavigationContent: updatedContent.navigationSettings,
+        })
+      )
+
+      expect(mockConfigYmlService.update).not.toHaveBeenCalled()
+      expect(mockFooterYmlService.update).not.toHaveBeenCalled()
+      expect(mockNavYmlService.update).toHaveBeenLastCalledWith(
+        reqDetails,
+        expectedNavigationServiceInput
+      )
+      expect(mockHomepagePageService.update).not.toHaveBeenCalled()
+    })
+
+    it("updates config, homepage, navigation, and footer data when all fields are updated", async () => {
+      const updatedContent = {
+        configSettings: {
+          description: updatedDescriptionValue,
+          title: updatedTitleValue,
+          "facebook-pixel": updatedFbPixelValue,
+        },
+        footerSettings: { faq: updatedFaq },
+        navigationSettings: { logo: updatedLogo },
+      }
+      const expectedConfigServiceInput = {
+        fileContent: {
+          ...configContent,
+          title: updatedTitleValue,
+          description: updatedDescriptionValue,
+          "facebook-pixel": updatedFbPixelValue,
+        },
+        sha: configSha,
+      }
+      const expectedHomepageServiceInput = {
+        content: homepageContent.pageBody,
+        frontMatter: {
+          ...homepageContent.frontMatter,
+          title: updatedTitleValue,
+          description: updatedDescriptionValue,
+        },
+        sha: homepage.sha,
+      }
+      const expectedFooterServiceInput = {
+        fileContent: {
+          ...footerContent,
+          faq: updatedFaq,
+        },
+        sha: footerSha,
+      }
+      const expectedNavigationServiceInput = {
+        fileContent: {
+          ...navigationContent,
+          logo: updatedLogo,
+        },
+        sha: navigationSha,
+      }
+
+      await expect(
+        service.updateSettingsFiles({
+          reqDetails,
+          config,
+          homepage,
+          footer,
+          navigation,
+          updatedConfigContent: updatedContent.configSettings,
+          updatedFooterContent: updatedContent.footerSettings,
+          updatedNavigationContent: updatedContent.navigationSettings,
+        })
+      )
+
+      expect(mockConfigYmlService.update).toHaveBeenLastCalledWith(
+        reqDetails,
+        expectedConfigServiceInput
+      )
+      expect(mockFooterYmlService.update).toHaveBeenLastCalledWith(
+        reqDetails,
+        expectedFooterServiceInput
+      )
+      expect(mockNavYmlService.update).toHaveBeenLastCalledWith(
+        reqDetails,
+        expectedNavigationServiceInput
+      )
+      expect(mockHomepagePageService.update).toHaveBeenLastCalledWith(
+        reqDetails,
+        expectedHomepageServiceInput
+      )
+    })
+  })
+})

--- a/services/configServices/__tests__/SettingsService.spec.js
+++ b/services/configServices/__tests__/SettingsService.spec.js
@@ -133,7 +133,7 @@ describe("Settings Service", () => {
           updatedFooterContent: updatedContent.footerSettings,
           updatedNavigationContent: updatedContent.navigationSettings,
         })
-      )
+      ).resolves.not.toThrow()
 
       expect(mockConfigYmlService.update).toHaveBeenLastCalledWith(
         reqDetails,
@@ -177,7 +177,7 @@ describe("Settings Service", () => {
           updatedFooterContent: updatedContent.footerSettings,
           updatedNavigationContent: updatedContent.navigationSettings,
         })
-      )
+      ).resolves.not.toThrow()
 
       expect(mockConfigYmlService.update).toHaveBeenLastCalledWith(
         reqDetails,
@@ -224,7 +224,7 @@ describe("Settings Service", () => {
           updatedFooterContent: updatedContent.footerSettings,
           updatedNavigationContent: updatedContent.navigationSettings,
         })
-      )
+      ).resolves.not.toThrow()
 
       expect(mockConfigYmlService.update).toHaveBeenLastCalledWith(
         reqDetails,
@@ -299,7 +299,7 @@ describe("Settings Service", () => {
           updatedFooterContent: updatedContent.footerSettings,
           updatedNavigationContent: updatedContent.navigationSettings,
         })
-      )
+      ).resolves.not.toThrow()
 
       expect(mockConfigYmlService.update).not.toHaveBeenCalled()
       expect(mockFooterYmlService.update).not.toHaveBeenCalled()
@@ -364,7 +364,7 @@ describe("Settings Service", () => {
           updatedFooterContent: updatedContent.footerSettings,
           updatedNavigationContent: updatedContent.navigationSettings,
         })
-      )
+      ).resolves.not.toThrow()
 
       expect(mockConfigYmlService.update).toHaveBeenLastCalledWith(
         reqDetails,

--- a/services/fileServices/MdPageServices/HomepagePageService.js
+++ b/services/fileServices/MdPageServices/HomepagePageService.js
@@ -1,0 +1,40 @@
+const {
+  retrieveDataFromMarkdown,
+  convertDataToMarkdown,
+} = require("@utils/markdown-utils")
+
+const HOMEPAGE_FILE_NAME = "index.md"
+
+class HomepagePageService {
+  constructor({ gitHubService }) {
+    this.gitHubService = gitHubService
+  }
+
+  async read(reqDetails) {
+    const { content: rawContent, sha } = await this.gitHubService.read(
+      reqDetails,
+      {
+        fileName: HOMEPAGE_FILE_NAME,
+      }
+    )
+    const { frontMatter, pageContent } = retrieveDataFromMarkdown(rawContent)
+    return { fileName, content: { frontMatter, pageBody: pageContent }, sha }
+  }
+
+  async update(reqDetails, { content, frontMatter, sha }) {
+    const newContent = convertDataToMarkdown(frontMatter, content)
+    const { newSha } = await this.gitHubService.update(reqDetails, {
+      fileContent: newContent,
+      sha,
+      fileName: HOMEPAGE_FILE_NAME,
+    })
+    return {
+      fileName,
+      content: { frontMatter, pageBody: content },
+      oldSha: sha,
+      newSha,
+    }
+  }
+}
+
+module.exports = { HomepagePageService }

--- a/services/fileServices/MdPageServices/HomepagePageService.js
+++ b/services/fileServices/MdPageServices/HomepagePageService.js
@@ -18,7 +18,7 @@ class HomepagePageService {
       }
     )
     const { frontMatter, pageContent } = retrieveDataFromMarkdown(rawContent)
-    return { fileName, content: { frontMatter, pageBody: pageContent }, sha }
+    return { content: { frontMatter, pageBody: pageContent }, sha }
   }
 
   async update(reqDetails, { content, frontMatter, sha }) {
@@ -29,7 +29,6 @@ class HomepagePageService {
       fileName: HOMEPAGE_FILE_NAME,
     })
     return {
-      fileName,
       content: { frontMatter, pageBody: content },
       oldSha: sha,
       newSha,

--- a/services/fileServices/MdPageServices/__tests__/CollectionPageService.spec.js
+++ b/services/fileServices/MdPageServices/__tests__/CollectionPageService.spec.js
@@ -184,7 +184,7 @@ describe("Collection Page Service", () => {
     it("Deleting pages works correctly", async () => {
       await expect(
         service.delete(reqDetails, { fileName, collectionName, sha })
-      )
+      ).resolves.not.toThrow()
       expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
         fileName,
         directoryName,

--- a/services/fileServices/MdPageServices/__tests__/HomepagePageService.spec.js
+++ b/services/fileServices/MdPageServices/__tests__/HomepagePageService.spec.js
@@ -1,0 +1,94 @@
+const {
+  homepageContent: mockHomepageContent,
+  homepageSha: mockHomepageSha,
+  rawHomepageContent: mockRawHomepageContent,
+} = require("../../../../fixtures/homepage")
+
+describe("Homepage Page Service", () => {
+  const siteName = "test-site"
+  const accessToken = "test-token"
+  const reqDetails = { siteName, accessToken }
+
+  const HOMEPAGE_FILE_NAME = "index.md"
+
+  const mockFrontMatter = mockHomepageContent.frontMatter
+  const mockContent = mockHomepageContent.pageBody
+
+  const mockGithubService = {
+    create: jest.fn(),
+    read: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  }
+
+  jest.mock("@utils/markdown-utils", () => ({
+    retrieveDataFromMarkdown: jest.fn().mockReturnValue({
+      frontMatter: mockFrontMatter,
+      pageContent: mockContent,
+    }),
+    convertDataToMarkdown: jest.fn().mockReturnValue(mockRawHomepageContent),
+  }))
+
+  const {
+    HomepagePageService,
+  } = require("@services/fileServices/MdPageServices/HomepagePageService")
+  const service = new HomepagePageService({
+    gitHubService: mockGithubService,
+  })
+
+  const {
+    retrieveDataFromMarkdown,
+    convertDataToMarkdown,
+  } = require("@utils/markdown-utils")
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("Read", () => {
+    mockGithubService.read.mockResolvedValue({
+      content: mockRawHomepageContent,
+      sha: mockHomepageSha,
+    })
+    it("Reading the homepage works correctly", async () => {
+      await expect(service.read(reqDetails)).resolves.toMatchObject({
+        content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+        sha: mockHomepageSha,
+      })
+      expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(
+        mockRawHomepageContent
+      )
+      expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+        fileName: HOMEPAGE_FILE_NAME,
+      })
+    })
+  })
+
+  describe("Update", () => {
+    const oldSha = "54321"
+    mockGithubService.update.mockResolvedValue({ newSha: mockHomepageSha })
+    it("Updating page content works correctly", async () => {
+      await expect(
+        service.update(reqDetails, {
+          fileName: HOMEPAGE_FILE_NAME,
+          content: mockContent,
+          frontMatter: mockFrontMatter,
+          sha: oldSha,
+        })
+      ).resolves.toMatchObject({
+        content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+        oldSha,
+        newSha: mockHomepageSha,
+      })
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        mockFrontMatter,
+        mockContent
+      )
+      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+        fileName: HOMEPAGE_FILE_NAME,
+        fileContent: mockRawHomepageContent,
+        sha: oldSha,
+      })
+    })
+  })
+})

--- a/services/fileServices/MdPageServices/__tests__/SubcollectionPageService.spec.js
+++ b/services/fileServices/MdPageServices/__tests__/SubcollectionPageService.spec.js
@@ -209,7 +209,7 @@ describe("Subcollection Page Service", () => {
           subcollectionName,
           sha,
         })
-      )
+      ).resolves.not.toThrow()
       expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
         fileName,
         directoryName,

--- a/services/fileServices/MdPageServices/__tests__/UnlinkedPageService.spec.js
+++ b/services/fileServices/MdPageServices/__tests__/UnlinkedPageService.spec.js
@@ -134,7 +134,9 @@ describe("Unlinked Page Service", () => {
 
   describe("Delete", () => {
     it("Deleting pages works correctly", async () => {
-      await expect(service.delete(reqDetails, { fileName, sha }))
+      await expect(
+        service.delete(reqDetails, { fileName, sha })
+      ).resolves.not.toThrow()
       expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
         fileName,
         directoryName,

--- a/services/fileServices/YmlFileServices/ConfigYmlService.js
+++ b/services/fileServices/YmlFileServices/ConfigYmlService.js
@@ -1,0 +1,32 @@
+const yaml = require("yaml")
+
+const CONFIG_FILE_NAME = "_config.yml"
+
+class ConfigYmlService {
+  constructor({ gitHubService }) {
+    this.gitHubService = gitHubService
+  }
+
+  async read(reqDetails) {
+    const { content: unparsedContent, sha } = await this.gitHubService.read(
+      reqDetails,
+      {
+        fileName: CONFIG_FILE_NAME,
+      }
+    )
+    const content = yaml.parse(unparsedContent)
+    return { content, sha }
+  }
+
+  async update(reqDetails, { fileContent, sha }) {
+    const stringifiedContent = yaml.stringify(fileContent)
+    const { newSha } = await this.gitHubService.update(reqDetails, {
+      fileContent: stringifiedContent,
+      sha,
+      fileName: CONFIG_FILE_NAME,
+    })
+    return { newSha }
+  }
+}
+
+module.exports = { ConfigYmlService }

--- a/services/fileServices/YmlFileServices/FooterYmlService.js
+++ b/services/fileServices/YmlFileServices/FooterYmlService.js
@@ -1,0 +1,35 @@
+const yaml = require("yaml")
+
+const FOOTER_FILE_NAME = "footer.yml"
+const FOOTER_FILE_DIR = "_data"
+
+class FooterYmlService {
+  constructor({ gitHubService }) {
+    this.gitHubService = gitHubService
+  }
+
+  async read(reqDetails) {
+    const { content: unparsedContent, sha } = await this.gitHubService.read(
+      reqDetails,
+      {
+        fileName: FOOTER_FILE_NAME,
+        directoryName: FOOTER_FILE_DIR,
+      }
+    )
+    const content = yaml.parse(unparsedContent)
+    return { content, sha }
+  }
+
+  async update(reqDetails, { fileContent, sha }) {
+    const stringifiedContent = yaml.stringify(fileContent)
+    const { newSha } = await this.gitHubService.update(reqDetails, {
+      fileContent: stringifiedContent,
+      sha,
+      fileName: FOOTER_FILE_NAME,
+      directoryName: FOOTER_FILE_DIR,
+    })
+    return { newSha }
+  }
+}
+
+module.exports = { FooterYmlService }

--- a/services/fileServices/YmlFileServices/__tests__/CollectionYmlService.spec.js
+++ b/services/fileServices/YmlFileServices/__tests__/CollectionYmlService.spec.js
@@ -345,7 +345,7 @@ describe("Collection Yml Service", () => {
           collectionName,
           item: itemName,
         })
-      )
+      ).resolves.not.toThrow()
       expect(mockGithubService.update).not.toHaveBeenCalled()
     })
   })

--- a/services/fileServices/YmlFileServices/__tests__/ConfigYmlService.spec.js
+++ b/services/fileServices/YmlFileServices/__tests__/ConfigYmlService.spec.js
@@ -1,0 +1,64 @@
+const {
+  configContent: mockConfigContent,
+  configSha: mockConfigSha,
+  rawConfigContent: mockRawConfigContent,
+} = require("../../../../fixtures/config")
+const { ConfigYmlService } = require("../ConfigYmlService")
+
+describe("Config Yml Service", () => {
+  const siteName = "test-site"
+  const accessToken = "test-token"
+  const reqDetails = { siteName, accessToken }
+
+  const CONFIG_FILE_NAME = "_config.yml"
+
+  const mockGithubService = {
+    create: jest.fn(),
+    read: jest.fn(),
+    update: jest.fn(),
+  }
+
+  const service = new ConfigYmlService({
+    gitHubService: mockGithubService,
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("Read", () => {
+    mockGithubService.read.mockResolvedValueOnce({
+      content: mockRawConfigContent,
+      sha: mockConfigSha,
+    })
+    it("Reading the _config.yml file works correctly", async () => {
+      await expect(service.read(reqDetails)).resolves.toMatchObject({
+        content: mockConfigContent,
+        sha: mockConfigSha,
+      })
+      expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+        fileName: CONFIG_FILE_NAME,
+      })
+    })
+  })
+
+  describe("Update", () => {
+    const oldSha = "54321"
+    mockGithubService.update.mockResolvedValueOnce({ newSha: mockConfigSha })
+    it("Updating _config.yml file works correctly", async () => {
+      await expect(
+        service.update(reqDetails, {
+          fileContent: mockConfigContent,
+          sha: oldSha,
+        })
+      ).resolves.toMatchObject({
+        newSha: mockConfigSha,
+      })
+      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+        fileName: CONFIG_FILE_NAME,
+        fileContent: mockRawConfigContent,
+        sha: oldSha,
+      })
+    })
+  })
+})

--- a/services/fileServices/YmlFileServices/__tests__/FooterYmlService.spec.js
+++ b/services/fileServices/YmlFileServices/__tests__/FooterYmlService.spec.js
@@ -1,0 +1,67 @@
+const {
+  footerContent: mockFooterContent,
+  footerSha: mockFooterSha,
+  rawFooterContent: mockRawFooterContent,
+} = require("../../../../fixtures/footer")
+const { FooterYmlService } = require("../FooterYmlService")
+
+describe("Footer Yml Service", () => {
+  const siteName = "test-site"
+  const accessToken = "test-token"
+  const reqDetails = { siteName, accessToken }
+
+  const FOOTER_FILE_NAME = "footer.yml"
+  const FOOTER_FILE_DIR = "_data"
+
+  const mockGithubService = {
+    create: jest.fn(),
+    read: jest.fn(),
+    update: jest.fn(),
+  }
+
+  const service = new FooterYmlService({
+    gitHubService: mockGithubService,
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("Read", () => {
+    mockGithubService.read.mockResolvedValueOnce({
+      content: mockRawFooterContent,
+      sha: mockFooterSha,
+    })
+    it("Reading the _data/footer.yml file works correctly", async () => {
+      await expect(service.read(reqDetails)).resolves.toMatchObject({
+        content: mockFooterContent,
+        sha: mockFooterSha,
+      })
+      expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+        fileName: FOOTER_FILE_NAME,
+        directoryName: FOOTER_FILE_DIR,
+      })
+    })
+  })
+
+  describe("Update", () => {
+    const oldSha = "54321"
+    mockGithubService.update.mockResolvedValueOnce({ newSha: mockFooterSha })
+    it("Updating _data/footer.yml file works correctly", async () => {
+      await expect(
+        service.update(reqDetails, {
+          fileContent: mockFooterContent,
+          sha: oldSha,
+        })
+      ).resolves.toMatchObject({
+        newSha: mockFooterSha,
+      })
+      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+        fileName: FOOTER_FILE_NAME,
+        directoryName: FOOTER_FILE_DIR,
+        fileContent: mockRawFooterContent,
+        sha: oldSha,
+      })
+    })
+  })
+})

--- a/services/fileServices/YmlFileServices/__tests__/NavYmlService.spec.js
+++ b/services/fileServices/YmlFileServices/__tests__/NavYmlService.spec.js
@@ -1,6 +1,11 @@
 const { deslugifyCollectionName } = require("@utils/utils")
 
 const {
+  navigationContent: mockNavigationContent,
+  navigationSha: mockNavigationSha,
+  rawNavigationContent: mockRawNavigationContent,
+} = require("../../../../fixtures/navigation")
+const {
   NavYmlService,
 } = require("@services/fileServices/YmlFileServices/NavYmlService")
 
@@ -16,7 +21,7 @@ describe("Nav Yml Service", () => {
   const fileName = NAV_FILE_NAME
   const collectionName = "collection"
   const directoryName = NAV_FILE_DIR
-  const sha = "12345"
+  
 
   const reqDetails = { siteName, accessToken }
   const mockParsedContent = {
@@ -57,8 +62,6 @@ describe("Nav Yml Service", () => {
       },
     ],
   }
-  const mockRawContent = yaml.stringify(mockParsedContent)
-
   const mockGithubService = {
     read: jest.fn(),
     update: jest.fn(),
@@ -74,37 +77,39 @@ describe("Nav Yml Service", () => {
 
   describe("Read", () => {
     mockGithubService.read.mockResolvedValueOnce({
-      content: mockRawContent,
-      sha,
-    }),
-      it("Reading the navigation.yml file works correctly", async () => {
-        await expect(service.read(reqDetails)).resolves.toMatchObject({
-          content: mockParsedContent,
-          sha,
-        })
-        expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
-          fileName,
-          directoryName,
-        })
+      content: mockRawNavigationContent,
+      sha: mockNavigationSha,
+    })
+    it("Reading the _data/navigation.yml file works correctly", async () => {
+      await expect(service.read(reqDetails)).resolves.toMatchObject({
+        content: mockNavigationContent,
+        sha: mockNavigationSha,
       })
+      expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+        fileName: NAV_FILE_NAME,
+        directoryName: NAV_FILE_DIR,
+      })
+    })
   })
 
   describe("Update", () => {
     const oldSha = "54321"
-    mockGithubService.update.mockResolvedValueOnce({ newSha: sha })
-    it("Updating raw content works correctly", async () => {
+    mockGithubService.update.mockResolvedValueOnce({
+      newSha: mockNavigationSha,
+    })
+    it("Updating _data/navigation.yml file works correctly", async () => {
       await expect(
         service.update(reqDetails, {
-          fileContent: mockParsedContent,
+          fileContent: mockNavigationContent,
           sha: oldSha,
         })
       ).resolves.toMatchObject({
-        newSha: sha,
+        newSha: mockNavigationSha,
       })
       expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
-        fileName,
-        directoryName,
-        fileContent: mockRawContent,
+        fileName: NAV_FILE_NAME,
+        directoryName: NAV_FILE_DIR,
+        fileContent: mockRawNavigationContent,
         sha: oldSha,
       })
     })
@@ -114,11 +119,12 @@ describe("Nav Yml Service", () => {
     const newSha = "54321"
     const newCollection = `new-collection`
     mockGithubService.read.mockResolvedValueOnce({
-      content: mockRawContent,
-      sha,
+      content: mockRawNavigationContent,
+      sha: mockNavigationSha,
     })
     const updatedMockParsedContent = {
-      links: mockParsedContent.links.concat({
+      ...mockNavigationContent,
+      links: mockNavigationContent.links.concat({
         title: deslugifyCollectionName(newCollection),
         collection: newCollection,
       }),
@@ -138,7 +144,7 @@ describe("Nav Yml Service", () => {
         fileName,
         directoryName,
         fileContent: yaml.stringify(updatedMockParsedContent),
-        sha,
+        sha: mockNavigationSha,
       })
     })
   })
@@ -147,11 +153,12 @@ describe("Nav Yml Service", () => {
     const newSha = "54321"
     const newCollection = `new-collection`
     mockGithubService.read.mockResolvedValueOnce({
-      content: mockRawContent,
-      sha,
+      content: mockRawNavigationContent,
+      sha: mockNavigationSha,
     })
     const updatedMockParsedContent = {
-      links: mockParsedContent.links.map((link) => {
+      ...mockNavigationContent,
+      links: mockNavigationContent.links.map((link) => {
         if (link.collection === collectionName) {
           return {
             title: deslugifyCollectionName(newCollection),
@@ -177,7 +184,7 @@ describe("Nav Yml Service", () => {
         fileName,
         directoryName,
         fileContent: yaml.stringify(updatedMockParsedContent),
-        sha,
+        sha: mockNavigationSha,
       })
     })
   })
@@ -185,11 +192,12 @@ describe("Nav Yml Service", () => {
   describe("deleteCollectionInNav", () => {
     const newSha = "54321"
     mockGithubService.read.mockResolvedValueOnce({
-      content: mockRawContent,
-      sha,
+      content: mockRawNavigationContent,
+      sha: mockNavigationSha,
     })
     const updatedMockParsedContent = {
-      links: mockParsedContent.links.filter(
+      ...mockNavigationContent,
+      links: mockNavigationContent.links.filter(
         (link) => link.collection !== collectionName
       ),
     }
@@ -208,7 +216,7 @@ describe("Nav Yml Service", () => {
         fileName,
         directoryName,
         fileContent: yaml.stringify(updatedMockParsedContent),
-        sha,
+        sha: mockNavigationSha,
       })
     })
   })

--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -107,6 +107,43 @@ const MoveResourceDirectoryPagesRequestSchema = Joi.object().keys({
     .required(),
   items: Joi.array().items(FileSchema).required(),
 })
+const UpdateSettingsRequestSchema = Joi.object().keys({
+  configSettings: Joi.object().keys({
+    colors: Joi.object().keys({
+      "primary-color": Joi.string(),
+      "secondary-color": Joi.string(),
+      "media-colors": Joi.array().items(
+        Joi.object().keys({
+          title: Joi.string(),
+          color: Joi.string(),
+        })
+      ),
+    }),
+    favicon: Joi.string(),
+    "facebook-pixel": Joi.string(),
+    google_analytics: Joi.string(),
+    "linkedin-insights": Joi.string(),
+    is_government: Joi.boolean(),
+    shareicon: Joi.string(),
+    title: Joi.string(),
+  }),
+  footerSettings: Joi.object().keys({
+    contact_us: Joi.string(),
+    feedback: Joi.string(),
+    faq: Joi.string(),
+    show_reach: Joi.boolean(),
+    social_media: Joi.object().keys({
+      facebook: Joi.string(),
+      twitter: Joi.string(),
+      youtube: Joi.string(),
+      instagram: Joi.string(),
+      linkedin: Joi.string(),
+    }),
+  }),
+  navigationSettings: Joi.object().keys({
+    logo: Joi.string(),
+  }),
+})
 
 module.exports = {
   CreatePageRequestSchema,
@@ -122,4 +159,5 @@ module.exports = {
   CreateResourceDirectoryRequestSchema,
   RenameResourceDirectoryRequestSchema,
   MoveResourceDirectoryPagesRequestSchema,
+  UpdateSettingsRequestSchema,
 }

--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -128,6 +128,7 @@ const UpdateSettingsRequestSchema = Joi.object().keys({
       is_government: Joi.boolean(),
       shareicon: Joi.string().allow(""),
       title: Joi.string().allow(""),
+      description: Joi.string().allow(""),
     })
     .required(),
   footerSettings: Joi.object()

--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -143,6 +143,8 @@ const UpdateSettingsRequestSchema = Joi.object().keys({
         youtube: Joi.string().allow(""),
         instagram: Joi.string().allow(""),
         linkedin: Joi.string().allow(""),
+        telegram: Joi.string().allow(""),
+        tiktok: Joi.string().allow(""),
       }),
     })
     .required(),

--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -109,50 +109,38 @@ const MoveResourceDirectoryPagesRequestSchema = Joi.object().keys({
   items: Joi.array().items(FileSchema).required(),
 })
 const UpdateSettingsRequestSchema = Joi.object().keys({
-  configSettings: Joi.object()
-    .keys({
-      colors: Joi.object().keys({
-        "primary-color": Joi.string().required(),
-        "secondary-color": Joi.string().required(),
-        "media-colors": Joi.array().items(
-          Joi.object().keys({
-            title: Joi.string().required(),
-            color: Joi.string().allow(""),
-          })
-        ),
-      }),
-      favicon: Joi.string(),
-      "facebook-pixel": Joi.string().allow(""),
-      google_analytics: Joi.string().allow(""),
-      "linkedin-insights": Joi.string().allow(""),
-      is_government: Joi.boolean(),
-      shareicon: Joi.string().allow(""),
-      title: Joi.string().allow(""),
-      description: Joi.string().allow(""),
-    })
-    .required(),
-  footerSettings: Joi.object()
-    .keys({
-      contact_us: Joi.string().allow(""),
-      feedback: Joi.string().allow(""),
-      faq: Joi.string().allow(""),
-      show_reach: Joi.boolean(),
-      social_media: Joi.object().keys({
-        facebook: Joi.string().allow(""),
-        twitter: Joi.string().allow(""),
-        youtube: Joi.string().allow(""),
-        instagram: Joi.string().allow(""),
-        linkedin: Joi.string().allow(""),
-        telegram: Joi.string().allow(""),
-        tiktok: Joi.string().allow(""),
-      }),
-    })
-    .required(),
-  navigationSettings: Joi.object()
-    .keys({
-      logo: Joi.string(),
-    })
-    .required(),
+  colors: Joi.object().keys({
+    "primary-color": Joi.string().required(),
+    "secondary-color": Joi.string().required(),
+    "media-colors": Joi.array().items(
+      Joi.object().keys({
+        title: Joi.string().required(),
+        color: Joi.string().allow(""),
+      })
+    ),
+  }),
+  favicon: Joi.string(),
+  "facebook-pixel": Joi.string().allow(""),
+  google_analytics: Joi.string().allow(""),
+  "linkedin-insights": Joi.string().allow(""),
+  is_government: Joi.boolean(),
+  shareicon: Joi.string().allow(""),
+  title: Joi.string().allow(""),
+  description: Joi.string().allow(""),
+  contact_us: Joi.string().allow(""),
+  feedback: Joi.string().allow(""),
+  faq: Joi.string().allow(""),
+  show_reach: Joi.boolean(),
+  social_media: Joi.object().keys({
+    facebook: Joi.string().allow(""),
+    twitter: Joi.string().allow(""),
+    youtube: Joi.string().allow(""),
+    instagram: Joi.string().allow(""),
+    linkedin: Joi.string().allow(""),
+    telegram: Joi.string().allow(""),
+    tiktok: Joi.string().allow(""),
+    logo: Joi.string(),
+  }),
 })
 
 module.exports = {

--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -139,8 +139,8 @@ const UpdateSettingsRequestSchema = Joi.object().keys({
     linkedin: Joi.string().allow(""),
     telegram: Joi.string().allow(""),
     tiktok: Joi.string().allow(""),
-    logo: Joi.string(),
   }),
+  logo: Joi.string().allow(""),
 })
 
 module.exports = {

--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -1,3 +1,4 @@
+const { required } = require("@root/node_modules/joi/lib/index")
 const Joi = require("joi")
 
 const FileSchema = Joi.object().keys({
@@ -108,41 +109,47 @@ const MoveResourceDirectoryPagesRequestSchema = Joi.object().keys({
   items: Joi.array().items(FileSchema).required(),
 })
 const UpdateSettingsRequestSchema = Joi.object().keys({
-  configSettings: Joi.object().keys({
-    colors: Joi.object().keys({
-      "primary-color": Joi.string(),
-      "secondary-color": Joi.string(),
-      "media-colors": Joi.array().items(
-        Joi.object().keys({
-          title: Joi.string(),
-          color: Joi.string(),
-        })
-      ),
-    }),
-    favicon: Joi.string(),
-    "facebook-pixel": Joi.string(),
-    google_analytics: Joi.string(),
-    "linkedin-insights": Joi.string(),
-    is_government: Joi.boolean(),
-    shareicon: Joi.string(),
-    title: Joi.string(),
-  }),
-  footerSettings: Joi.object().keys({
-    contact_us: Joi.string(),
-    feedback: Joi.string(),
-    faq: Joi.string(),
-    show_reach: Joi.boolean(),
-    social_media: Joi.object().keys({
-      facebook: Joi.string(),
-      twitter: Joi.string(),
-      youtube: Joi.string(),
-      instagram: Joi.string(),
-      linkedin: Joi.string(),
-    }),
-  }),
-  navigationSettings: Joi.object().keys({
-    logo: Joi.string(),
-  }),
+  configSettings: Joi.object()
+    .keys({
+      colors: Joi.object().keys({
+        "primary-color": Joi.string().required(),
+        "secondary-color": Joi.string().required(),
+        "media-colors": Joi.array().items(
+          Joi.object().keys({
+            title: Joi.string().required(),
+            color: Joi.string().allow(""),
+          })
+        ),
+      }),
+      favicon: Joi.string(),
+      "facebook-pixel": Joi.string().allow(""),
+      google_analytics: Joi.string().allow(""),
+      "linkedin-insights": Joi.string().allow(""),
+      is_government: Joi.boolean(),
+      shareicon: Joi.string().allow(""),
+      title: Joi.string().allow(""),
+    })
+    .required(),
+  footerSettings: Joi.object()
+    .keys({
+      contact_us: Joi.string().allow(""),
+      feedback: Joi.string().allow(""),
+      faq: Joi.string().allow(""),
+      show_reach: Joi.boolean(),
+      social_media: Joi.object().keys({
+        facebook: Joi.string().allow(""),
+        twitter: Joi.string().allow(""),
+        youtube: Joi.string().allow(""),
+        instagram: Joi.string().allow(""),
+        linkedin: Joi.string().allow(""),
+      }),
+    })
+    .required(),
+  navigationSettings: Joi.object()
+    .keys({
+      logo: Joi.string(),
+    })
+    .required(),
 })
 
 module.exports = {


### PR DESCRIPTION
**Note: this PR contains a BREAKING CHANGE.**

## Overview
This PR continues our efforts to refactor the CMS as specified by this design document ([link](https://docs.google.com/document/d/1664ww4X5PIy0mi5qB_q9JIWQaJ0qiLVIuV1v993Dlas/edit)). In this PR, I refactor the existing endpoints for reading and updating our repo settings:
- GET `/{siteName}/settings` - read settings
- POST `/{siteName}/settings` - update settings

The main change is the introduction of the new `SettingsRouter` class. The `SettingsRouter` uses the new `SettingsService` class which contains the bulk of the implementation logic, and uses the newly-created `ConfigYmlService`, `FooterYmlService`, `NavYmlService`, and `HomepagePageService` to simplify the retrieval and updating of settings data from different source files. There is some code duplication between the different service classes, but @alexanderleegs and I decided that any further simplification is out of the scope of this PR.

This PR adds a validation schema for the request body of the `updateSettingsPage` route function, and refactors the response sent from the `getSettingsPage` route function to match this schema. This is a **BREAKING CHANGE** and so this PR is to be reviewed in conjunction with PR #[618](https://github.com/isomerpages/isomercms-frontend/pull/618) on the frontend.

Finally, this PR also includes tests for the newly-introduced components in the same style as the existing tests. Some changes to testing include: 
- the creation of a `fixtures` directory which contains example test data that is reusable across different tests
- using `toHaveBeenLastCalledWith` instead of `toHaveBeenCalledWith`, so that we can make more accurate assertions (this is done in addition to the `jest.clearAllMocks()` invocation that is done in between tests)