### PR TITLE
Refactor/resources refactor

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -375,6 +375,32 @@ auth.post(
   verifyJwt
 )
 
+// Resource Categories
+auth.get(
+  "/v2/sites/:siteName/resourceRoom/:resourceRoomName/resources",
+  verifyJwt
+)
+auth.get(
+  "/v2/sites/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory",
+  verifyJwt
+)
+auth.post(
+  "/v2/sites/:siteName/resourceRoom/:resourceRoomName/resources",
+  verifyJwt
+)
+auth.post(
+  "/v2/sites/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory",
+  verifyJwt
+)
+auth.delete(
+  "/v2/sites/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory",
+  verifyJwt
+)
+auth.post(
+  "/v2/sites/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/move",
+  verifyJwt
+)
+
 auth.use((req, res, next) => {
   if (!req.route) {
     return res.status(404).send("Unauthorised for unknown route")

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -324,6 +324,24 @@ auth.delete(
   verifyJwt
 )
 
+// Resource Pages
+auth.post(
+  "/v2/sites/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/pages",
+  verifyJwt
+)
+auth.get(
+  "/v2/sites/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/pages/:pageName",
+  verifyJwt
+)
+auth.post(
+  "/v2/sites/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/pages/:pageName",
+  verifyJwt
+)
+auth.delete(
+  "/v2/sites/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/pages/:pageName",
+  verifyJwt
+)
+
 // Collections
 auth.get("/v2/sites/:siteName/collections", verifyJwt)
 auth.get("/v2/sites/:siteName/collections/:collectionName", verifyJwt)

--- a/newroutes/__tests__/ResourceCategories.spec.js
+++ b/newroutes/__tests__/ResourceCategories.spec.js
@@ -1,0 +1,260 @@
+const express = require("express")
+const request = require("supertest")
+
+const { errorHandler } = require("@middleware/errorHandler")
+const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
+
+const { ResourceCategoriesRouter } = require("../resourceCategories")
+
+describe("Resource Categories Router", () => {
+  const mockResourceDirectoryService = {
+    listAllResourceCategories: jest.fn(),
+    listFiles: jest.fn(),
+    createResourceDirectory: jest.fn(),
+    renameResourceDirectory: jest.fn(),
+    deleteResourceDirectory: jest.fn(),
+    moveResourcePages: jest.fn(),
+  }
+
+  const router = new ResourceCategoriesRouter({
+    resourceDirectoryService: mockResourceDirectoryService,
+  })
+
+  const app = express()
+  app.use(express.json({ limit: "7mb" }))
+  app.use(express.urlencoded({ extended: false }))
+
+  // We can use read route handler here because we don't need to lock the repo
+  app.get(
+    "/:siteName/resourceRoom/:resourceRoomName/resources",
+    attachReadRouteHandlerWrapper(router.listAllResourceCategories)
+  )
+  app.get(
+    "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory",
+    attachReadRouteHandlerWrapper(router.listResourceDirectoryFiles)
+  )
+  app.post(
+    "/:siteName/resourceRoom/:resourceRoomName/resources",
+    attachReadRouteHandlerWrapper(router.createResourceDirectory)
+  )
+  app.post(
+    "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory",
+    attachReadRouteHandlerWrapper(router.renameResourceDirectory)
+  )
+  app.delete(
+    "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory",
+    attachReadRouteHandlerWrapper(router.deleteResourceDirectory)
+  )
+  app.post(
+    "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/move",
+    attachReadRouteHandlerWrapper(router.moveResourceDirectoryPages)
+  )
+
+  app.use(errorHandler)
+
+  const siteName = "test-site"
+  const resourceRoomName = "resource-room"
+  const resourceCategory = "resource-category"
+
+  // Can't set request fields - will always be undefined
+  const accessToken = undefined
+  const currentCommitSha = undefined
+  const treeSha = undefined
+
+  const reqDetails = { siteName, accessToken }
+  const additionalReqDetails = { ...reqDetails, currentCommitSha, treeSha }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("listAllResourceCategories", () => {
+    it("lists the set of all resource categories", async () => {
+      const expectedResponse = [
+        {
+          name: "test-cat",
+          type: "dir",
+        },
+        {
+          name: "test-cate2",
+          type: "dir",
+        },
+      ]
+      mockResourceDirectoryService.listAllResourceCategories.mockResolvedValueOnce(
+        expectedResponse
+      )
+      const resp = await request(app)
+        .get(`/${siteName}/resourceRoom/${resourceRoomName}/resources`)
+        .expect(200)
+      expect(resp.body).toStrictEqual(expectedResponse)
+      expect(
+        mockResourceDirectoryService.listAllResourceCategories
+      ).toHaveBeenCalledWith(reqDetails, { resourceRoomName })
+    })
+  })
+
+  describe("listResourceDirectoryFiles", () => {
+    it("returns the details of all files in a resource", async () => {
+      const expectedResponse = [
+        {
+          name: "testfile",
+          type: "file",
+        },
+        {
+          name: "testfile1",
+          type: "file",
+        },
+        {
+          name: "testfile2",
+          type: "file",
+        },
+      ]
+      mockResourceDirectoryService.listFiles.mockResolvedValueOnce(
+        expectedResponse
+      )
+      const resp = await request(app)
+        .get(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}`
+        )
+        .expect(200)
+      expect(resp.body).toStrictEqual(expectedResponse)
+      expect(
+        mockResourceDirectoryService.listFiles
+      ).toHaveBeenCalledWith(reqDetails, { resourceRoomName, resourceCategory })
+    })
+  })
+
+  describe("createResourceDirectory", () => {
+    it("rejects requests with invalid body", async () => {
+      await request(app)
+        .post(`/${siteName}/resourceRoom/${resourceRoomName}/resources`)
+        .send({})
+        .expect(400)
+    })
+
+    it("accepts valid category create requests and returns the details of the category created", async () => {
+      mockResourceDirectoryService.createResourceDirectory.mockResolvedValueOnce(
+        {}
+      )
+      const resourceDetails = {
+        newDirectoryName: resourceCategory,
+      }
+      const resp = await request(app)
+        .post(`/${siteName}/resourceRoom/${resourceRoomName}/resources`)
+        .send(resourceDetails)
+        .expect(200)
+      expect(resp.body).toStrictEqual({})
+      expect(
+        mockResourceDirectoryService.createResourceDirectory
+      ).toHaveBeenCalledWith(reqDetails, {
+        resourceRoomName,
+        resourceCategory,
+      })
+    })
+  })
+
+  describe("renameResourceDirectory", () => {
+    const newDirectoryName = "new-dir"
+
+    it("rejects requests with invalid body", async () => {
+      await request(app)
+        .post(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}`
+        )
+        .send({})
+        .expect(400)
+    })
+
+    it("accepts valid resource rename requests", async () => {
+      await request(app)
+        .post(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}`
+        )
+        .send({ newDirectoryName })
+        .expect(200)
+      expect(
+        mockResourceDirectoryService.renameResourceDirectory
+      ).toHaveBeenCalledWith(reqDetails, {
+        resourceRoomName,
+        resourceCategory,
+        newDirectoryName,
+      })
+    })
+  })
+
+  describe("deleteResourceDirectory", () => {
+    it("accepts valid resource delete requests", async () => {
+      await request(app)
+        .delete(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}`
+        )
+        .expect(200)
+      expect(
+        mockResourceDirectoryService.deleteResourceDirectory
+      ).toHaveBeenCalledWith(reqDetails, {
+        resourceRoomName,
+        resourceCategory,
+      })
+    })
+  })
+
+  describe("moveResourceDirectoryPages", () => {
+    const targetResourceCategory = "resource"
+    const items = [
+      {
+        name: "testfile",
+        type: "file",
+      },
+      {
+        name: "testfile1",
+        type: "file",
+      },
+    ]
+    it("rejects move requests with invalid body", async () => {
+      await request(app)
+        .post(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}/move`
+        )
+        .send({})
+        .expect(400)
+    })
+
+    it("rejects move requests with invalid body", async () => {
+      await request(app)
+        .post(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}/move`
+        )
+        .send({
+          target: { resourceCategory: targetResourceCategory },
+          items: items.concat({ name: "testdir", type: "dir" }),
+        })
+        .expect(400)
+    })
+
+    it("rejects move requests with invalid body", async () => {
+      await request(app)
+        .post(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}/move`
+        )
+        .send({ target: {}, items })
+        .expect(400)
+    })
+
+    it("accepts valid resource page move requests to another resource", async () => {
+      await request(app)
+        .post(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}/move`
+        )
+        .send({ items, target: { resourceCategory: targetResourceCategory } })
+        .expect(200)
+      expect(
+        mockResourceDirectoryService.moveResourcePages
+      ).toHaveBeenCalledWith(reqDetails, {
+        resourceRoomName,
+        resourceCategory,
+        targetResourceCategory,
+        objArray: items,
+      })
+    })
+  })
+})

