### PR TITLE
fix(hotfix-master): update ebextension

### DIFF
--- a/.ebextensions/nginx-max-body-size.config
+++ b/.ebextensions/nginx-max-body-size.config
@@ -5,7 +5,3 @@ files:
         group: root
         content: |
            client_max_body_size 10M;
-
-commands:
-  00_reload_nginx:
-    command: "service nginx reload"


### PR DESCRIPTION
### Context

Deployments to AWS EB fail with the following error: 

`Command failed on instance. Return code: 7 Output: command 00_reload_nginx in .ebextensions/nginx-max-body-size.config failed. For more detail, check /var/log/eb-activity.log using console or EB CLI.`

We found a Stackoverflow recommendation that fixes the issue and tested it on the CMS staging environment:
https://stackoverflow.com/questions/40766708/issue-with-aws-beanstalk-command/48203336#48203336 

### Fix

We removed the unnecessary `service nginx reload` command and the deploy succeeded on staging.