### PR TITLE
ci: update production eb env name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   STAGING_BRANCH: refs/heads/staging
   DEV_BRANCH: refs/heads/staging-dev
   EB_APP: isomer-cms
-  EB_ENV_PRODUCTION: isomercms-backend-prod
+  EB_ENV_PRODUCTION: cms-backend-prod
   EB_ENV_STAGING: isomercms-backend-staging
   EB_ENV_DEV: isomercms-backend-staging-dev
   COMMIT_MESSAGE: ${{ github.event.head_commit.message }}


### PR DESCRIPTION
This PR changes the EB production environment name to the new `cms-backend-prod` env.

This PR is to be merged into the `hotfix/migrate-to-platform-hooks` branch, and then subsequently into master and develop.