--- a/newroutes/resourceCategories.js
+++ b/newroutes/resourceCategories.js
@@ -1,0 +1,164 @@
+const autoBind = require("auto-bind")
+const express = require("express")
+
+// Import middleware
+const { BadRequestError } = require("@errors/BadRequestError")
+
+const {
+  attachReadRouteHandlerWrapper,
+  attachRollbackRouteHandlerWrapper,
+} = require("@middleware/routeHandler")
+
+const {
+  CreateResourceDirectoryRequestSchema,
+  RenameResourceDirectoryRequestSchema,
+  MoveResourceDirectoryPagesRequestSchema,
+} = require("@validators/RequestSchema")
+
+class ResourceCategoriesRouter {
+  constructor({ resourceDirectoryService }) {
+    this.resourceDirectoryService = resourceDirectoryService
+    // We need to bind all methods because we don't invoke them from the class directly
+    autoBind(this)
+  }
+
+  // List all resource categories
+  async listAllResourceCategories(req, res) {
+    const { accessToken } = req
+
+    const { siteName, resourceRoomName } = req.params
+    const listResp = await this.resourceDirectoryService.listAllResourceCategories(
+      {
+        siteName,
+        accessToken,
+      },
+      {
+        resourceRoomName,
+      }
+    )
+
+    return res.status(200).json(listResp)
+  }
+
+  // List files in a resource category
+  async listResourceDirectoryFiles(req, res) {
+    const { accessToken } = req
+
+    const { siteName, resourceRoomName, resourceCategory } = req.params
+    const listResp = await this.resourceDirectoryService.listFiles(
+      { siteName, accessToken },
+      { resourceRoomName, resourceCategory }
+    )
+    return res.status(200).json(listResp)
+  }
+
+  // Create new resource category
+  async createResourceDirectory(req, res) {
+    const { accessToken } = req
+
+    const { siteName, resourceRoomName } = req.params
+    const { error } = CreateResourceDirectoryRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error.message)
+    const { newDirectoryName } = req.body
+    const createResp = await this.resourceDirectoryService.createResourceDirectory(
+      { siteName, accessToken },
+      {
+        resourceRoomName,
+        resourceCategory: newDirectoryName,
+      }
+    )
+
+    return res.status(200).json(createResp)
+  }
+
+  // Rename resource category
+  async renameResourceDirectory(req, res) {
+    const { accessToken, currentCommitSha, treeSha } = req
+
+    const { siteName, resourceRoomName, resourceCategory } = req.params
+    const { error } = RenameResourceDirectoryRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error.message)
+    const { newDirectoryName } = req.body
+    await this.resourceDirectoryService.renameResourceDirectory(
+      { siteName, accessToken, currentCommitSha, treeSha },
+      {
+        resourceRoomName,
+        resourceCategory,
+        newDirectoryName,
+      }
+    )
+
+    return res.status(200).send("OK")
+  }
+
+  // Delete resource category
+  async deleteResourceDirectory(req, res) {
+    const { accessToken, currentCommitSha, treeSha } = req
+
+    const { siteName, resourceRoomName, resourceCategory } = req.params
+    await this.resourceDirectoryService.deleteResourceDirectory(
+      { siteName, accessToken, currentCommitSha, treeSha },
+      {
+        resourceRoomName,
+        resourceCategory,
+      }
+    )
+    return res.status(200).send("OK")
+  }
+
+  // Move resource category
+  async moveResourceDirectoryPages(req, res) {
+    const { accessToken } = req
+
+    const { siteName, resourceRoomName, resourceCategory } = req.params
+    const { error } = MoveResourceDirectoryPagesRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error.message)
+    const {
+      items,
+      target: { resourceCategory: targetResourceCategory },
+    } = req.body
+    await this.resourceDirectoryService.moveResourcePages(
+      { siteName, accessToken },
+      {
+        resourceRoomName,
+        resourceCategory,
+        targetResourceCategory,
+        objArray: items,
+      }
+    )
+    return res.status(200).send("OK")
+  }
+
+  getRouter() {
+    const router = express.Router()
+
+    router.get(
+      "/:siteName/resourceRoom/:resourceRoomName/resources",
+      attachReadRouteHandlerWrapper(this.listAllResourceCategories)
+    )
+    router.get(
+      "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory",
+      attachReadRouteHandlerWrapper(this.listResourceDirectoryFiles)
+    )
+    router.post(
+      "/:siteName/resourceRoom/:resourceRoomName/resources",
+      attachRollbackRouteHandlerWrapper(this.createResourceDirectory)
+    )
+    router.post(
+      "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory",
+      attachRollbackRouteHandlerWrapper(this.renameResourceDirectory)
+    )
+    router.delete(
+      "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory",
+      attachRollbackRouteHandlerWrapper(this.deleteResourceDirectory)
+    )
+    router.post(
+      "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/move",
+      attachRollbackRouteHandlerWrapper(this.moveResourceDirectoryPages)
+    )
+
+    return router
+  }
+}
+
+module.exports = { ResourceCategoriesRouter }

