### PR TITLE
Fix: change git tree object format

### DIFF
--- a/classes/Collection.js
+++ b/classes/Collection.js
@@ -149,7 +149,8 @@ class Collection {
     const newCollectionDirectoryName = `_${newCollectionName}`
     const newGitTree = []
     gitTree.forEach((item) => {
-      if (item.path === oldCollectionDirectoryName) {
+      if (item.path === oldCollectionDirectoryName && item.type === "tree") {
+        // Rename old subdirectory to new name
         newGitTree.push({
           ...item,
           path: newCollectionDirectoryName,
@@ -158,6 +159,7 @@ class Collection {
         item.path.startsWith(`${oldCollectionDirectoryName}/`) &&
         item.type !== "tree"
       ) {
+        // Delete old subdirectory items
         newGitTree.push({
           ...item,
           sha: null,

--- a/classes/MediaSubfolder.js
+++ b/classes/MediaSubfolder.js
@@ -36,17 +36,17 @@ class MediaSubfolder {
     )
     const directoryName = `${this.mediaFolderName}/${subfolderPath}`
     const newGitTree = gitTree
-      .filter((item) => {
-        return !item.path.includes(directoryName)
-      })
-      .filter((item) => {
-        return !(
-          item.type === "tree" && item.path.includes(this.mediaFolderName)
-        )
-      })
-
+      .filter(
+        (item) =>
+          item.type !== "tree" && item.path.startsWith(`${directoryName}/`)
+      )
+      .map((item) => ({
+        ...item,
+        sha: null,
+      }))
     await sendTree(
       newGitTree,
+      treeSha,
       currentCommitSha,
       this.siteName,
       this.accessToken,
@@ -72,19 +72,19 @@ class MediaSubfolder {
           ...item,
           path: newDirectoryName,
         })
-      } else if (item.path.includes(oldDirectoryName)) {
-        // We don't want to include these because they use the old path, they are included with the renamed tree
       } else if (
-        item.type === "tree" &&
-        item.path.includes(this.mediaFolderName)
+        item.path.startsWith(`${oldDirectoryName}/`) &&
+        item.type !== "tree"
       ) {
-        // We don't include any other trees - we reconstruct them by adding all their individual files instead
-      } else {
-        newGitTree.push(item)
+        newGitTree.push({
+          ...item,
+          sha: null,
+        })
       }
     })
     await sendTree(
       newGitTree,
+      treeSha,
       currentCommitSha,
       this.siteName,
       this.accessToken,

--- a/classes/MediaSubfolder.js
+++ b/classes/MediaSubfolder.js
@@ -67,7 +67,8 @@ class MediaSubfolder {
     const newDirectoryName = `${this.mediaFolderName}/${newSubfolderPath}`
     const newGitTree = []
     gitTree.forEach((item) => {
-      if (item.path === oldDirectoryName) {
+      if (item.path === oldDirectoryName && item.type === "tree") {
+        // Rename old subdirectory to new name
         newGitTree.push({
           ...item,
           path: newDirectoryName,
@@ -76,6 +77,7 @@ class MediaSubfolder {
         item.path.startsWith(`${oldDirectoryName}/`) &&
         item.type !== "tree"
       ) {
+        // Delete old subdirectory items
         newGitTree.push({
           ...item,
           sha: null,

--- a/classes/Resource.js
+++ b/classes/Resource.js
@@ -68,7 +68,11 @@ class Resource {
     const newGitTree = []
     gitTree.forEach((item) => {
       // We need to append resource room to the file path because the path is relative to the subtree
-      if (item.path === `${resourceRoomName}/${resourceName}`) {
+      if (
+        item.path === `${resourceRoomName}/${resourceName}` &&
+        item.type === "tree"
+      ) {
+        // Rename old subdirectory to new name
         newGitTree.push({
           ...item,
           path: `${resourceRoomName}/${newResourceName}`,
@@ -77,6 +81,7 @@ class Resource {
         item.path.startsWith(`${resourceRoomName}/${resourceName}/`) &&
         item.type !== "tree"
       ) {
+        // Delete old subdirectory items
         newGitTree.push({
           ...item,
           sha: null,

--- a/classes/Resource.js
+++ b/classes/Resource.js
@@ -59,38 +59,33 @@ class Resource {
       this.siteName,
       this.accessToken
     )
-    const gitTree = await getTree(this.siteName, this.accessToken, treeSha)
-    const newGitTree = []
-    let resourceRoomTreeSha
-    // Retrieve all git trees of other items
-    gitTree.forEach((item) => {
-      if (item.path === resourceRoomName) {
-        resourceRoomTreeSha = item.sha
-      } else {
-        newGitTree.push(item)
-      }
-    })
-    const resourceRoomTree = await getTree(
+    const gitTree = await getTree(
       this.siteName,
       this.accessToken,
-      resourceRoomTreeSha
+      treeSha,
+      true
     )
-    resourceRoomTree.forEach((item) => {
+    const newGitTree = []
+    gitTree.forEach((item) => {
       // We need to append resource room to the file path because the path is relative to the subtree
-      if (item.path === resourceName) {
+      if (item.path === `${resourceRoomName}/${resourceName}`) {
         newGitTree.push({
           ...item,
           path: `${resourceRoomName}/${newResourceName}`,
         })
-      } else {
+      } else if (
+        item.path.startsWith(`${resourceRoomName}/${resourceName}/`) &&
+        item.type !== "tree"
+      ) {
         newGitTree.push({
           ...item,
-          path: `${resourceRoomName}/${item.path}`,
+          sha: null,
         })
       }
     })
     await sendTree(
       newGitTree,
+      treeSha,
       currentCommitSha,
       this.siteName,
       this.accessToken,

--- a/classes/ResourceRoom.js
+++ b/classes/ResourceRoom.js
@@ -121,18 +121,32 @@ class ResourceRoom {
       this.siteName,
       this.accessToken
     )
-    const gitTree = await getTree(this.siteName, this.accessToken, treeSha)
-    const newGitTree = gitTree.map((item) => {
+    const gitTree = await getTree(
+      this.siteName,
+      this.accessToken,
+      treeSha,
+      true
+    )
+    const newGitTree = []
+    gitTree.forEach((item) => {
       if (item.path === resourceRoomName) {
-        return {
+        newGitTree.push({
           ...item,
           path: newResourceRoom,
-        }
+        })
+      } else if (
+        item.path.startsWith(`${resourceRoomName}/`) &&
+        item.type !== "tree"
+      ) {
+        newGitTree.push({
+          ...item,
+          sha: null,
+        })
       }
-      return item
     })
     await sendTree(
       newGitTree,
+      treeSha,
       currentCommitSha,
       this.siteName,
       this.accessToken,
@@ -197,9 +211,9 @@ class ResourceRoom {
     const resources = await IsomerResource.list(resourceRoomName)
 
     if (!_.isEmpty(resources)) {
-      await Bluebird.map(resources, async (resource) => {
-        return IsomerResource.delete(resourceRoomName, resource.dirName)
-      })
+      await Bluebird.map(resources, async (resource) =>
+        IsomerResource.delete(resourceRoomName, resource.dirName)
+      )
     }
 
     // Delete index file in resourceRoom

--- a/classes/ResourceRoom.js
+++ b/classes/ResourceRoom.js
@@ -129,7 +129,8 @@ class ResourceRoom {
     )
     const newGitTree = []
     gitTree.forEach((item) => {
-      if (item.path === resourceRoomName) {
+      if (item.path === resourceRoomName && item.type === "tree") {
+        // Rename old subdirectory to new name
         newGitTree.push({
           ...item,
           path: newResourceRoom,
@@ -138,6 +139,7 @@ class ResourceRoom {
         item.path.startsWith(`${resourceRoomName}/`) &&
         item.type !== "tree"
       ) {
+        // Delete old subdirectory items
         newGitTree.push({
           ...item,
           sha: null,

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -63,6 +63,7 @@ async function getTree(
 // send the new tree object back to Github and point the latest commit on the staging branch to it
 async function sendTree(
   gitTree,
+  baseTreeSha,
   currentCommitSha,
   repo,
   accessToken,
@@ -77,6 +78,7 @@ async function sendTree(
     `https://api.github.com/repos/${GITHUB_ORG_NAME}/${repo}/git/trees`,
     {
       tree: gitTree,
+      base_tree: baseTreeSha,
     },
     {
       headers,


### PR DESCRIPTION
This PR fixes an issue with git trees being too large for sites with a large number of files. Previously, when we wanted to use git trees to delete/rename directories, we would send the information of every file in the repo as a git tree - this resulted in 502 errors as github was unable to parse such a large amount of files. 

Recently, github has updated their API to allow for specifying that files are deleted via leaving the sha of the target files as `null` (see [link](https://developer.github.com/enterprise/2.17/v3/git/trees/#create-a-tree)). This method is much more space efficient, as the number of files deleted is significantly less than the total number of files in a repo.

We hypothesise that this PR will resolve our issues with unrecognised 502 errors.