### PR TITLE
Feat: add resources tests

### DIFF
--- a/newroutes/__tests__/ResourceCategories.spec.js
+++ b/newroutes/__tests__/ResourceCategories.spec.js
@@ -1,0 +1,260 @@
+const express = require("express")
+const request = require("supertest")
+
+const { errorHandler } = require("@middleware/errorHandler")
+const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
+
+const { ResourceCategoriesRouter } = require("../resourceCategories")
+
+describe("Resource Categories Router", () => {
+  const mockResourceDirectoryService = {
+    listAllResourceCategories: jest.fn(),
+    listFiles: jest.fn(),
+    createResourceDirectory: jest.fn(),
+    renameResourceDirectory: jest.fn(),
+    deleteResourceDirectory: jest.fn(),
+    moveResourcePages: jest.fn(),
+  }
+
+  const router = new ResourceCategoriesRouter({
+    resourceDirectoryService: mockResourceDirectoryService,
+  })
+
+  const app = express()
+  app.use(express.json({ limit: "7mb" }))
+  app.use(express.urlencoded({ extended: false }))
+
+  // We can use read route handler here because we don't need to lock the repo
+  app.get(
+    "/:siteName/resourceRoom/:resourceRoomName/resources",
+    attachReadRouteHandlerWrapper(router.listAllResourceCategories)
+  )
+  app.get(
+    "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory",
+    attachReadRouteHandlerWrapper(router.listResourceDirectoryFiles)
+  )
+  app.post(
+    "/:siteName/resourceRoom/:resourceRoomName/resources",
+    attachReadRouteHandlerWrapper(router.createResourceDirectory)
+  )
+  app.post(
+    "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory",
+    attachReadRouteHandlerWrapper(router.renameResourceDirectory)
+  )
+  app.delete(
+    "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory",
+    attachReadRouteHandlerWrapper(router.deleteResourceDirectory)
+  )
+  app.post(
+    "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategory/move",
+    attachReadRouteHandlerWrapper(router.moveResourceDirectoryPages)
+  )
+
+  app.use(errorHandler)
+
+  const siteName = "test-site"
+  const resourceRoomName = "resource-room"
+  const resourceCategory = "resource-category"
+
+  // Can't set request fields - will always be undefined
+  const accessToken = undefined
+  const currentCommitSha = undefined
+  const treeSha = undefined
+
+  const reqDetails = { siteName, accessToken }
+  const additionalReqDetails = { ...reqDetails, currentCommitSha, treeSha }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("listAllResourceCategories", () => {
+    it("lists the set of all resource categories", async () => {
+      const expectedResponse = [
+        {
+          name: "test-cat",
+          type: "dir",
+        },
+        {
+          name: "test-cate2",
+          type: "dir",
+        },
+      ]
+      mockResourceDirectoryService.listAllResourceCategories.mockResolvedValueOnce(
+        expectedResponse
+      )
+      const resp = await request(app)
+        .get(`/${siteName}/resourceRoom/${resourceRoomName}/resources`)
+        .expect(200)
+      expect(resp.body).toStrictEqual(expectedResponse)
+      expect(
+        mockResourceDirectoryService.listAllResourceCategories
+      ).toHaveBeenCalledWith(reqDetails, { resourceRoomName })
+    })
+  })
+
+  describe("listResourceDirectoryFiles", () => {
+    it("returns the details of all files in a resource", async () => {
+      const expectedResponse = [
+        {
+          name: "testfile",
+          type: "file",
+        },
+        {
+          name: "testfile1",
+          type: "file",
+        },
+        {
+          name: "testfile2",
+          type: "file",
+        },
+      ]
+      mockResourceDirectoryService.listFiles.mockResolvedValueOnce(
+        expectedResponse
+      )
+      const resp = await request(app)
+        .get(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}`
+        )
+        .expect(200)
+      expect(resp.body).toStrictEqual(expectedResponse)
+      expect(
+        mockResourceDirectoryService.listFiles
+      ).toHaveBeenCalledWith(reqDetails, { resourceRoomName, resourceCategory })
+    })
+  })
+
+  describe("createResourceDirectory", () => {
+    it("rejects requests with invalid body", async () => {
+      await request(app)
+        .post(`/${siteName}/resourceRoom/${resourceRoomName}/resources`)
+        .send({})
+        .expect(400)
+    })
+
+    it("accepts valid category create requests and returns the details of the category created", async () => {
+      mockResourceDirectoryService.createResourceDirectory.mockResolvedValueOnce(
+        {}
+      )
+      const resourceDetails = {
+        newDirectoryName: resourceCategory,
+      }
+      const resp = await request(app)
+        .post(`/${siteName}/resourceRoom/${resourceRoomName}/resources`)
+        .send(resourceDetails)
+        .expect(200)
+      expect(resp.body).toStrictEqual({})
+      expect(
+        mockResourceDirectoryService.createResourceDirectory
+      ).toHaveBeenCalledWith(reqDetails, {
+        resourceRoomName,
+        resourceCategory,
+      })
+    })
+  })
+
+  describe("renameResourceDirectory", () => {
+    const newDirectoryName = "new-dir"
+
+    it("rejects requests with invalid body", async () => {
+      await request(app)
+        .post(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}`
+        )
+        .send({})
+        .expect(400)
+    })
+
+    it("accepts valid resource rename requests", async () => {
+      await request(app)
+        .post(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}`
+        )
+        .send({ newDirectoryName })
+        .expect(200)
+      expect(
+        mockResourceDirectoryService.renameResourceDirectory
+      ).toHaveBeenCalledWith(reqDetails, {
+        resourceRoomName,
+        resourceCategory,
+        newDirectoryName,
+      })
+    })
+  })
+
+  describe("deleteResourceDirectory", () => {
+    it("accepts valid resource delete requests", async () => {
+      await request(app)
+        .delete(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}`
+        )
+        .expect(200)
+      expect(
+        mockResourceDirectoryService.deleteResourceDirectory
+      ).toHaveBeenCalledWith(reqDetails, {
+        resourceRoomName,
+        resourceCategory,
+      })
+    })
+  })
+
+  describe("moveResourceDirectoryPages", () => {
+    const targetResourceCategory = "resource"
+    const items = [
+      {
+        name: "testfile",
+        type: "file",
+      },
+      {
+        name: "testfile1",
+        type: "file",
+      },
+    ]
+    it("rejects move requests with invalid body", async () => {
+      await request(app)
+        .post(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}/move`
+        )
+        .send({})
+        .expect(400)
+    })
+
+    it("rejects move requests with invalid body", async () => {
+      await request(app)
+        .post(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}/move`
+        )
+        .send({
+          target: { resourceCategory: targetResourceCategory },
+          items: items.concat({ name: "testdir", type: "dir" }),
+        })
+        .expect(400)
+    })
+
+    it("rejects move requests with invalid body", async () => {
+      await request(app)
+        .post(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}/move`
+        )
+        .send({ target: {}, items })
+        .expect(400)
+    })
+
+    it("accepts valid resource page move requests to another resource", async () => {
+      await request(app)
+        .post(
+          `/${siteName}/resourceRoom/${resourceRoomName}/resources/${resourceCategory}/move`
+        )
+        .send({ items, target: { resourceCategory: targetResourceCategory } })
+        .expect(200)
+      expect(
+        mockResourceDirectoryService.moveResourcePages
+      ).toHaveBeenCalledWith(reqDetails, {
+        resourceRoomName,
+        resourceCategory,
+        targetResourceCategory,
+        objArray: items,
+      })
+    })
+  })
+})

--- a/services/directoryServices/__tests__/BaseDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/BaseDirectoryService.spec.js
@@ -40,6 +40,14 @@ describe("Base Directory Service", () => {
     },
     {
       type: "file",
+      path: `${directoryName}/${subcollectionName}/file2.md`,
+    },
+    {
+      type: "file",
+      path: `${directoryName}/${subcollectionName}/file3.md`,
+    },
+    {
+      type: "file",
       path: `_to-keep/${directoryName}/${subcollectionName}/file.md`,
     },
   ]
@@ -115,6 +123,16 @@ describe("Base Directory Service", () => {
         path: `${directoryName}/${subcollectionName}/file.md`,
         sha: null,
       },
+      {
+        type: "file",
+        path: `${directoryName}/${subcollectionName}/file2.md`,
+        sha: null,
+      },
+      {
+        type: "file",
+        path: `${directoryName}/${subcollectionName}/file3.md`,
+        sha: null,
+      },
     ]
     mockGithubService.getTree.mockResolvedValueOnce(mockedTree)
     mockGithubService.updateTree.mockResolvedValueOnce(sha)
@@ -154,6 +172,16 @@ describe("Base Directory Service", () => {
         path: `${directoryName}/${subcollectionName}/file.md`,
         sha: null,
       },
+      {
+        type: "file",
+        path: `${directoryName}/${subcollectionName}/file2.md`,
+        sha: null,
+      },
+      {
+        type: "file",
+        path: `${directoryName}/${subcollectionName}/file3.md`,
+        sha: null,
+      },
     ]
     mockGithubService.getTree.mockResolvedValueOnce(mockedTree)
     mockGithubService.updateTree.mockResolvedValueOnce(sha)
@@ -169,6 +197,55 @@ describe("Base Directory Service", () => {
       })
       expect(mockGithubService.updateTree).toHaveBeenCalledWith(reqDetails, {
         gitTree: mockedDeletedTree,
+        message,
+      })
+      expect(mockGithubService.updateRepoState).toHaveBeenCalledWith(
+        reqDetails,
+        {
+          commitSha: sha,
+        }
+      )
+    })
+  })
+
+  describe("Move Files", () => {
+    const targetDir = "_target-dir"
+    const mockedMovedTree = [
+      {
+        type: "file",
+        path: `${targetDir}/file.md`,
+      },
+      {
+        type: "file",
+        path: `${directoryName}/${subcollectionName}/file.md`,
+        sha: null,
+      },
+      {
+        type: "file",
+        path: `${targetDir}/file2.md`,
+      },
+      {
+        type: "file",
+        path: `${directoryName}/${subcollectionName}/file2.md`,
+        sha: null,
+      },
+    ]
+    mockGithubService.getTree.mockResolvedValueOnce(mockedTree)
+    mockGithubService.updateTree.mockResolvedValueOnce(sha)
+    it("Moving files in directories works correctly", async () => {
+      await expect(
+        service.moveFiles(reqDetails, {
+          oldDirectoryName: `${directoryName}/${subcollectionName}`,
+          newDirectoryName: targetDir,
+          targetFiles: ["file.md", "file2.md"],
+          message,
+        })
+      ).resolves.not.toThrow()
+      expect(mockGithubService.getTree).toHaveBeenCalledWith(reqDetails, {
+        isRecursive: true,
+      })
+      expect(mockGithubService.updateTree).toHaveBeenCalledWith(reqDetails, {
+        gitTree: mockedMovedTree,
         message,
       })
       expect(mockGithubService.updateRepoState).toHaveBeenCalledWith(

--- a/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
@@ -1,0 +1,332 @@
+const { BadRequestError } = require("@errors/BadRequestError")
+
+const INDEX_FILE_NAME = "index.html"
+
+describe("Resource Directory Service", () => {
+  const siteName = "test-site"
+  const accessToken = "test-token"
+  const resourceCategory = "resource-cat"
+  const resourceRoomName = "resource-room"
+  const directoryName = `${resourceRoomName}/${resourceCategory}`
+  const mockContent = ""
+  const mockMarkdownContent = "---test---"
+  const mockFrontMatter = {
+    layout: "resources-alt",
+    title: resourceCategory,
+  }
+  const sha = "12345"
+
+  const objArray = [
+    {
+      type: "file",
+      name: "file.md",
+    },
+    {
+      type: "file",
+      name: `file2.md`,
+    },
+  ]
+
+  const reqDetails = { siteName, accessToken }
+
+  const mockBaseDirectoryService = {
+    list: jest.fn(),
+    rename: jest.fn(),
+    delete: jest.fn(),
+    moveFiles: jest.fn(),
+  }
+
+  const mockGitHubService = {
+    create: jest.fn(),
+    read: jest.fn(),
+    update: jest.fn(),
+  }
+
+  jest.mock("@utils/markdown-utils", () => ({
+    retrieveDataFromMarkdown: jest.fn().mockReturnValue({
+      frontMatter: mockFrontMatter,
+      pageContent: mockContent,
+    }),
+    convertDataToMarkdown: jest.fn().mockReturnValue(mockMarkdownContent),
+  }))
+  const {
+    ResourceDirectoryService,
+  } = require("@services/directoryServices/ResourceDirectoryService")
+  const service = new ResourceDirectoryService({
+    baseDirectoryService: mockBaseDirectoryService,
+    gitHubService: mockGitHubService,
+  })
+  const {
+    convertDataToMarkdown,
+    retrieveDataFromMarkdown,
+  } = require("@utils/markdown-utils")
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("ListAllResourceCategories", () => {
+    const listResp = [
+      {
+        name: "index.html",
+        path: `${resourceRoomName}/index.html`,
+        sha: "test-sha0",
+        size: 10,
+        type: "file",
+      },
+      {
+        name: resourceCategory,
+        path: `${resourceRoomName}/${resourceCategory}`,
+        sha: "test-sha4",
+        size: 10,
+        type: "dir",
+      },
+      {
+        name: `category-2`,
+        path: `${resourceRoomName}/category-2`,
+        sha: "test-sha5",
+        size: 10,
+        type: "dir",
+      },
+    ]
+    const expectedResp = [
+      {
+        name: resourceCategory,
+        type: "dir",
+      },
+      {
+        name: `category-2`,
+        type: "dir",
+      },
+    ]
+    mockBaseDirectoryService.list.mockResolvedValueOnce(listResp)
+    it("Listing resource categories returns the full list of resource categories", async () => {
+      await expect(
+        service.listAllResourceCategories(reqDetails, { resourceRoomName })
+      ).resolves.toMatchObject(expectedResp)
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+        directoryName: resourceRoomName,
+      })
+    })
+  })
+
+  describe("ListFiles", () => {
+    const listResp = [
+      {
+        name: "2021-10-13-file-example-title1.md",
+        path: `${directoryName}/_posts/2021-10-13-file-example-title1.md`,
+        sha: "test-sha0",
+        size: 10,
+        type: "file",
+      },
+      {
+        name: "2021-10-06-post-example-title.md",
+        path: `${directoryName}/_posts/2021-10-06-post-example-title.md`,
+        sha: "test-sha4",
+        size: 10,
+        type: "file",
+      },
+    ]
+    const expectedResp = [
+      {
+        name: "2021-10-13-file-example-title1.md",
+        type: "file",
+      },
+      {
+        name: "2021-10-06-post-example-title.md",
+        type: "file",
+      },
+    ]
+    mockBaseDirectoryService.list.mockResolvedValueOnce(listResp)
+    it("ListFiles returns all files in the category", async () => {
+      await expect(
+        service.listFiles(reqDetails, { resourceRoomName, resourceCategory })
+      ).resolves.toMatchObject(expectedResp)
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+        directoryName: `${directoryName}/_posts`,
+      })
+    })
+  })
+
+  describe("CreateResourceDirectory", () => {
+    it("rejects resource categories with special characters", async () => {
+      await expect(
+        service.createResourceDirectory(reqDetails, {
+          resourceRoomName,
+          resourceCategory: "dir/dir",
+        })
+      ).rejects.toThrowError(BadRequestError)
+    })
+
+    it("Creating a resource category works correctly", async () => {
+      await expect(
+        service.createResourceDirectory(reqDetails, {
+          resourceRoomName,
+          resourceCategory,
+        })
+      ).resolves.toMatchObject({
+        newDirectoryName: resourceCategory,
+      })
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        { ...mockFrontMatter },
+        mockContent
+      )
+      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: mockMarkdownContent,
+        fileName: INDEX_FILE_NAME,
+        directoryName,
+      })
+    })
+
+    it("Creating a resource category slugifies the name", async () => {
+      const originalCategoryName = "Test Category"
+      const slugifiedCategoryName = "test-category"
+      await expect(
+        service.createResourceDirectory(reqDetails, {
+          resourceRoomName,
+          resourceCategory: originalCategoryName,
+        })
+      ).resolves.toMatchObject({
+        newDirectoryName: slugifiedCategoryName,
+      })
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        {
+          ...mockFrontMatter,
+          title: originalCategoryName,
+        },
+        mockContent
+      )
+      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: mockMarkdownContent,
+        fileName: INDEX_FILE_NAME,
+        directoryName: `${resourceRoomName}/${slugifiedCategoryName}`,
+      })
+    })
+  })
+
+  describe("RenameResourceDirectory", () => {
+    const newDirectoryName = "new-dir"
+    it("rejects resource categories with special characters", async () => {
+      await expect(
+        service.renameResourceDirectory(reqDetails, {
+          resourceRoomName,
+          resourceCategory,
+          newDirectoryName: "dir/dir",
+        })
+      ).rejects.toThrowError(BadRequestError)
+    })
+    mockGitHubService.read.mockResolvedValueOnce({
+      content: mockMarkdownContent,
+      sha,
+    })
+    it("Renaming a resource category works correctly", async () => {
+      await expect(
+        service.renameResourceDirectory(reqDetails, {
+          resourceRoomName,
+          resourceCategory,
+          newDirectoryName,
+        })
+      ).resolves.not.toThrowError()
+      expect(mockGitHubService.read).toHaveBeenCalledWith(reqDetails, {
+        fileName: INDEX_FILE_NAME,
+        directoryName,
+      })
+      expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(mockMarkdownContent)
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        {
+          ...mockFrontMatter,
+          title: newDirectoryName,
+        },
+        mockContent
+      )
+      expect(mockGitHubService.update).toHaveBeenCalledWith(reqDetails, {
+        fileContent: mockMarkdownContent,
+        sha,
+        fileName: INDEX_FILE_NAME,
+        directoryName,
+      })
+      expect(mockBaseDirectoryService.rename).toHaveBeenCalledWith(reqDetails, {
+        oldDirectoryName: directoryName,
+        newDirectoryName: `${resourceRoomName}/${newDirectoryName}`,
+        message: `Renaming resource category ${resourceCategory} to ${newDirectoryName}`,
+      })
+    })
+    mockGitHubService.read.mockResolvedValueOnce({
+      content: mockMarkdownContent,
+      sha,
+    })
+    it("Renaming a resource category slugifies the name correctly", async () => {
+      const originalResourceCategory = "Test Resource"
+      const slugifiedResourceCategory = "test-resource"
+      await expect(
+        service.renameResourceDirectory(reqDetails, {
+          resourceRoomName,
+          resourceCategory,
+          newDirectoryName: originalResourceCategory,
+        })
+      ).resolves.not.toThrowError()
+      expect(mockGitHubService.read).toHaveBeenCalledWith(reqDetails, {
+        fileName: INDEX_FILE_NAME,
+        directoryName,
+      })
+      expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(mockMarkdownContent)
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        {
+          ...mockFrontMatter,
+          title: originalResourceCategory,
+        },
+        mockContent
+      )
+      expect(mockGitHubService.update).toHaveBeenCalledWith(reqDetails, {
+        fileContent: mockMarkdownContent,
+        sha,
+        fileName: INDEX_FILE_NAME,
+        directoryName,
+      })
+      expect(mockBaseDirectoryService.rename).toHaveBeenCalledWith(reqDetails, {
+        oldDirectoryName: directoryName,
+        newDirectoryName: `${resourceRoomName}/${slugifiedResourceCategory}`,
+        message: `Renaming resource category ${resourceCategory} to ${slugifiedResourceCategory}`,
+      })
+    })
+  })
+
+  describe("DeleteResourceDirectory", () => {
+    it("Deleting a resource category works correctly", async () => {
+      await expect(
+        service.deleteResourceDirectory(reqDetails, {
+          resourceRoomName,
+          resourceCategory,
+        })
+      ).resolves.not.toThrowError()
+      expect(mockBaseDirectoryService.delete).toHaveBeenCalledWith(reqDetails, {
+        directoryName,
+        message: `Deleting resource category ${resourceCategory}`,
+      })
+    })
+  })
+
+  describe("MoveResourcePages", () => {
+    const targetResourceCategory = "target-resource"
+    const targetFiles = ["file.md", "file2.md"]
+    it("Moving resource pages works correctly", async () => {
+      await expect(
+        service.moveResourcePages(reqDetails, {
+          resourceRoomName,
+          resourceCategory,
+          targetResourceCategory,
+          objArray,
+        })
+      ).resolves.not.toThrowError()
+      expect(mockBaseDirectoryService.moveFiles).toHaveBeenCalledWith(
+        reqDetails,
+        {
+          oldDirectoryName: `${directoryName}/_posts`,
+          newDirectoryName: `${resourceRoomName}/${targetResourceCategory}/_posts`,
+          targetFiles,
+          message: `Moving resource pages from ${resourceCategory} to ${targetResourceCategory}`,
+        }
+      )
+    })
+  })
+})

--- a/services/fileServices/MdPageServices/__tests__/ResourcePageService.spec.js
+++ b/services/fileServices/MdPageServices/__tests__/ResourcePageService.spec.js
@@ -1,0 +1,210 @@
+const { BadRequestError } = require("@errors/BadRequestError")
+
+describe("Resource Page Service", () => {
+  const siteName = "test-site"
+  const accessToken = "test-token"
+  const fileName = "test file.md"
+  const resourceRoomName = "resource-room"
+  const resourceCategory = "category"
+  const directoryName = `${resourceRoomName}/${resourceCategory}/_posts`
+  const mockContent = "test"
+  const mockMarkdownContent = "---test---"
+  const mockFrontMatter = {
+    title: "fileTitle",
+    permalink: "file/permalink",
+  }
+  const sha = "12345"
+
+  const reqDetails = { siteName, accessToken }
+
+  const mockGithubService = {
+    create: jest.fn(),
+    read: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  }
+
+  jest.mock("@utils/markdown-utils", () => ({
+    retrieveDataFromMarkdown: jest.fn().mockReturnValue({
+      frontMatter: mockFrontMatter,
+      pageContent: mockContent,
+    }),
+    convertDataToMarkdown: jest.fn().mockReturnValue(mockMarkdownContent),
+  }))
+  const {
+    ResourcePageService,
+  } = require("@services/fileServices/MdPageServices/ResourcePageService")
+  const service = new ResourcePageService({
+    gitHubService: mockGithubService,
+  })
+  const {
+    retrieveDataFromMarkdown,
+    convertDataToMarkdown,
+  } = require("@utils/markdown-utils")
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("Create", () => {
+    mockGithubService.create.mockResolvedValue({ sha })
+    it("rejects page names with special characters", async () => {
+      await expect(
+        service.create(reqDetails, {
+          fileName: "file/file.md",
+          resourceRoomName,
+          resourceCategory,
+          content: mockContent,
+          frontMatter: { ...mockFrontMatter },
+        })
+      ).rejects.toThrowError(BadRequestError)
+    })
+    it("Creating pages works correctly", async () => {
+      await expect(
+        service.create(reqDetails, {
+          fileName,
+          resourceRoomName,
+          resourceCategory,
+          content: mockContent,
+          frontMatter: { ...mockFrontMatter },
+        })
+      ).resolves.toMatchObject({
+        fileName,
+        content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+        sha,
+      })
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        { ...mockFrontMatter },
+        mockContent
+      )
+      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: mockMarkdownContent,
+        fileName,
+        directoryName,
+      })
+    })
+  })
+
+  describe("Read", () => {
+    mockGithubService.read.mockResolvedValue({
+      content: mockMarkdownContent,
+      sha,
+    }),
+      it("Reading pages works correctly", async () => {
+        await expect(
+          service.read(reqDetails, {
+            fileName,
+            resourceRoomName,
+            resourceCategory,
+          })
+        ).resolves.toMatchObject({
+          fileName,
+          content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+          sha,
+        })
+        expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(
+          mockMarkdownContent
+        )
+        expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+          fileName,
+          directoryName,
+        })
+      })
+  })
+
+  describe("Update", () => {
+    const oldSha = "54321"
+    mockGithubService.update.mockResolvedValue({ newSha: sha })
+    it("Updating page content works correctly", async () => {
+      await expect(
+        service.update(reqDetails, {
+          fileName,
+          resourceRoomName,
+          resourceCategory,
+          content: mockContent,
+          frontMatter: mockFrontMatter,
+          sha: oldSha,
+        })
+      ).resolves.toMatchObject({
+        fileName,
+        content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+        oldSha,
+        newSha: sha,
+      })
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        mockFrontMatter,
+        mockContent
+      )
+      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+        fileName,
+        directoryName,
+        fileContent: mockMarkdownContent,
+        sha: oldSha,
+      })
+    })
+  })
+
+  describe("Delete", () => {
+    it("Deleting pages works correctly", async () => {
+      await expect(
+        service.delete(reqDetails, {
+          fileName,
+          resourceRoomName,
+          resourceCategory,
+          sha,
+        })
+      ).resolves.not.toThrow()
+      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+        fileName,
+        directoryName,
+        sha,
+      })
+    })
+  })
+
+  describe("Rename", () => {
+    const oldSha = "54321"
+    const oldFileName = "test-old-file"
+    mockGithubService.create.mockResolvedValue({ sha })
+    it("rejects renaming to page names with special characters", async () => {
+      await expect(
+        service.rename(reqDetails, {
+          oldFileName,
+          newFileName: "file/file.md",
+          resourceRoomName,
+          resourceCategory,
+          content: mockContent,
+          frontMatter: { ...mockFrontMatter },
+        })
+      ).rejects.toThrowError(BadRequestError)
+    })
+    it("Renaming pages works correctly", async () => {
+      await expect(
+        service.rename(reqDetails, {
+          oldFileName,
+          newFileName: fileName,
+          resourceRoomName,
+          resourceCategory,
+          content: mockContent,
+          frontMatter: mockFrontMatter,
+          sha: oldSha,
+        })
+      ).resolves.toMatchObject({
+        fileName,
+        content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+        oldSha,
+        newSha: sha,
+      })
+      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+        fileName: oldFileName,
+        directoryName,
+        sha: oldSha,
+      })
+      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: mockMarkdownContent,
+        fileName,
+        directoryName,
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds tests for resources and resource categories. In addition, the tests for `BaseDirectoryService` have been extended to include one for file movement.