--- a/newroutes/resourcePages.js
+++ b/newroutes/resourcePages.js
@@ -1,0 +1,160 @@
+const autoBind = require("auto-bind")
+const express = require("express")
+
+// Import middleware
+const { BadRequestError } = require("@errors/BadRequestError")
+
+const {
+  attachReadRouteHandlerWrapper,
+  attachWriteRouteHandlerWrapper,
+  attachRollbackRouteHandlerWrapper,
+} = require("@middleware/routeHandler")
+
+const {
+  CreateResourcePageRequestSchema,
+  UpdateResourcePageRequestSchema,
+  DeleteResourcePageRequestSchema,
+} = require("@validators/RequestSchema")
+
+class ResourcePagesRouter {
+  constructor({ resourcePageService }) {
+    this.resourcePageService = resourcePageService
+    // We need to bind all methods because we don't invoke them from the class directly
+    autoBind(this)
+  }
+
+  // Create new page in resource category
+  async createResourcePage(req, res) {
+    const { accessToken } = req
+
+    const { siteName, resourceRoomName, resourceCategory } = req.params
+    const { error } = CreateResourcePageRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error.message)
+    const {
+      content: { frontMatter, pageBody },
+      newFileName,
+    } = req.body
+    const reqDetails = { siteName, accessToken }
+    const createResp = await this.resourcePageService.create(reqDetails, {
+      fileName: newFileName,
+      resourceRoomName,
+      resourceCategory,
+      content: pageBody,
+      frontMatter,
+    })
+
+    return res.status(200).json(createResp)
+  }
+
+  // Read page in resource category
+  async readResourcePage(req, res) {
+    const { accessToken } = req
+
+    const {
+      siteName,
+      resourceRoomName,
+      resourceCategory,
+      pageName,
+    } = req.params
+
+    const reqDetails = { siteName, accessToken }
+    const readResp = await this.resourcePageService.read(reqDetails, {
+      fileName: pageName,
+      resourceRoomName,
+      resourceCategory,
+    })
+
+    return res.status(200).json(readResp)
+  }
+
+  // Update page in resource category
+  async updateResourcePage(req, res) {
+    const { accessToken } = req
+
+    const {
+      siteName,
+      resourceRoomName,
+      resourceCategory,
+      pageName,
+    } = req.params
+    const { error } = UpdateResourcePageRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error)
+    const {
+      content: { frontMatter, pageBody },
+      sha,
+      newFileName,
+    } = req.body
+    const reqDetails = { siteName, accessToken }
+    let updateResp
+    if (newFileName) {
+      updateResp = await this.resourcePageService.rename(reqDetails, {
+        oldFileName: pageName,
+        newFileName,
+        resourceRoomName,
+        resourceCategory,
+        content: pageBody,
+        frontMatter,
+        sha,
+      })
+    } else {
+      updateResp = await this.resourcePageService.update(reqDetails, {
+        fileName: pageName,
+        resourceRoomName,
+        resourceCategory,
+        content: pageBody,
+        frontMatter,
+        sha,
+      })
+    }
+    return res.status(200).json(updateResp)
+  }
+
+  // Delete page in resource category
+  async deleteResourcePage(req, res) {
+    const { accessToken } = req
+
+    const {
+      siteName,
+      resourceRoomName,
+      resourceCategory,
+      pageName,
+    } = req.params
+    const { error } = DeleteResourcePageRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error)
+    const { sha } = req.body
+    const reqDetails = { siteName, accessToken }
+    await this.resourcePageService.delete(reqDetails, {
+      fileName: pageName,
+      resourceRoomName,
+      resourceCategory,
+      sha,
+    })
+
+    return res.status(200).send("OK")
+  }
+
+  getRouter() {
+    const router = express.Router()
+
+    router.post(
+      "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/pages",
+      attachRollbackRouteHandlerWrapper(this.createResourcePage)
+    )
+    router.get(
+      "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/pages/:pageName",
+      attachReadRouteHandlerWrapper(this.readResourcePage)
+    )
+    router.post(
+      "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/pages/:pageName",
+      attachWriteRouteHandlerWrapper(this.updateResourcePage)
+    )
+    router.delete(
+      "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/pages/:pageName",
+      attachRollbackRouteHandlerWrapper(this.deleteResourcePage)
+    )
+
+    return router
+  }
+}
+
+module.exports = { ResourcePagesRouter }

