### PR TITLE
fix: handle empty resource categories in v1

### DIFF
--- a/classes/Resource.js
+++ b/classes/Resource.js
@@ -3,6 +3,8 @@ const _ = require("lodash")
 const yaml = require("yaml")
 
 // Import classes
+const { NotFoundError } = require("@errors/NotFoundError")
+
 const { Directory, ResourceRoomType } = require("@classes/Directory.js")
 const {
   File,
@@ -136,7 +138,12 @@ class Resource {
       resourceName
     )
     IsomerFile.setFileType(resourcePageType)
-    const resourcePages = await IsomerFile.list()
+    let resourcePages = []
+    try {
+      resourcePages = await IsomerFile.list()
+    } catch (error) {
+      if (!(error instanceof NotFoundError)) throw error
+    }
 
     if (_.isEmpty(resourcePages)) return
 

--- a/routes/resourcePages.js
+++ b/routes/resourcePages.js
@@ -34,8 +34,12 @@ async function listResourcePages(req, res) {
   const IsomerFile = new File(accessToken, siteName)
   const resourcePageType = new ResourcePageType(resourceRoomName, resourceName)
   IsomerFile.setFileType(resourcePageType)
-  const resourcePages = await IsomerFile.list()
-
+  let resourcePages = []
+  try {
+    resourcePages = await IsomerFile.list()
+  } catch (error) {
+    if (!(error instanceof NotFoundError)) throw error
+  }
   return res.status(200).json({ resourcePages })
 }
 


### PR DESCRIPTION
This PR also fixes the following bug:

- Empty resource category handling
  - Due to PR Fix/unhandled errors for list directory and read media #310, some existing functionality for handling empty resource categories broke, as non-existent folders now throw an error, rather than return an empty array, as empty resource categories do not have a placeholder file in _posts where files are stored.
  - We now correctly return an empty array for this scenario.