### PR TITLE
hotfix (master): migrate to platform hooks

### DIFF
--- a/.ebextensions/nginx-max-body-size.config
+++ b/.ebextensions/nginx-max-body-size.config
@@ -1,7 +1,0 @@
-files:
-    "/etc/nginx/conf.d/proxy.conf" :
-        mode: "000755"
-        owner: root
-        group: root
-        content: |
-           client_max_body_size 10M;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   STAGING_BRANCH: refs/heads/staging
   DEV_BRANCH: refs/heads/staging-dev
   EB_APP: isomer-cms
-  EB_ENV_PRODUCTION: isomercms-backend-prod
+  EB_ENV_PRODUCTION: cms-backend-prod
   EB_ENV_STAGING: isomercms-backend-staging
   EB_ENV_DEV: isomercms-backend-staging-dev
   COMMIT_MESSAGE: ${{ github.event.head_commit.message }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         - name: Install NPM
           run: npm ci
         - name: Zip application
-          run: zip -r "deploy.zip" * .ebextensions .platform -x .env-example .gitignore package-lock.json
+          run: zip -r "deploy.zip" * .platform -x .env-example .gitignore package-lock.json
         - name: Get timestamp
           shell: bash
           run: echo "##[set-output name=timestamp;]$(env TZ=Asia/Singapore date '+%Y%m%d%H%M%S')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,9 @@ on:
 env:
   PRODUCTION_BRANCH: refs/heads/master
   STAGING_BRANCH: refs/heads/staging
-  DEV_BRANCH: refs/heads/staging-dev
   EB_APP: isomer-cms
   EB_ENV_PRODUCTION: cms-backend-prod
-  EB_ENV_STAGING: isomercms-backend-staging
-  EB_ENV_DEV: isomercms-backend-staging-dev
+  EB_ENV_STAGING: cms-backend-staging
   COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 jobs:
   gatekeep:
@@ -27,8 +25,7 @@ jobs:
           ref = os.environ['GITHUB_REF']
           prod = os.environ['PRODUCTION_BRANCH']
           staging = os.environ['STAGING_BRANCH']
-          dev = os.environ['DEV_BRANCH']
-          if ref == prod or ref == staging or ref == dev:
+          if ref == prod or ref == staging:
             print('::set-output name=proceed::true')
           else:
             print('::set-output name=proceed::false')
@@ -81,20 +78,15 @@ jobs:
             branch = os.environ['GITHUB_REF']
             production = os.environ['PRODUCTION_BRANCH']
             staging = os.environ['STAGING_BRANCH']
-            dev = os.environ['DEV_BRANCH']
             eb_app = os.environ['EB_APP']
             eb_env_production = os.environ['EB_ENV_PRODUCTION']
             eb_env_staging = os.environ['EB_ENV_STAGING']
-            eb_env_dev = os.environ['EB_ENV_DEV']
             if branch == production:
               print('::set-output name=eb_app::' + eb_app)
               print('::set-output name=eb_env::' + eb_env_production)
             elif branch == staging:
               print('::set-output name=eb_app::' + eb_app)
               print('::set-output name=eb_env::' + eb_env_staging)
-            elif branch == dev:
-              print('::set-output name=eb_app::' + eb_app)
-              print('::set-output name=eb_env::' + eb_env_dev)
           id: select_eb_vars
         - name: Deploy to EB
           uses: opengovsg/beanstalk-deploy@v11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         - name: Install NPM
           run: npm ci
         - name: Zip application
-          run: zip -r "deploy.zip" * .ebextensions -x .env-example .gitignore package-lock.json
+          run: zip -r "deploy.zip" * .ebextensions .platform -x .env-example .gitignore package-lock.json
         - name: Get timestamp
           shell: bash
           run: echo "##[set-output name=timestamp;]$(env TZ=Asia/Singapore date '+%Y%m%d%H%M%S')"

--- a/.platform/nginx/conf.d/proxy.conf
+++ b/.platform/nginx/conf.d/proxy.conf
@@ -1,0 +1,1 @@
+client_max_body_size  10M;

--- a/package.json
+++ b/package.json
@@ -97,5 +97,6 @@
       "eslint --fix",
       "prettier --write"
     ]
-  }
+  },
+  "engines": { "node" : ">=14.17.5" }
 }


### PR DESCRIPTION
### Context
We discovered that the staging CMS backend EB environment was unable to receive payloads of >1 MB - this led us to realize that there was an issue with the nginx `client_max_body_size  10M;` configuration in the `.ebextensions/nginx-max-body-size.conf` file.

We suspected that this happened because the Amazon Linux 2 platform uses platform hooks for nginx-specific configurations.

### Fix
This PR does the following:
- migrates the existing .ebextensions nginx configuration to use .platform hooks instead
- adds the `engines` field in the package.json file - was seeing the error `Instance deployment: You didn't specify a Node.js version in the 'package.json' file in your source bundle. The deployment didn't install a specific Node.js version.` ([link](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/nodejs-platform-dependencies.html))
- updates the CI file to reference `cms-backend-prod` for the prod EB env
- updates the CI file to reference `cms-backend-staging` for the staging EB env
- deletes all references to the DEV branch in the CI file since we no longer use it