--- a/server.js
+++ b/server.js
@@ -59,6 +59,9 @@ const {
   CollectionDirectoryService,
 } = require("@services/directoryServices/CollectionDirectoryService")
 const {
+  ResourceDirectoryService,
+} = require("@services/directoryServices/ResourceDirectoryService")
+const {
   SubcollectionDirectoryService,
 } = require("@services/directoryServices/SubcollectionDirectoryService")
 const {
@@ -83,6 +86,7 @@ const { MoverService } = require("@services/moverServices/MoverService")
 
 const { CollectionPagesRouter } = require("./newroutes/collectionPages")
 const { CollectionsRouter } = require("./newroutes/collections")
+const { ResourceCategoriesRouter } = require("./newroutes/resourceCategories")
 const { ResourcePagesRouter } = require("./newroutes/resourcePages")
 const { UnlinkedPagesRouter } = require("./newroutes/unlinkedPages")
 
@@ -122,6 +126,10 @@ const subcollectionDirectoryService = new SubcollectionDirectoryService({
   subcollectionPageService,
   gitHubService,
 })
+const resourceDirectoryService = new ResourceDirectoryService({
+  baseDirectoryService,
+  gitHubService,
+})
 
 const unlinkedPagesRouter = new UnlinkedPagesRouter({
   unlinkedPageService,
@@ -137,6 +145,9 @@ const collectionsV2Router = new CollectionsRouter({
 })
 const resourcePagesV2Router = new ResourcePagesRouter({
   resourcePageService,
+})
+const resourceDirectoryV2Router = new ResourceCategoriesRouter({
+  resourceDirectoryService,
 })
 
 const app = express()
@@ -184,6 +195,7 @@ app.use("/v2/sites", collectionPagesV2Router.getRouter())
 app.use("/v2/sites", unlinkedPagesRouter.getRouter())
 app.use("/v2/sites", collectionsV2Router.getRouter())
 app.use("/v2/sites", resourcePagesV2Router.getRouter())
+app.use("/v2/sites", resourceDirectoryV2Router.getRouter())
 
 app.use("/v2/ping", (req, res, next) => res.status(200).send("Ok"))
 

--- a/server.js
+++ b/server.js
@@ -68,6 +68,9 @@ const {
   CollectionPageService,
 } = require("@services/fileServices/MdPageServices/CollectionPageService")
 const {
+  ResourcePageService,
+} = require("@services/fileServices/MdPageServices/ResourcePageService")
+const {
   UnlinkedPageService,
 } = require("@services/fileServices/MdPageServices/UnlinkedPageService")
 const {
@@ -80,6 +83,7 @@ const { MoverService } = require("@services/moverServices/MoverService")
 
 const { CollectionPagesRouter } = require("./newroutes/collectionPages")
 const { CollectionsRouter } = require("./newroutes/collections")
+const { ResourcePagesRouter } = require("./newroutes/resourcePages")
 const { UnlinkedPagesRouter } = require("./newroutes/unlinkedPages")
 
 const gitHubService = new GitHubService({ axiosInstance })
@@ -94,6 +98,7 @@ const subcollectionPageService = new SubcollectionPageService({
   collectionYmlService,
 })
 const unlinkedPageService = new UnlinkedPageService({ gitHubService })
+const resourcePageService = new ResourcePageService({ gitHubService })
 const moverService = new MoverService({
   unlinkedPageService,
   collectionPageService,
@@ -129,6 +134,9 @@ const collectionPagesV2Router = new CollectionPagesRouter({
 const collectionsV2Router = new CollectionsRouter({
   collectionDirectoryService,
   subcollectionDirectoryService,
+})
+const resourcePagesV2Router = new ResourcePagesRouter({
+  resourcePageService,
 })
 
 const app = express()
@@ -175,6 +183,7 @@ app.use("/v1/sites", netlifyTomlRouter)
 app.use("/v2/sites", collectionPagesV2Router.getRouter())
 app.use("/v2/sites", unlinkedPagesRouter.getRouter())
 app.use("/v2/sites", collectionsV2Router.getRouter())
+app.use("/v2/sites", resourcePagesV2Router.getRouter())
 
 app.use("/v2/ping", (req, res, next) => res.status(200).send("Ok"))
 

--- a/services/directoryServices/ResourceDirectoryService.js
+++ b/services/directoryServices/ResourceDirectoryService.js
@@ -1,0 +1,164 @@
+const { BadRequestError } = require("@errors/BadRequestError")
+
+const {
+  retrieveDataFromMarkdown,
+  convertDataToMarkdown,
+} = require("@utils/markdown-utils")
+const { slugifyCollectionName } = require("@utils/utils")
+
+const INDEX_FILE_NAME = "index.html"
+
+class ResourceDirectoryService {
+  constructor({ baseDirectoryService, gitHubService }) {
+    this.baseDirectoryService = baseDirectoryService
+    this.gitHubService = gitHubService
+  }
+
+  getResourceDirectoryPath({ resourceRoomName, resourceCategory }) {
+    return `${resourceRoomName}/${resourceCategory}`
+  }
+
+  async listAllResourceCategories(reqDetails, { resourceRoomName }) {
+    const filesOrDirs = await this.baseDirectoryService.list(reqDetails, {
+      directoryName: `${resourceRoomName}`,
+    })
+    return filesOrDirs.reduce((acc, curr) => {
+      if (curr.type === "dir")
+        acc.push({
+          name: curr.name,
+          type: "dir",
+        })
+      return acc
+    }, [])
+  }
+
+  async listFiles(reqDetails, { resourceRoomName, resourceCategory }) {
+    const filesOrDirs = await this.baseDirectoryService.list(reqDetails, {
+      directoryName: `${this.getResourceDirectoryPath({
+        resourceRoomName,
+        resourceCategory,
+      })}/_posts`,
+    })
+
+    return filesOrDirs.reduce((acc, curr) => {
+      if (curr.type === "file")
+        acc.push({
+          name: curr.name,
+          type: "file",
+        })
+      return acc
+    }, [])
+  }
+
+  async createResourceDirectory(
+    reqDetails,
+    { resourceRoomName, resourceCategory }
+  ) {
+    if (/[^a-zA-Z0-9- ]/g.test(resourceCategory)) {
+      // Contains non-allowed characters
+      throw new BadRequestError(
+        "Special characters not allowed in resource category name"
+      )
+    }
+    const slugifiedResourceCategoryName = slugifyCollectionName(
+      resourceCategory
+    )
+    const frontMatter = {
+      layout: "resources-alt",
+      title: resourceCategory,
+    }
+    const newContent = convertDataToMarkdown(frontMatter, "")
+    await this.gitHubService.create(reqDetails, {
+      content: newContent,
+      fileName: INDEX_FILE_NAME,
+      directoryName: this.getResourceDirectoryPath({
+        resourceRoomName,
+        resourceCategory: slugifiedResourceCategoryName,
+      }),
+    })
+    return {
+      newDirectoryName: slugifiedResourceCategoryName,
+    }
+  }
+
+  async renameResourceDirectory(
+    reqDetails,
+    { resourceRoomName, resourceCategory, newDirectoryName }
+  ) {
+    if (/[^a-zA-Z0-9- ]/g.test(newDirectoryName)) {
+      // Contains non-allowed characters
+      throw new BadRequestError(
+        "Special characters not allowed in resource category name"
+      )
+    }
+    const oldDirectoryName = this.getResourceDirectoryPath({
+      resourceRoomName,
+      resourceCategory,
+    })
+    const slugifiedNewResourceCategoryName = slugifyCollectionName(
+      newDirectoryName
+    )
+    const { content: rawContent, sha } = await this.gitHubService.read(
+      reqDetails,
+      {
+        fileName: INDEX_FILE_NAME,
+        directoryName: oldDirectoryName,
+      }
+    )
+    const { frontMatter, pageContent } = retrieveDataFromMarkdown(rawContent)
+    frontMatter.title = newDirectoryName
+    const newContent = convertDataToMarkdown(frontMatter, pageContent)
+    await this.gitHubService.update(reqDetails, {
+      fileContent: newContent,
+      sha,
+      fileName: INDEX_FILE_NAME,
+      directoryName: oldDirectoryName,
+    })
+
+    await this.baseDirectoryService.rename(reqDetails, {
+      oldDirectoryName,
+      newDirectoryName: this.getResourceDirectoryPath({
+        resourceRoomName,
+        resourceCategory: slugifiedNewResourceCategoryName,
+      }),
+      message: `Renaming resource category ${resourceCategory} to ${slugifiedNewResourceCategoryName}`,
+    })
+  }
+
+  async deleteResourceDirectory(
+    reqDetails,
+    { resourceRoomName, resourceCategory }
+  ) {
+    await this.baseDirectoryService.delete(reqDetails, {
+      directoryName: this.getResourceDirectoryPath({
+        resourceRoomName,
+        resourceCategory,
+      }),
+      message: `Deleting resource category ${resourceCategory}`,
+    })
+  }
+
+  async moveResourcePages(
+    reqDetails,
+    { resourceRoomName, resourceCategory, targetResourceCategory, objArray }
+  ) {
+    const targetFiles = objArray.map((item) => item.name)
+    const oldDirectoryName = `${this.getResourceDirectoryPath({
+      resourceRoomName,
+      resourceCategory,
+    })}/_posts`
+    const newDirectoryName = `${this.getResourceDirectoryPath({
+      resourceRoomName,
+      resourceCategory: targetResourceCategory,
+    })}/_posts`
+
+    await this.baseDirectoryService.moveFiles(reqDetails, {
+      oldDirectoryName,
+      newDirectoryName,
+      targetFiles,
+      message: `Moving resource pages from ${resourceCategory} to ${targetResourceCategory}`,
+    })
+  }
+}
+
+module.exports = { ResourceDirectoryService }

--- a/services/directoryServices/__tests__/BaseDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/BaseDirectoryService.spec.js
@@ -40,6 +40,14 @@ describe("Base Directory Service", () => {
     },
     {
       type: "file",
+      path: `${directoryName}/${subcollectionName}/file2.md`,
+    },
+    {
+      type: "file",
+      path: `${directoryName}/${subcollectionName}/file3.md`,
+    },
+    {
+      type: "file",
       path: `_to-keep/${directoryName}/${subcollectionName}/file.md`,
     },
   ]
@@ -115,6 +123,16 @@ describe("Base Directory Service", () => {
         path: `${directoryName}/${subcollectionName}/file.md`,
         sha: null,
       },
+      {
+        type: "file",
+        path: `${directoryName}/${subcollectionName}/file2.md`,
+        sha: null,
+      },
+      {
+        type: "file",
+        path: `${directoryName}/${subcollectionName}/file3.md`,
+        sha: null,
+      },
     ]
     mockGithubService.getTree.mockResolvedValueOnce(mockedTree)
     mockGithubService.updateTree.mockResolvedValueOnce(sha)
@@ -154,6 +172,16 @@ describe("Base Directory Service", () => {
         path: `${directoryName}/${subcollectionName}/file.md`,
         sha: null,
       },
+      {
+        type: "file",
+        path: `${directoryName}/${subcollectionName}/file2.md`,
+        sha: null,
+      },
+      {
+        type: "file",
+        path: `${directoryName}/${subcollectionName}/file3.md`,
+        sha: null,
+      },
     ]
     mockGithubService.getTree.mockResolvedValueOnce(mockedTree)
     mockGithubService.updateTree.mockResolvedValueOnce(sha)
@@ -169,6 +197,55 @@ describe("Base Directory Service", () => {
       })
       expect(mockGithubService.updateTree).toHaveBeenCalledWith(reqDetails, {
         gitTree: mockedDeletedTree,
+        message,
+      })
+      expect(mockGithubService.updateRepoState).toHaveBeenCalledWith(
+        reqDetails,
+        {
+          commitSha: sha,
+        }
+      )
+    })
+  })
+
+  describe("Move Files", () => {
+    const targetDir = "_target-dir"
+    const mockedMovedTree = [
+      {
+        type: "file",
+        path: `${targetDir}/file.md`,
+      },
+      {
+        type: "file",
+        path: `${directoryName}/${subcollectionName}/file.md`,
+        sha: null,
+      },
+      {
+        type: "file",
+        path: `${targetDir}/file2.md`,
+      },
+      {
+        type: "file",
+        path: `${directoryName}/${subcollectionName}/file2.md`,
+        sha: null,
+      },
+    ]
+    mockGithubService.getTree.mockResolvedValueOnce(mockedTree)
+    mockGithubService.updateTree.mockResolvedValueOnce(sha)
+    it("Moving files in directories works correctly", async () => {
+      await expect(
+        service.moveFiles(reqDetails, {
+          oldDirectoryName: `${directoryName}/${subcollectionName}`,
+          newDirectoryName: targetDir,
+          targetFiles: ["file.md", "file2.md"],
+          message,
+        })
+      ).resolves.not.toThrow()
+      expect(mockGithubService.getTree).toHaveBeenCalledWith(reqDetails, {
+        isRecursive: true,
+      })
+      expect(mockGithubService.updateTree).toHaveBeenCalledWith(reqDetails, {
+        gitTree: mockedMovedTree,
         message,
       })
       expect(mockGithubService.updateRepoState).toHaveBeenCalledWith(

--- a/services/directoryServices/__tests__/CollectionDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/CollectionDirectoryService.spec.js
@@ -299,25 +299,25 @@ describe("Collection Directory Service", () => {
       const slugifiedCollectionName = "test-collection"
       await expect(
         service.renameDirectory(reqDetails, {
-          collectionName: originalCollectionName,
-          newDirectoryName: slugifiedCollectionName,
+          collectionName,
+          newDirectoryName: originalCollectionName,
         })
       ).resolves.not.toThrowError()
       expect(mockBaseDirectoryService.rename).toHaveBeenCalledWith(reqDetails, {
-        oldDirectoryName: `_${originalCollectionName}`,
+        oldDirectoryName: `_${collectionName}`,
         newDirectoryName: `_${slugifiedCollectionName}`,
-        message: `Renaming collection ${originalCollectionName} to ${slugifiedCollectionName}`,
+        message: `Renaming collection ${collectionName} to ${slugifiedCollectionName}`,
       })
       expect(
         mockCollectionYmlService.renameCollectionInOrder
       ).toHaveBeenCalledWith(reqDetails, {
-        oldCollectionName: originalCollectionName,
+        oldCollectionName: collectionName,
         newCollectionName: slugifiedCollectionName,
       })
       expect(mockNavYmlService.renameCollectionInNav).toHaveBeenCalledWith(
         reqDetails,
         {
-          oldCollectionName: originalCollectionName,
+          oldCollectionName: collectionName,
           newCollectionName: slugifiedCollectionName,
         }
       )

--- a/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
@@ -1,0 +1,332 @@
+const { BadRequestError } = require("@errors/BadRequestError")
+
+const INDEX_FILE_NAME = "index.html"
+
+describe("Resource Directory Service", () => {
+  const siteName = "test-site"
+  const accessToken = "test-token"
+  const resourceCategory = "resource-cat"
+  const resourceRoomName = "resource-room"
+  const directoryName = `${resourceRoomName}/${resourceCategory}`
+  const mockContent = ""
+  const mockMarkdownContent = "---test---"
+  const mockFrontMatter = {
+    layout: "resources-alt",
+    title: resourceCategory,
+  }
+  const sha = "12345"
+
+  const objArray = [
+    {
+      type: "file",
+      name: "file.md",
+    },
+    {
+      type: "file",
+      name: `file2.md`,
+    },
+  ]
+
+  const reqDetails = { siteName, accessToken }
+
+  const mockBaseDirectoryService = {
+    list: jest.fn(),
+    rename: jest.fn(),
+    delete: jest.fn(),
+    moveFiles: jest.fn(),
+  }
+
+  const mockGitHubService = {
+    create: jest.fn(),
+    read: jest.fn(),
+    update: jest.fn(),
+  }
+
+  jest.mock("@utils/markdown-utils", () => ({
+    retrieveDataFromMarkdown: jest.fn().mockReturnValue({
+      frontMatter: mockFrontMatter,
+      pageContent: mockContent,
+    }),
+    convertDataToMarkdown: jest.fn().mockReturnValue(mockMarkdownContent),
+  }))
+  const {
+    ResourceDirectoryService,
+  } = require("@services/directoryServices/ResourceDirectoryService")
+  const service = new ResourceDirectoryService({
+    baseDirectoryService: mockBaseDirectoryService,
+    gitHubService: mockGitHubService,
+  })
+  const {
+    convertDataToMarkdown,
+    retrieveDataFromMarkdown,
+  } = require("@utils/markdown-utils")
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("ListAllResourceCategories", () => {
+    const listResp = [
+      {
+        name: "index.html",
+        path: `${resourceRoomName}/index.html`,
+        sha: "test-sha0",
+        size: 10,
+        type: "file",
+      },
+      {
+        name: resourceCategory,
+        path: `${resourceRoomName}/${resourceCategory}`,
+        sha: "test-sha4",
+        size: 10,
+        type: "dir",
+      },
+      {
+        name: `category-2`,
+        path: `${resourceRoomName}/category-2`,
+        sha: "test-sha5",
+        size: 10,
+        type: "dir",
+      },
+    ]
+    const expectedResp = [
+      {
+        name: resourceCategory,
+        type: "dir",
+      },
+      {
+        name: `category-2`,
+        type: "dir",
+      },
+    ]
+    mockBaseDirectoryService.list.mockResolvedValueOnce(listResp)
+    it("Listing resource categories returns the full list of resource categories", async () => {
+      await expect(
+        service.listAllResourceCategories(reqDetails, { resourceRoomName })
+      ).resolves.toMatchObject(expectedResp)
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+        directoryName: resourceRoomName,
+      })
+    })
+  })
+
+  describe("ListFiles", () => {
+    const listResp = [
+      {
+        name: "2021-10-13-file-example-title1.md",
+        path: `${directoryName}/_posts/2021-10-13-file-example-title1.md`,
+        sha: "test-sha0",
+        size: 10,
+        type: "file",
+      },
+      {
+        name: "2021-10-06-post-example-title.md",
+        path: `${directoryName}/_posts/2021-10-06-post-example-title.md`,
+        sha: "test-sha4",
+        size: 10,
+        type: "file",
+      },
+    ]
+    const expectedResp = [
+      {
+        name: "2021-10-13-file-example-title1.md",
+        type: "file",
+      },
+      {
+        name: "2021-10-06-post-example-title.md",
+        type: "file",
+      },
+    ]
+    mockBaseDirectoryService.list.mockResolvedValueOnce(listResp)
+    it("ListFiles returns all files in the category", async () => {
+      await expect(
+        service.listFiles(reqDetails, { resourceRoomName, resourceCategory })
+      ).resolves.toMatchObject(expectedResp)
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+        directoryName: `${directoryName}/_posts`,
+      })
+    })
+  })
+
+  describe("CreateResourceDirectory", () => {
+    it("rejects resource categories with special characters", async () => {
+      await expect(
+        service.createResourceDirectory(reqDetails, {
+          resourceRoomName,
+          resourceCategory: "dir/dir",
+        })
+      ).rejects.toThrowError(BadRequestError)
+    })
+
+    it("Creating a resource category works correctly", async () => {
+      await expect(
+        service.createResourceDirectory(reqDetails, {
+          resourceRoomName,
+          resourceCategory,
+        })
+      ).resolves.toMatchObject({
+        newDirectoryName: resourceCategory,
+      })
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        { ...mockFrontMatter },
+        mockContent
+      )
+      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: mockMarkdownContent,
+        fileName: INDEX_FILE_NAME,
+        directoryName,
+      })
+    })
+
+    it("Creating a resource category slugifies the name", async () => {
+      const originalCategoryName = "Test Category"
+      const slugifiedCategoryName = "test-category"
+      await expect(
+        service.createResourceDirectory(reqDetails, {
+          resourceRoomName,
+          resourceCategory: originalCategoryName,
+        })
+      ).resolves.toMatchObject({
+        newDirectoryName: slugifiedCategoryName,
+      })
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        {
+          ...mockFrontMatter,
+          title: originalCategoryName,
+        },
+        mockContent
+      )
+      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: mockMarkdownContent,
+        fileName: INDEX_FILE_NAME,
+        directoryName: `${resourceRoomName}/${slugifiedCategoryName}`,
+      })
+    })
+  })
+
+  describe("RenameResourceDirectory", () => {
+    const newDirectoryName = "new-dir"
+    it("rejects resource categories with special characters", async () => {
+      await expect(
+        service.renameResourceDirectory(reqDetails, {
+          resourceRoomName,
+          resourceCategory,
+          newDirectoryName: "dir/dir",
+        })
+      ).rejects.toThrowError(BadRequestError)
+    })
+    mockGitHubService.read.mockResolvedValueOnce({
+      content: mockMarkdownContent,
+      sha,
+    })
+    it("Renaming a resource category works correctly", async () => {
+      await expect(
+        service.renameResourceDirectory(reqDetails, {
+          resourceRoomName,
+          resourceCategory,
+          newDirectoryName,
+        })
+      ).resolves.not.toThrowError()
+      expect(mockGitHubService.read).toHaveBeenCalledWith(reqDetails, {
+        fileName: INDEX_FILE_NAME,
+        directoryName,
+      })
+      expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(mockMarkdownContent)
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        {
+          ...mockFrontMatter,
+          title: newDirectoryName,
+        },
+        mockContent
+      )
+      expect(mockGitHubService.update).toHaveBeenCalledWith(reqDetails, {
+        fileContent: mockMarkdownContent,
+        sha,
+        fileName: INDEX_FILE_NAME,
+        directoryName,
+      })
+      expect(mockBaseDirectoryService.rename).toHaveBeenCalledWith(reqDetails, {
+        oldDirectoryName: directoryName,
+        newDirectoryName: `${resourceRoomName}/${newDirectoryName}`,
+        message: `Renaming resource category ${resourceCategory} to ${newDirectoryName}`,
+      })
+    })
+    mockGitHubService.read.mockResolvedValueOnce({
+      content: mockMarkdownContent,
+      sha,
+    })
+    it("Renaming a resource category slugifies the name correctly", async () => {
+      const originalResourceCategory = "Test Resource"
+      const slugifiedResourceCategory = "test-resource"
+      await expect(
+        service.renameResourceDirectory(reqDetails, {
+          resourceRoomName,
+          resourceCategory,
+          newDirectoryName: originalResourceCategory,
+        })
+      ).resolves.not.toThrowError()
+      expect(mockGitHubService.read).toHaveBeenCalledWith(reqDetails, {
+        fileName: INDEX_FILE_NAME,
+        directoryName,
+      })
+      expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(mockMarkdownContent)
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        {
+          ...mockFrontMatter,
+          title: originalResourceCategory,
+        },
+        mockContent
+      )
+      expect(mockGitHubService.update).toHaveBeenCalledWith(reqDetails, {
+        fileContent: mockMarkdownContent,
+        sha,
+        fileName: INDEX_FILE_NAME,
+        directoryName,
+      })
+      expect(mockBaseDirectoryService.rename).toHaveBeenCalledWith(reqDetails, {
+        oldDirectoryName: directoryName,
+        newDirectoryName: `${resourceRoomName}/${slugifiedResourceCategory}`,
+        message: `Renaming resource category ${resourceCategory} to ${slugifiedResourceCategory}`,
+      })
+    })
+  })
+
+  describe("DeleteResourceDirectory", () => {
+    it("Deleting a resource category works correctly", async () => {
+      await expect(
+        service.deleteResourceDirectory(reqDetails, {
+          resourceRoomName,
+          resourceCategory,
+        })
+      ).resolves.not.toThrowError()
+      expect(mockBaseDirectoryService.delete).toHaveBeenCalledWith(reqDetails, {
+        directoryName,
+        message: `Deleting resource category ${resourceCategory}`,
+      })
+    })
+  })
+
+  describe("MoveResourcePages", () => {
+    const targetResourceCategory = "target-resource"
+    const targetFiles = ["file.md", "file2.md"]
+    it("Moving resource pages works correctly", async () => {
+      await expect(
+        service.moveResourcePages(reqDetails, {
+          resourceRoomName,
+          resourceCategory,
+          targetResourceCategory,
+          objArray,
+        })
+      ).resolves.not.toThrowError()
+      expect(mockBaseDirectoryService.moveFiles).toHaveBeenCalledWith(
+        reqDetails,
+        {
+          oldDirectoryName: `${directoryName}/_posts`,
+          newDirectoryName: `${resourceRoomName}/${targetResourceCategory}/_posts`,
+          targetFiles,
+          message: `Moving resource pages from ${resourceCategory} to ${targetResourceCategory}`,
+        }
+      )
+    })
+  })
+})

