### PR TITLE
Fix: prevent truncating of page body

### DIFF
--- a/utils/markdown-utils.js
+++ b/utils/markdown-utils.js
@@ -2,9 +2,9 @@ const yaml = require("yaml")
 
 const retrieveDataFromMarkdown = (fileContent) => {
   // eslint-disable-next-line no-unused-vars
-  const [unused, encodedFrontMatter, pageContent] = fileContent.split("---")
+  const [unused, encodedFrontMatter, ...pageContent] = fileContent.split("---")
   const frontMatter = yaml.parse(encodedFrontMatter)
-  return { frontMatter, pageContent }
+  return { frontMatter, pageContent: pageContent.join("---") }
 }
 
 const convertDataToMarkdown = (frontMatter, pageContent) => {


### PR DESCRIPTION
This PR fixes an issue where having `---` in the page body would truncate the contents when viewed on the CMS. This was due to our reliance on this string to denote the location of the frontmatter. This PR modifies the check for frontmatter to only search for the first 2 occurrences of this, to prevent this behaviour.