### PR TITLE
Fix: handle 409 errors when editing files

### DIFF
--- a/classes/File.js
+++ b/classes/File.js
@@ -131,6 +131,10 @@ class File {
     } catch (err) {
       const { status } = err.response
       if (status === 404) throw new NotFoundError("File does not exist")
+      if (status === 409)
+        throw new ConflictError(
+          "File has been changed recently, please try again"
+        )
       throw err
     }
   }

--- a/classes/File.js
+++ b/classes/File.js
@@ -159,6 +159,10 @@ class File {
     } catch (err) {
       const { status } = err.response
       if (status === 404) throw new NotFoundError("File does not exist")
+      if (status === 409)
+        throw new ConflictError(
+          "File has been changed recently, please try again"
+        )
       throw err
     }
   }

--- a/classes/MediaFile.js
+++ b/classes/MediaFile.js
@@ -157,14 +157,24 @@ class MediaFile {
       sha,
     }
 
-    const resp = await axios.put(endpoint, params, {
-      headers: {
-        Authorization: `token ${this.accessToken}`,
-        "Content-Type": "application/json",
-      },
-    })
+    try {
+      const resp = await axios.put(endpoint, params, {
+        headers: {
+          Authorization: `token ${this.accessToken}`,
+          "Content-Type": "application/json",
+        },
+      })
 
-    return { newSha: resp.data.commit.sha }
+      return { newSha: resp.data.commit.sha }
+    } catch (err) {
+      const { status } = err.response
+      if (status === 404) throw new NotFoundError("File does not exist")
+      if (status === 409)
+        throw new ConflictError(
+          "File has been changed recently, please try again"
+        )
+      throw err
+    }
   }
 
   async delete(fileName, sha) {
@@ -176,13 +186,23 @@ class MediaFile {
       sha,
     }
 
-    await axios.delete(endpoint, {
-      data: params,
-      headers: {
-        Authorization: `token ${this.accessToken}`,
-        "Content-Type": "application/json",
-      },
-    })
+    try {
+      await axios.delete(endpoint, {
+        data: params,
+        headers: {
+          Authorization: `token ${this.accessToken}`,
+          "Content-Type": "application/json",
+        },
+      })
+    } catch (err) {
+      const { status } = err.response
+      if (status === 404) throw new NotFoundError("File does not exist")
+      if (status === 409)
+        throw new ConflictError(
+          "File has been changed recently, please try again"
+        )
+      throw err
+    }
   }
 }
 

--- a/services/db/GitHubService.js
+++ b/services/db/GitHubService.js
@@ -177,6 +177,10 @@ class GitHubService {
     } catch (err) {
       const { status } = err.response
       if (status === 404) throw new NotFoundError("File does not exist")
+      if (status === 409)
+        throw new ConflictError(
+          "File has been changed recently, please try again"
+        )
       throw err
     }
   }

--- a/services/db/GitHubService.js
+++ b/services/db/GitHubService.js
@@ -140,6 +140,10 @@ class GitHubService {
       if (err instanceof NotFoundError) throw err
       const { status } = err.response
       if (status === 404) throw new NotFoundError("File does not exist")
+      if (status === 409)
+        throw new ConflictError(
+          "File has been changed recently, please try again"
+        )
       throw err
     }
   }


### PR DESCRIPTION
This PR fixes a bug where we were not handling 409 errors when sending update requests to Github. When users attempt to modify a page with an outdated sha, a 409 error is received, which we previously did not anticipate. This PR fixes this by correctly catching and throwing an appropriate error.