--- a/services/fileServices/MdPageServices/ResourcePageService.js
+++ b/services/fileServices/MdPageServices/ResourcePageService.js
@@ -1,0 +1,136 @@
+const { BadRequestError } = require("@errors/BadRequestError")
+
+const {
+  retrieveDataFromMarkdown,
+  convertDataToMarkdown,
+} = require("@utils/markdown-utils")
+
+const { titleSpecialCharCheck } = require("@validators/validators")
+
+class ResourcePageService {
+  constructor({ gitHubService }) {
+    this.gitHubService = gitHubService
+  }
+
+  getResourceDirectoryPath({ resourceRoomName, resourceCategory }) {
+    return `${resourceRoomName}/${resourceCategory}/_posts`
+  }
+
+  async create(
+    reqDetails,
+    { fileName, resourceRoomName, resourceCategory, content, frontMatter }
+  ) {
+    if (titleSpecialCharCheck({ title: fileName, isFile: true }))
+      throw new BadRequestError("Special characters not allowed in file name")
+    const parsedDirectoryName = this.getResourceDirectoryPath({
+      resourceRoomName,
+      resourceCategory,
+    })
+
+    const newContent = convertDataToMarkdown(frontMatter, content)
+
+    const { sha } = await this.gitHubService.create(reqDetails, {
+      content: newContent,
+      fileName,
+      directoryName: parsedDirectoryName,
+    })
+    return { fileName, content: { frontMatter, pageBody: content }, sha }
+  }
+
+  async read(reqDetails, { fileName, resourceRoomName, resourceCategory }) {
+    const parsedDirectoryName = this.getResourceDirectoryPath({
+      resourceRoomName,
+      resourceCategory,
+    })
+    const { content: rawContent, sha } = await this.gitHubService.read(
+      reqDetails,
+      {
+        fileName,
+        directoryName: parsedDirectoryName,
+      }
+    )
+    const { frontMatter, pageContent } = retrieveDataFromMarkdown(rawContent)
+    return { fileName, content: { frontMatter, pageBody: pageContent }, sha }
+  }
+
+  async update(
+    reqDetails,
+    { fileName, resourceRoomName, resourceCategory, content, frontMatter, sha }
+  ) {
+    const parsedDirectoryName = this.getResourceDirectoryPath({
+      resourceRoomName,
+      resourceCategory,
+    })
+    const newContent = convertDataToMarkdown(frontMatter, content)
+    const { newSha } = await this.gitHubService.update(reqDetails, {
+      fileContent: newContent,
+      sha,
+      fileName,
+      directoryName: parsedDirectoryName,
+    })
+    return {
+      fileName,
+      content: { frontMatter, pageBody: content },
+      oldSha: sha,
+      newSha,
+    }
+  }
+
+  async delete(
+    reqDetails,
+    { fileName, resourceRoomName, resourceCategory, sha }
+  ) {
+    const parsedDirectoryName = this.getResourceDirectoryPath({
+      resourceRoomName,
+      resourceCategory,
+    })
+
+    return this.gitHubService.delete(reqDetails, {
+      sha,
+      fileName,
+      directoryName: parsedDirectoryName,
+    })
+  }
+
+  async rename(
+    reqDetails,
+    {
+      oldFileName,
+      newFileName,
+      resourceRoomName,
+      resourceCategory,
+      content,
+      frontMatter,
+      sha,
+    }
+  ) {
+    if (titleSpecialCharCheck({ title: newFileName, isFile: true }))
+      throw new BadRequestError("Special characters not allowed in file name")
+    const parsedDirectoryName = this.getResourceDirectoryPath({
+      resourceRoomName,
+      resourceCategory,
+    })
+
+    await this.gitHubService.delete(reqDetails, {
+      sha,
+      fileName: oldFileName,
+      directoryName: parsedDirectoryName,
+    })
+
+    const newContent = convertDataToMarkdown(frontMatter, content)
+
+    const { sha: newSha } = await this.gitHubService.create(reqDetails, {
+      content: newContent,
+      fileName: newFileName,
+      directoryName: parsedDirectoryName,
+    })
+    return {
+      fileName: newFileName,
+      content: { frontMatter, pageBody: content },
+      oldSha: sha,
+      newSha,
+    }
+  }
+}
+
+module.exports = { ResourcePageService }

--- a/services/fileServices/MdPageServices/__tests__/ResourcePageService.spec.js
+++ b/services/fileServices/MdPageServices/__tests__/ResourcePageService.spec.js
@@ -1,0 +1,210 @@
+const { BadRequestError } = require("@errors/BadRequestError")
+
+describe("Resource Page Service", () => {
+  const siteName = "test-site"
+  const accessToken = "test-token"
+  const fileName = "test file.md"
+  const resourceRoomName = "resource-room"
+  const resourceCategory = "category"
+  const directoryName = `${resourceRoomName}/${resourceCategory}/_posts`
+  const mockContent = "test"
+  const mockMarkdownContent = "---test---"
+  const mockFrontMatter = {
+    title: "fileTitle",
+    permalink: "file/permalink",
+  }
+  const sha = "12345"
+
+  const reqDetails = { siteName, accessToken }
+
+  const mockGithubService = {
+    create: jest.fn(),
+    read: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  }
+
+  jest.mock("@utils/markdown-utils", () => ({
+    retrieveDataFromMarkdown: jest.fn().mockReturnValue({
+      frontMatter: mockFrontMatter,
+      pageContent: mockContent,
+    }),
+    convertDataToMarkdown: jest.fn().mockReturnValue(mockMarkdownContent),
+  }))
+  const {
+    ResourcePageService,
+  } = require("@services/fileServices/MdPageServices/ResourcePageService")
+  const service = new ResourcePageService({
+    gitHubService: mockGithubService,
+  })
+  const {
+    retrieveDataFromMarkdown,
+    convertDataToMarkdown,
+  } = require("@utils/markdown-utils")
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("Create", () => {
+    mockGithubService.create.mockResolvedValue({ sha })
+    it("rejects page names with special characters", async () => {
+      await expect(
+        service.create(reqDetails, {
+          fileName: "file/file.md",
+          resourceRoomName,
+          resourceCategory,
+          content: mockContent,
+          frontMatter: { ...mockFrontMatter },
+        })
+      ).rejects.toThrowError(BadRequestError)
+    })
+    it("Creating pages works correctly", async () => {
+      await expect(
+        service.create(reqDetails, {
+          fileName,
+          resourceRoomName,
+          resourceCategory,
+          content: mockContent,
+          frontMatter: { ...mockFrontMatter },
+        })
+      ).resolves.toMatchObject({
+        fileName,
+        content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+        sha,
+      })
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        { ...mockFrontMatter },
+        mockContent
+      )
+      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: mockMarkdownContent,
+        fileName,
+        directoryName,
+      })
+    })
+  })
+
+  describe("Read", () => {
+    mockGithubService.read.mockResolvedValue({
+      content: mockMarkdownContent,
+      sha,
+    }),
+      it("Reading pages works correctly", async () => {
+        await expect(
+          service.read(reqDetails, {
+            fileName,
+            resourceRoomName,
+            resourceCategory,
+          })
+        ).resolves.toMatchObject({
+          fileName,
+          content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+          sha,
+        })
+        expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(
+          mockMarkdownContent
+        )
+        expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+          fileName,
+          directoryName,
+        })
+      })
+  })
+
+  describe("Update", () => {
+    const oldSha = "54321"
+    mockGithubService.update.mockResolvedValue({ newSha: sha })
+    it("Updating page content works correctly", async () => {
+      await expect(
+        service.update(reqDetails, {
+          fileName,
+          resourceRoomName,
+          resourceCategory,
+          content: mockContent,
+          frontMatter: mockFrontMatter,
+          sha: oldSha,
+        })
+      ).resolves.toMatchObject({
+        fileName,
+        content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+        oldSha,
+        newSha: sha,
+      })
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        mockFrontMatter,
+        mockContent
+      )
+      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+        fileName,
+        directoryName,
+        fileContent: mockMarkdownContent,
+        sha: oldSha,
+      })
+    })
+  })
+
+  describe("Delete", () => {
+    it("Deleting pages works correctly", async () => {
+      await expect(
+        service.delete(reqDetails, {
+          fileName,
+          resourceRoomName,
+          resourceCategory,
+          sha,
+        })
+      ).resolves.not.toThrow()
+      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+        fileName,
+        directoryName,
+        sha,
+      })
+    })
+  })
+
+  describe("Rename", () => {
+    const oldSha = "54321"
+    const oldFileName = "test-old-file"
+    mockGithubService.create.mockResolvedValue({ sha })
+    it("rejects renaming to page names with special characters", async () => {
+      await expect(
+        service.rename(reqDetails, {
+          oldFileName,
+          newFileName: "file/file.md",
+          resourceRoomName,
+          resourceCategory,
+          content: mockContent,
+          frontMatter: { ...mockFrontMatter },
+        })
+      ).rejects.toThrowError(BadRequestError)
+    })
+    it("Renaming pages works correctly", async () => {
+      await expect(
+        service.rename(reqDetails, {
+          oldFileName,
+          newFileName: fileName,
+          resourceRoomName,
+          resourceCategory,
+          content: mockContent,
+          frontMatter: mockFrontMatter,
+          sha: oldSha,
+        })
+      ).resolves.toMatchObject({
+        fileName,
+        content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+        oldSha,
+        newSha: sha,
+      })
+      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+        fileName: oldFileName,
+        directoryName,
+        sha: oldSha,
+      })
+      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: mockMarkdownContent,
+        fileName,
+        directoryName,
+      })
+    })
+  })
+})

--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -1,5 +1,15 @@
 const Joi = require("joi")
 
+const FileSchema = Joi.object().keys({
+  name: Joi.string().required(),
+  type: Joi.string().valid("file").required(),
+})
+
+const ItemSchema = FileSchema.keys({
+  type: Joi.string().valid("file", "dir").required(),
+  children: Joi.array().items(Joi.string()),
+})
+
 // Pages
 const FrontMatterSchema = Joi.object({
   title: Joi.string().required(),
@@ -27,17 +37,36 @@ const DeletePageRequestSchema = Joi.object().keys({
   sha: Joi.string().required(),
 })
 
+// Resource Pages
+const ResourceFrontMatterSchema = Joi.object({
+  title: Joi.string().required(),
+  date: Joi.string().required(),
+  permalink: Joi.string().required(),
+  layout: Joi.string().valid("post"),
+  file_url: Joi.string(),
+}).unknown(true)
+
+const ResourceContentSchema = Joi.object({
+  frontMatter: ResourceFrontMatterSchema.required(),
+  pageBody: Joi.string().allow(""),
+})
+
+const CreateResourcePageRequestSchema = Joi.object().keys({
+  content: ResourceContentSchema.required(),
+  newFileName: Joi.string().required(),
+})
+
+const UpdateResourcePageRequestSchema = Joi.object().keys({
+  content: ResourceContentSchema.required(),
+  sha: Joi.string().required(),
+  newFileName: Joi.string(),
+})
+
+const DeleteResourcePageRequestSchema = Joi.object().keys({
+  sha: Joi.string().required(),
+})
+
 // Collections
-const FileSchema = Joi.object().keys({
-  name: Joi.string().required(),
-  type: Joi.string().valid("file").required(),
-})
-
-const ItemSchema = FileSchema.keys({
-  type: Joi.string().valid("file", "dir").required(),
-  children: Joi.array().items(Joi.string()),
-})
-
 const CreateDirectoryRequestSchema = Joi.object().keys({
   newDirectoryName: Joi.string().required(),
   items: Joi.array().items(FileSchema),
@@ -65,6 +94,9 @@ module.exports = {
   CreatePageRequestSchema,
   UpdatePageRequestSchema,
   DeletePageRequestSchema,
+  CreateResourcePageRequestSchema,
+  UpdateResourcePageRequestSchema,
+  DeleteResourcePageRequestSchema,
   CreateDirectoryRequestSchema,
   RenameDirectoryRequestSchema,
   ReorderDirectoryRequestSchema,

--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -90,6 +90,24 @@ const MoveDirectoryPagesRequestSchema = Joi.object().keys({
   items: Joi.array().items(FileSchema).required(),
 })
 
+// Resource categories
+const CreateResourceDirectoryRequestSchema = Joi.object().keys({
+  newDirectoryName: Joi.string().required(),
+})
+
+const RenameResourceDirectoryRequestSchema = Joi.object().keys({
+  newDirectoryName: Joi.string().required(),
+})
+
+const MoveResourceDirectoryPagesRequestSchema = Joi.object().keys({
+  target: Joi.object()
+    .keys({
+      resourceCategory: Joi.string().required(),
+    })
+    .required(),
+  items: Joi.array().items(FileSchema).required(),
+})
+
 module.exports = {
   CreatePageRequestSchema,
   UpdatePageRequestSchema,
@@ -101,4 +119,7 @@ module.exports = {
   RenameDirectoryRequestSchema,
   ReorderDirectoryRequestSchema,
   MoveDirectoryPagesRequestSchema,
+  CreateResourceDirectoryRequestSchema,
+  RenameResourceDirectoryRequestSchema,
+  MoveResourceDirectoryPagesRequestSchema,
 }


### PR DESCRIPTION
This PR refactors the resources and resource pages flow. Tests will be added in a future PR. It adds several new components:

resource categories, resource pages routers
resource category, resource page directory services

The resource pages router contains the following endpoints:
POST /:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/pages - Create a resource page
GET /:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/pages/:pageName - Read a resource page)
POST /:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/pages/:pageName - Update/Rename a resource page
DELETE /:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/pages/:pageName - Delete a resource page
 
The resource categories router contains the following endpoints:
GET /:siteName/resourceRoom/:resourceRoomName/resources - List all resource categories
GET /:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory - List all resource pages in a category
POST /:siteName/resourceRoom/:resourceRoomName/resources - Create a resource category
POST /:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory - Rename an existing resource category
DELETE /:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory - Delete an existing resource category
POST /:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/move - Move pages in an existing resource category

This PR also introduces new validation schemas for the new routes. The format accepted for each route can be referred to [here](https://docs.google.com/document/d/1ao6AOtrhYTtHgaTF3KjLhdSG_4zZ65sg1gTv8f8Mnnk/edit#heading=h.vwtvtn8wqwf4).

A new method for moving files has been added to the `BaseDirectoryService` rather than the `MoverService` - I felt that the logic for file movement for all files which do not have special information in the front matter or require special data written to files (i.e. all non-collection/unlinked pages) should go here, as the mechanism for file movement in these cases would be to use the existing git tree methods which are similarly used by other methods in the `BaseDirectoryService`, In contrast, `MoverService` currently only has dependencies on page level services (e.g. `UnlinkedPageService`, `CollectionPageService`), and adding an additional dependency on `BaseDirectoryService` would cause the dependency chain to become significantly more difficult to understand.

The resource room related endpoints will be added in a future PR, after the [settings refactor](https://github.com/isomerpages/isomercms-backend/pull/282). We have elected to place the listing of all resource categories under the `ResourceDirectoryService`, rather than the future `ResourceRoomDirectoryService` - we feel that this more closely matches the currently behaviour of the `CollectionDirectoryService`.

Also, the formation of the `index.html` files on creation of a new resource category is currently contained within the `ResourceDirectoryService`. A possible alternative to this would be to move the `index.html` methods out into its own special service. However, given that this file is not used often (only on creating/renaming of a resource category), I feel this is not necessary.