### PR TITLE
Refactor/media flow

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -409,27 +409,18 @@ auth.post(
 )
 
 // Media directories
-auth.get("/v2/sites/:siteName/media/:mediaType/:directoryName", verifyJwt)
-auth.post("/v2/sites/:siteName/media/:mediaType", verifyJwt)
-auth.post("/v2/sites/:siteName/media/:mediaType/:directoryName", verifyJwt)
-auth.delete("/v2/sites/:siteName/media/:mediaType/:directoryName", verifyJwt)
-auth.post("/v2/sites/:siteName/media/:mediaType/:directoryName/move", verifyJwt)
+auth.get("/v2/sites/:siteName/media/:directoryName", verifyJwt)
+auth.post("/v2/sites/:siteName/media", verifyJwt)
+auth.post("/v2/sites/:siteName/media/:directoryName", verifyJwt)
+auth.delete("/v2/sites/:siteName/media:directoryName", verifyJwt)
+auth.post("/v2/sites/:siteName/media/:directoryName/move", verifyJwt)
 
 // Media files
-auth.post(
-  "/v2/sites/:siteName/media/:mediaType/:directoryName/pages",
-  verifyJwt
-)
-auth.get(
-  "/v2/sites/:siteName/media/:mediaType/:directoryName/pages/:fileName",
-  verifyJwt
-)
-auth.post(
-  "/v2/sites/:siteName/media/:mediaType/:directoryName/pages/:fileName",
-  verifyJwt
-)
+auth.post("/v2/sites/:siteName/media/:directoryName/pages", verifyJwt)
+auth.get("/v2/sites/:siteName/media/:directoryName/pages/:fileName", verifyJwt)
+auth.post("/v2/sites/:siteName/media/:directoryName/pages/:fileName", verifyJwt)
 auth.delete(
-  "/v2/sites/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+  "/v2/sites/:siteName/media/:directoryName/pages/:fileName",
   verifyJwt
 )
 

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -412,7 +412,7 @@ auth.post(
 auth.get("/v2/sites/:siteName/media/:directoryName", verifyJwt)
 auth.post("/v2/sites/:siteName/media", verifyJwt)
 auth.post("/v2/sites/:siteName/media/:directoryName", verifyJwt)
-auth.delete("/v2/sites/:siteName/media:directoryName", verifyJwt)
+auth.delete("/v2/sites/:siteName/media/:directoryName", verifyJwt)
 auth.post("/v2/sites/:siteName/media/:directoryName/move", verifyJwt)
 
 // Media files

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -408,6 +408,24 @@ auth.post(
   verifyJwt
 )
 
+// Media files
+auth.post(
+  "/v2/sites/:siteName/media/:mediaType/:directoryName/pages",
+  verifyJwt
+)
+auth.get(
+  "/v2/sites/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+  verifyJwt
+)
+auth.post(
+  "/v2/sites/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+  verifyJwt
+)
+auth.delete(
+  "/v2/sites/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+  verifyJwt
+)
+
 auth.use((req, res, next) => {
   if (!req.route) {
     return res.status(404).send("Unauthorised for unknown route")

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -408,6 +408,13 @@ auth.post(
   verifyJwt
 )
 
+// Media directories
+auth.get("/v2/sites/:siteName/media/:mediaType/:directoryName", verifyJwt)
+auth.post("/v2/sites/:siteName/media/:mediaType", verifyJwt)
+auth.post("/v2/sites/:siteName/media/:mediaType/:directoryName", verifyJwt)
+auth.delete("/v2/sites/:siteName/media/:mediaType/:directoryName", verifyJwt)
+auth.post("/v2/sites/:siteName/media/:mediaType/:directoryName/move", verifyJwt)
+
 // Media files
 auth.post(
   "/v2/sites/:siteName/media/:mediaType/:directoryName/pages",

--- a/newroutes/__tests__/MediaCategories.spec.js
+++ b/newroutes/__tests__/MediaCategories.spec.js
@@ -227,7 +227,7 @@ describe("Media Categories Router", () => {
         .post(`/${siteName}/media/images/${directoryName}/move`)
         .send({
           items,
-          target: { directoryName: targetMediaCategory },
+          target: { mediaType: "images", mediaDirectoryName: "newDir" },
         })
         .expect(200)
       expect(mockMediaDirectoryService.moveMediaFiles).toHaveBeenCalledWith(

--- a/newroutes/__tests__/MediaCategories.spec.js
+++ b/newroutes/__tests__/MediaCategories.spec.js
@@ -226,7 +226,7 @@ describe("Media Categories Router", () => {
         .post(`/${siteName}/media/${directoryName}/move`)
         .send({
           items,
-          target: { mediaType: "images", mediaDirectoryName: "newDir" },
+          target: { directoryName: "images/newDir" },
         })
         .expect(200)
       expect(mockMediaDirectoryService.moveMediaFiles).toHaveBeenCalledWith(

--- a/newroutes/__tests__/MediaCategories.spec.js
+++ b/newroutes/__tests__/MediaCategories.spec.js
@@ -25,23 +25,23 @@ describe("Media Categories Router", () => {
 
   // We can use read route handler here because we don't need to lock the repo
   app.get(
-    "/:siteName/media/:mediaType/:directoryName",
+    "/:siteName/media/:directoryName",
     attachReadRouteHandlerWrapper(router.listMediaDirectoryFiles)
   )
   app.post(
-    "/:siteName/media/:mediaType",
+    "/:siteName/media",
     attachReadRouteHandlerWrapper(router.createMediaDirectory)
   )
   app.post(
-    "/:siteName/media/:mediaType/:directoryName",
+    "/:siteName/media/:directoryName",
     attachReadRouteHandlerWrapper(router.renameMediaDirectory)
   )
   app.delete(
-    "/:siteName/media/:mediaType/:directoryName",
+    "/:siteName/media/:directoryName",
     attachReadRouteHandlerWrapper(router.deleteMediaDirectory)
   )
   app.post(
-    "/:siteName/media/:mediaType/:directoryName/move",
+    "/:siteName/media/:directoryName/move",
     attachReadRouteHandlerWrapper(router.moveMediaFiles)
   )
 
@@ -85,13 +85,12 @@ describe("Media Categories Router", () => {
         expectedResponse
       )
       const resp = await request(app)
-        .get(`/${siteName}/media/images/${directoryName}`)
+        .get(`/${siteName}/media/${directoryName}`)
         .expect(200)
       expect(resp.body).toStrictEqual(expectedResponse)
       expect(mockMediaDirectoryService.listFiles).toHaveBeenCalledWith(
         reqDetails,
         {
-          mediaType: "images",
           directoryName,
         }
       )
@@ -100,7 +99,7 @@ describe("Media Categories Router", () => {
 
   describe("createMediaDirectory", () => {
     it("rejects requests with invalid body", async () => {
-      await request(app).post(`/${siteName}/media/images`).send({}).expect(400)
+      await request(app).post(`/${siteName}/media`).send({}).expect(400)
     })
 
     it("accepts valid category create requests and returns the details of the category created", async () => {
@@ -109,7 +108,7 @@ describe("Media Categories Router", () => {
         newDirectoryName: directoryName,
       }
       const resp = await request(app)
-        .post(`/${siteName}/media/images`)
+        .post(`/${siteName}/media`)
         .send(mediaDetails)
         .expect(200)
       expect(resp.body).toStrictEqual({})
@@ -136,7 +135,7 @@ describe("Media Categories Router", () => {
         ],
       }
       const resp = await request(app)
-        .post(`/${siteName}/media/images`)
+        .post(`/${siteName}/media`)
         .send(mediaDetails)
         .expect(200)
       expect(resp.body).toStrictEqual({})
@@ -154,14 +153,14 @@ describe("Media Categories Router", () => {
 
     it("rejects requests with invalid body", async () => {
       await request(app)
-        .post(`/${siteName}/media/images/${directoryName}`)
+        .post(`/${siteName}/media/${directoryName}`)
         .send({})
         .expect(400)
     })
 
     it("accepts valid media rename requests", async () => {
       await request(app)
-        .post(`/${siteName}/media/images/${directoryName}`)
+        .post(`/${siteName}/media/${directoryName}`)
         .send({ newDirectoryName })
         .expect(200)
       expect(
@@ -176,7 +175,7 @@ describe("Media Categories Router", () => {
   describe("deleteMediaDirectory", () => {
     it("accepts valid media delete requests", async () => {
       await request(app)
-        .delete(`/${siteName}/media/images/${directoryName}`)
+        .delete(`/${siteName}/media/${directoryName}`)
         .expect(200)
       expect(
         mockMediaDirectoryService.deleteMediaDirectory
@@ -200,14 +199,14 @@ describe("Media Categories Router", () => {
     ]
     it("rejects move requests with invalid body", async () => {
       await request(app)
-        .post(`/${siteName}/media/images/${directoryName}/move`)
+        .post(`/${siteName}/media/${directoryName}/move`)
         .send({})
         .expect(400)
     })
 
     it("rejects move requests with invalid body", async () => {
       await request(app)
-        .post(`/${siteName}/media/images/${directoryName}/move`)
+        .post(`/${siteName}/media/${directoryName}/move`)
         .send({
           target: { directoryName: targetMediaCategory },
           items: items.concat({ name: "testdir", type: "dir" }),
@@ -217,14 +216,14 @@ describe("Media Categories Router", () => {
 
     it("rejects move requests with invalid body", async () => {
       await request(app)
-        .post(`/${siteName}/media/images/${directoryName}/move`)
+        .post(`/${siteName}/media/${directoryName}/move`)
         .send({ target: {}, items })
         .expect(400)
     })
 
     it("accepts valid media page move requests to another media", async () => {
       await request(app)
-        .post(`/${siteName}/media/images/${directoryName}/move`)
+        .post(`/${siteName}/media/${directoryName}/move`)
         .send({
           items,
           target: { mediaType: "images", mediaDirectoryName: "newDir" },

--- a/newroutes/__tests__/MediaCategories.spec.js
+++ b/newroutes/__tests__/MediaCategories.spec.js
@@ -1,0 +1,215 @@
+const express = require("express")
+const request = require("supertest")
+
+const { errorHandler } = require("@middleware/errorHandler")
+const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
+
+const { MediaCategoriesRouter } = require("../mediaCategories")
+
+describe("Media Categories Router", () => {
+  const mockMediaDirectoryService = {
+    listFiles: jest.fn(),
+    createMediaDirectory: jest.fn(),
+    renameMediaDirectory: jest.fn(),
+    deleteMediaDirectory: jest.fn(),
+    moveMediaFiles: jest.fn(),
+  }
+
+  const router = new MediaCategoriesRouter({
+    mediaDirectoryService: mockMediaDirectoryService,
+  })
+
+  const app = express()
+  app.use(express.json({ limit: "7mb" }))
+  app.use(express.urlencoded({ extended: false }))
+
+  // We can use read route handler here because we don't need to lock the repo
+  app.get(
+    "/:siteName/media/:mediaType/:directoryName",
+    attachReadRouteHandlerWrapper(router.listMediaDirectoryFiles)
+  )
+  app.post(
+    "/:siteName/media/:mediaType",
+    attachReadRouteHandlerWrapper(router.createMediaDirectory)
+  )
+  app.post(
+    "/:siteName/media/:mediaType/:directoryName",
+    attachReadRouteHandlerWrapper(router.renameMediaDirectory)
+  )
+  app.delete(
+    "/:siteName/media/:mediaType/:directoryName",
+    attachReadRouteHandlerWrapper(router.deleteMediaDirectory)
+  )
+  app.post(
+    "/:siteName/media/:mediaType/:directoryName/move",
+    attachReadRouteHandlerWrapper(router.moveMediaFiles)
+  )
+
+  app.use(errorHandler)
+
+  const siteName = "test-site"
+  const directoryName = "imageDir"
+
+  // Can't set request fields - will always be undefined
+  const accessToken = undefined
+  const currentCommitSha = undefined
+  const treeSha = undefined
+
+  const reqDetails = { siteName, accessToken }
+  const additionalReqDetails = { ...reqDetails, currentCommitSha, treeSha }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("listMediaDirectoryFiles", () => {
+    it("returns the details of all files in a media", async () => {
+      const expectedResponse = [
+        {
+          sha: "mockSha",
+          mediaUrl: "mockContent",
+          name: "fileName",
+        },
+        {
+          sha: "mockSha1",
+          mediaUrl: "mockContent1",
+          name: "fileName1",
+        },
+        {
+          sha: "mockSha2",
+          mediaUrl: "mockContent2",
+          name: "fileName2",
+        },
+      ]
+      mockMediaDirectoryService.listFiles.mockResolvedValueOnce(
+        expectedResponse
+      )
+      const resp = await request(app)
+        .get(`/${siteName}/media/images/${directoryName}`)
+        .expect(200)
+      expect(resp.body).toStrictEqual(expectedResponse)
+      expect(mockMediaDirectoryService.listFiles).toHaveBeenCalledWith(
+        reqDetails,
+        {
+          mediaType: "images",
+          directoryName,
+        }
+      )
+    })
+  })
+
+  describe("createMediaDirectory", () => {
+    it("rejects requests with invalid body", async () => {
+      await request(app).post(`/${siteName}/media/images`).send({}).expect(400)
+    })
+
+    it("accepts valid category create requests and returns the details of the category created", async () => {
+      mockMediaDirectoryService.createMediaDirectory.mockResolvedValueOnce({})
+      const mediaDetails = {
+        newDirectoryName: directoryName,
+      }
+      const resp = await request(app)
+        .post(`/${siteName}/media/images`)
+        .send(mediaDetails)
+        .expect(200)
+      expect(resp.body).toStrictEqual({})
+      expect(
+        mockMediaDirectoryService.createMediaDirectory
+      ).toHaveBeenCalledWith(reqDetails, {
+        directoryName,
+      })
+    })
+  })
+
+  describe("renameMediaDirectory", () => {
+    const newDirectoryName = "new-dir"
+
+    it("rejects requests with invalid body", async () => {
+      await request(app)
+        .post(`/${siteName}/media/images/${directoryName}`)
+        .send({})
+        .expect(400)
+    })
+
+    it("accepts valid media rename requests", async () => {
+      await request(app)
+        .post(`/${siteName}/media/images/${directoryName}`)
+        .send({ newDirectoryName })
+        .expect(200)
+      expect(
+        mockMediaDirectoryService.renameMediaDirectory
+      ).toHaveBeenCalledWith(reqDetails, {
+        directoryName,
+        newDirectoryName,
+      })
+    })
+  })
+
+  describe("deleteMediaDirectory", () => {
+    it("accepts valid media delete requests", async () => {
+      await request(app)
+        .delete(`/${siteName}/media/images/${directoryName}`)
+        .expect(200)
+      expect(
+        mockMediaDirectoryService.deleteMediaDirectory
+      ).toHaveBeenCalledWith(additionalReqDetails, {
+        directoryName,
+      })
+    })
+  })
+
+  describe("moveMediaDirectoryPages", () => {
+    const targetMediaCategory = "images/newDir"
+    const items = [
+      {
+        name: "testfile",
+        type: "file",
+      },
+      {
+        name: "testfile1",
+        type: "file",
+      },
+    ]
+    it("rejects move requests with invalid body", async () => {
+      await request(app)
+        .post(`/${siteName}/media/images/${directoryName}/move`)
+        .send({})
+        .expect(400)
+    })
+
+    it("rejects move requests with invalid body", async () => {
+      await request(app)
+        .post(`/${siteName}/media/images/${directoryName}/move`)
+        .send({
+          target: { directoryName: targetMediaCategory },
+          items: items.concat({ name: "testdir", type: "dir" }),
+        })
+        .expect(400)
+    })
+
+    it("rejects move requests with invalid body", async () => {
+      await request(app)
+        .post(`/${siteName}/media/images/${directoryName}/move`)
+        .send({ target: {}, items })
+        .expect(400)
+    })
+
+    it("accepts valid media page move requests to another media", async () => {
+      await request(app)
+        .post(`/${siteName}/media/images/${directoryName}/move`)
+        .send({
+          items,
+          target: { directoryName: targetMediaCategory },
+        })
+        .expect(200)
+      expect(mockMediaDirectoryService.moveMediaFiles).toHaveBeenCalledWith(
+        reqDetails,
+        {
+          directoryName,
+          targetDirectoryName: targetMediaCategory,
+          objArray: items,
+        }
+      )
+    })
+  })
+})

--- a/newroutes/__tests__/MediaCategories.spec.js
+++ b/newroutes/__tests__/MediaCategories.spec.js
@@ -117,6 +117,34 @@ describe("Media Categories Router", () => {
         mockMediaDirectoryService.createMediaDirectory
       ).toHaveBeenCalledWith(reqDetails, {
         directoryName,
+        objArray: undefined,
+      })
+    })
+    it("accepts valid category create requests with files and returns the details of the category created", async () => {
+      mockMediaDirectoryService.createMediaDirectory.mockResolvedValueOnce({})
+      const mediaDetails = {
+        newDirectoryName: directoryName,
+        items: [
+          {
+            name: `fileName`,
+            type: `file`,
+          },
+          {
+            name: `fileName2`,
+            type: `file`,
+          },
+        ],
+      }
+      const resp = await request(app)
+        .post(`/${siteName}/media/images`)
+        .send(mediaDetails)
+        .expect(200)
+      expect(resp.body).toStrictEqual({})
+      expect(
+        mockMediaDirectoryService.createMediaDirectory
+      ).toHaveBeenCalledWith(reqDetails, {
+        directoryName,
+        objArray: mediaDetails.items,
       })
     })
   })

--- a/newroutes/__tests__/MediaFiles.spec.js
+++ b/newroutes/__tests__/MediaFiles.spec.js
@@ -25,19 +25,19 @@ describe("Media Files Router", () => {
 
   // We can use read route handler here because we don't need to lock the repo
   app.post(
-    "/:siteName/media/:mediaType/:directoryName/pages",
+    "/:siteName/media/:directoryName/pages",
     attachReadRouteHandlerWrapper(router.createMediaFile)
   )
   app.get(
-    "/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+    "/:siteName/media/:directoryName/pages/:fileName",
     attachReadRouteHandlerWrapper(router.readMediaFile)
   )
   app.post(
-    "/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+    "/:siteName/media/:directoryName/pages/:fileName",
     attachReadRouteHandlerWrapper(router.updateMediaFile)
   )
   app.delete(
-    "/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+    "/:siteName/media/:directoryName/pages/:fileName",
     attachReadRouteHandlerWrapper(router.deleteMediaFile)
   )
   app.use(errorHandler)
@@ -63,7 +63,7 @@ describe("Media Files Router", () => {
 
     it("rejects requests with invalid body", async () => {
       await request(app)
-        .post(`/${siteName}/media/images/${directoryName}/pages`)
+        .post(`/${siteName}/media/${directoryName}/pages`)
         .send({})
         .expect(400)
     })
@@ -75,7 +75,7 @@ describe("Media Files Router", () => {
         content: mockContent,
       }
       await request(app)
-        .post(`/${siteName}/media/images/${directoryName}/pages`)
+        .post(`/${siteName}/media/${directoryName}/pages`)
         .send(pageDetails)
         .expect(200)
       expect(mockMediaFileService.create).toHaveBeenCalledWith(
@@ -97,10 +97,9 @@ describe("Media Files Router", () => {
       const expectedServiceInput = {
         fileName,
         directoryName,
-        mediaType: "images",
       }
       const resp = await request(app)
-        .get(`/${siteName}/media/images/${directoryName}/pages/${fileName}`)
+        .get(`/${siteName}/media/${directoryName}/pages/${fileName}`)
         .expect(200)
       expect(resp.body).toStrictEqual(expectedResponse)
       expect(mockMediaFileService.read).toHaveBeenCalledWith(
@@ -123,7 +122,7 @@ describe("Media Files Router", () => {
 
     it("rejects requests with invalid body", async () => {
       await request(app)
-        .post(`/${siteName}/media/images/${directoryName}/pages/${fileName}`)
+        .post(`/${siteName}/media/${directoryName}/pages/${fileName}`)
         .send({})
         .expect(400)
     })
@@ -136,7 +135,7 @@ describe("Media Files Router", () => {
         sha: mockSha,
       }
       await request(app)
-        .post(`/${siteName}/media/images/${directoryName}/pages/${fileName}`)
+        .post(`/${siteName}/media/${directoryName}/pages/${fileName}`)
         .send(updatePageDetails)
         .expect(200)
       expect(mockMediaFileService.update).toHaveBeenCalledWith(
@@ -154,7 +153,7 @@ describe("Media Files Router", () => {
         sha: mockSha,
       }
       await request(app)
-        .post(`/${siteName}/media/images/${directoryName}/pages/${fileName}`)
+        .post(`/${siteName}/media/${directoryName}/pages/${fileName}`)
         .send(renamePageDetails)
         .expect(200)
       expect(mockMediaFileService.rename).toHaveBeenCalledWith(
@@ -171,7 +170,7 @@ describe("Media Files Router", () => {
 
     it("rejects requests with invalid body", async () => {
       await request(app)
-        .delete(`/${siteName}/media/images/${directoryName}/pages/${fileName}`)
+        .delete(`/${siteName}/media/${directoryName}/pages/${fileName}`)
         .send({})
         .expect(400)
     })
@@ -183,7 +182,7 @@ describe("Media Files Router", () => {
         sha: pageDetails.sha,
       }
       await request(app)
-        .delete(`/${siteName}/media/images/${directoryName}/pages/${fileName}`)
+        .delete(`/${siteName}/media/${directoryName}/pages/${fileName}`)
         .send(pageDetails)
         .expect(200)
       expect(mockMediaFileService.delete).toHaveBeenCalledWith(

--- a/newroutes/__tests__/MediaFiles.spec.js
+++ b/newroutes/__tests__/MediaFiles.spec.js
@@ -1,0 +1,195 @@
+const express = require("express")
+const request = require("supertest")
+
+const { errorHandler } = require("@middleware/errorHandler")
+const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
+
+const { MediaFilesRouter } = require("../mediaFiles")
+
+describe("Media Files Router", () => {
+  const mockMediaFileService = {
+    create: jest.fn(),
+    read: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    rename: jest.fn(),
+  }
+
+  const router = new MediaFilesRouter({
+    mediaFileService: mockMediaFileService,
+  })
+
+  const app = express()
+  app.use(express.json({ limit: "7mb" }))
+  app.use(express.urlencoded({ extended: false }))
+
+  // We can use read route handler here because we don't need to lock the repo
+  app.post(
+    "/:siteName/media/:mediaType/:directoryName/pages",
+    attachReadRouteHandlerWrapper(router.createMediaFile)
+  )
+  app.get(
+    "/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+    attachReadRouteHandlerWrapper(router.readMediaFile)
+  )
+  app.post(
+    "/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+    attachReadRouteHandlerWrapper(router.updateMediaFile)
+  )
+  app.delete(
+    "/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+    attachReadRouteHandlerWrapper(router.deleteMediaFile)
+  )
+  app.use(errorHandler)
+
+  const siteName = "test-site"
+  const directoryName = "imageDir"
+  const accessToken = undefined // Can't set request fields - will always be undefined
+  const fileName = "test-file"
+  const mockSha = "12345"
+  const mockContent = "mock-content"
+
+  const reqDetails = { siteName, accessToken }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("createMediaFile", () => {
+    const pageDetails = {
+      newFileName: fileName,
+      content: mockContent,
+    }
+
+    it("rejects requests with invalid body", async () => {
+      await request(app)
+        .post(`/${siteName}/media/images/${directoryName}/pages`)
+        .send({})
+        .expect(400)
+    })
+
+    it("accepts valid media file create requests and returns the details of the file created", async () => {
+      const expectedServiceInput = {
+        fileName,
+        directoryName,
+        content: mockContent,
+      }
+      await request(app)
+        .post(`/${siteName}/media/images/${directoryName}/pages`)
+        .send(pageDetails)
+        .expect(200)
+      expect(mockMediaFileService.create).toHaveBeenCalledWith(
+        reqDetails,
+        expectedServiceInput
+      )
+    })
+  })
+
+  describe("readMediaFile", () => {
+    const expectedResponse = {
+      sha: mockSha,
+      mediaUrl: mockContent,
+      name: fileName,
+    }
+    mockMediaFileService.read.mockResolvedValueOnce(expectedResponse)
+
+    it("retrieves media file details", async () => {
+      const expectedServiceInput = {
+        fileName,
+        directoryName,
+        mediaType: "images",
+      }
+      const resp = await request(app)
+        .get(`/${siteName}/media/images/${directoryName}/pages/${fileName}`)
+        .expect(200)
+      expect(resp.body).toStrictEqual(expectedResponse)
+      expect(mockMediaFileService.read).toHaveBeenCalledWith(
+        reqDetails,
+        expectedServiceInput
+      )
+    })
+  })
+
+  describe("updateMediaFile", () => {
+    const updatePageDetails = {
+      content: mockContent,
+      sha: mockSha,
+    }
+
+    const renamePageDetails = {
+      ...updatePageDetails,
+      newFileName: "new-file",
+    }
+
+    it("rejects requests with invalid body", async () => {
+      await request(app)
+        .post(`/${siteName}/media/images/${directoryName}/pages/${fileName}`)
+        .send({})
+        .expect(400)
+    })
+
+    it("accepts valid media file update requests and returns the details of the file updated", async () => {
+      const expectedServiceInput = {
+        fileName,
+        directoryName,
+        content: mockContent,
+        sha: mockSha,
+      }
+      await request(app)
+        .post(`/${siteName}/media/images/${directoryName}/pages/${fileName}`)
+        .send(updatePageDetails)
+        .expect(200)
+      expect(mockMediaFileService.update).toHaveBeenCalledWith(
+        reqDetails,
+        expectedServiceInput
+      )
+    })
+
+    it("accepts valid media file rename requests and returns the details of the file updated", async () => {
+      const expectedServiceInput = {
+        oldFileName: fileName,
+        newFileName: renamePageDetails.newFileName,
+        directoryName,
+        content: mockContent,
+        sha: mockSha,
+      }
+      await request(app)
+        .post(`/${siteName}/media/images/${directoryName}/pages/${fileName}`)
+        .send(renamePageDetails)
+        .expect(200)
+      expect(mockMediaFileService.rename).toHaveBeenCalledWith(
+        reqDetails,
+        expectedServiceInput
+      )
+    })
+  })
+
+  describe("deleteMediaFile", () => {
+    const pageDetails = {
+      sha: mockSha,
+    }
+
+    it("rejects requests with invalid body", async () => {
+      await request(app)
+        .delete(`/${siteName}/media/images/${directoryName}/pages/${fileName}`)
+        .send({})
+        .expect(400)
+    })
+
+    it("accepts valid media file delete requests", async () => {
+      const expectedServiceInput = {
+        fileName,
+        directoryName,
+        sha: pageDetails.sha,
+      }
+      await request(app)
+        .delete(`/${siteName}/media/images/${directoryName}/pages/${fileName}`)
+        .send(pageDetails)
+        .expect(200)
+      expect(mockMediaFileService.delete).toHaveBeenCalledWith(
+        reqDetails,
+        expectedServiceInput
+      )
+    })
+  })
+})

--- a/newroutes/collectionPages.js
+++ b/newroutes/collectionPages.js
@@ -116,7 +116,7 @@ class CollectionPagesRouter {
         })
       }
     } else {
-    /* eslint-disable no-lonely-if */
+      /* eslint-disable no-lonely-if */
       if (newFileName) {
         updateResp = await this.collectionPageService.rename(reqDetails, {
           oldFileName: pageName,
@@ -188,11 +188,11 @@ class CollectionPagesRouter {
     )
     router.post(
       "/:siteName/collections/:collectionName/pages/:pageName",
-      attachWriteRouteHandlerWrapper(this.updateCollectionPage)
+      attachRollbackRouteHandlerWrapper(this.updateCollectionPage)
     )
     router.post(
       "/:siteName/collections/:collectionName/subcollections/:subcollectionName/pages/:pageName",
-      attachWriteRouteHandlerWrapper(this.updateCollectionPage)
+      attachRollbackRouteHandlerWrapper(this.updateCollectionPage)
     )
     router.delete(
       "/:siteName/collections/:collectionName/pages/:pageName",

--- a/newroutes/mediaCategories.js
+++ b/newroutes/mediaCategories.js
@@ -26,10 +26,10 @@ class MediaCategoriesRouter {
   async listMediaDirectoryFiles(req, res) {
     const { accessToken } = req
 
-    const { siteName, mediaType, directoryName } = req.params
+    const { siteName, directoryName } = req.params
     const listResp = await this.mediaDirectoryService.listFiles(
       { siteName, accessToken },
-      { mediaType, directoryName }
+      { directoryName }
     )
     return res.status(200).json(listResp)
   }
@@ -38,7 +38,7 @@ class MediaCategoriesRouter {
   async createMediaDirectory(req, res) {
     const { accessToken, currentCommitSha, treeSha } = req
 
-    const { siteName, mediaType } = req.params
+    const { siteName } = req.params
     const { error } = CreateMediaDirectoryRequestSchema.validate(req.body)
     if (error) throw new BadRequestError(error.message)
     const { newDirectoryName, items } = req.body
@@ -57,7 +57,7 @@ class MediaCategoriesRouter {
   async renameMediaDirectory(req, res) {
     const { accessToken, currentCommitSha, treeSha } = req
 
-    const { siteName, mediaType, directoryName } = req.params
+    const { siteName, directoryName } = req.params
     const { error } = RenameMediaDirectoryRequestSchema.validate(req.body)
     if (error) throw new BadRequestError(error.message)
     const { newDirectoryName } = req.body
@@ -76,7 +76,7 @@ class MediaCategoriesRouter {
   async deleteMediaDirectory(req, res) {
     const { accessToken, currentCommitSha, treeSha } = req
 
-    const { siteName, mediaType, directoryName } = req.params
+    const { siteName, directoryName } = req.params
     await this.mediaDirectoryService.deleteMediaDirectory(
       { siteName, accessToken, currentCommitSha, treeSha },
       {
@@ -90,7 +90,7 @@ class MediaCategoriesRouter {
   async moveMediaFiles(req, res) {
     const { accessToken, currentCommitSha, treeSha } = req
 
-    const { siteName, mediaType, directoryName } = req.params
+    const { siteName, directoryName } = req.params
     const { error } = MoveMediaDirectoryFilesRequestSchema.validate(req.body)
     if (error) throw new BadRequestError(error.message)
     const {
@@ -115,23 +115,23 @@ class MediaCategoriesRouter {
     const router = express.Router()
 
     router.get(
-      "/:siteName/media/:mediaType/:directoryName",
+      "/:siteName/media/:directoryName",
       attachReadRouteHandlerWrapper(this.listMediaDirectoryFiles)
     )
     router.post(
-      "/:siteName/media/:mediaType",
+      "/:siteName/media",
       attachRollbackRouteHandlerWrapper(this.createMediaDirectory)
     )
     router.post(
-      "/:siteName/media/:mediaType/:directoryName",
+      "/:siteName/media/:directoryName",
       attachRollbackRouteHandlerWrapper(this.renameMediaDirectory)
     )
     router.delete(
-      "/:siteName/media/:mediaType/:directoryName",
+      "/:siteName/media/:directoryName",
       attachRollbackRouteHandlerWrapper(this.deleteMediaDirectory)
     )
     router.post(
-      "/:siteName/media/:mediaType/:directoryName/move",
+      "/:siteName/media/:directoryName/move",
       attachRollbackRouteHandlerWrapper(this.moveMediaFiles)
     )
 

--- a/newroutes/mediaCategories.js
+++ b/newroutes/mediaCategories.js
@@ -38,12 +38,12 @@ class MediaCategoriesRouter {
   async createMediaDirectory(req, res) {
     const { accessToken } = req
 
-    const { siteName, mediaType } = req.params
+    const { siteName, mediaType, currentCommitSha, treeSha } = req.params
     const { error } = CreateMediaDirectoryRequestSchema.validate(req.body)
     if (error) throw new BadRequestError(error.message)
     const { newDirectoryName, items } = req.body
     const createResp = await this.mediaDirectoryService.createMediaDirectory(
-      { siteName, accessToken },
+      { siteName, accessToken, currentCommitSha, treeSha },
       {
         directoryName: newDirectoryName,
         objArray: items,
@@ -88,7 +88,7 @@ class MediaCategoriesRouter {
 
   // Move resource category
   async moveMediaFiles(req, res) {
-    const { accessToken } = req
+    const { accessToken, currentCommitSha, treeSha } = req
 
     const { siteName, mediaType, directoryName } = req.params
     const { error } = MoveMediaDirectoryFilesRequestSchema.validate(req.body)
@@ -98,7 +98,7 @@ class MediaCategoriesRouter {
       target: { directoryName: targetDirectoryName },
     } = req.body
     await this.mediaDirectoryService.moveMediaFiles(
-      { siteName, accessToken },
+      { siteName, accessToken, currentCommitSha, treeSha },
       {
         directoryName,
         targetDirectoryName,

--- a/newroutes/mediaCategories.js
+++ b/newroutes/mediaCategories.js
@@ -36,9 +36,9 @@ class MediaCategoriesRouter {
 
   // Create new media directory
   async createMediaDirectory(req, res) {
-    const { accessToken } = req
+    const { accessToken, currentCommitSha, treeSha } = req
 
-    const { siteName, mediaType, currentCommitSha, treeSha } = req.params
+    const { siteName, mediaType } = req.params
     const { error } = CreateMediaDirectoryRequestSchema.validate(req.body)
     if (error) throw new BadRequestError(error.message)
     const { newDirectoryName, items } = req.body

--- a/newroutes/mediaCategories.js
+++ b/newroutes/mediaCategories.js
@@ -41,11 +41,12 @@ class MediaCategoriesRouter {
     const { siteName, mediaType } = req.params
     const { error } = CreateMediaDirectoryRequestSchema.validate(req.body)
     if (error) throw new BadRequestError(error.message)
-    const { newDirectoryName } = req.body
+    const { newDirectoryName, items } = req.body
     const createResp = await this.mediaDirectoryService.createMediaDirectory(
       { siteName, accessToken },
       {
         directoryName: newDirectoryName,
+        objArray: items,
       }
     )
 

--- a/newroutes/mediaCategories.js
+++ b/newroutes/mediaCategories.js
@@ -95,11 +95,8 @@ class MediaCategoriesRouter {
     if (error) throw new BadRequestError(error.message)
     const {
       items,
-      target: { mediaType: targetMediaType, mediaDirectoryName },
+      target: { directoryName: targetDirectoryName },
     } = req.body
-    const targetDirectoryName = `${targetMediaType}${
-      mediaDirectoryName ? `/${mediaDirectoryName}` : ""
-    }`
     await this.mediaDirectoryService.moveMediaFiles(
       { siteName, accessToken, currentCommitSha, treeSha },
       {

--- a/newroutes/mediaCategories.js
+++ b/newroutes/mediaCategories.js
@@ -95,8 +95,11 @@ class MediaCategoriesRouter {
     if (error) throw new BadRequestError(error.message)
     const {
       items,
-      target: { directoryName: targetDirectoryName },
+      target: { mediaType: targetMediaType, mediaDirectoryName },
     } = req.body
+    const targetDirectoryName = `${targetMediaType}${
+      mediaDirectoryName ? `/${mediaDirectoryName}` : ""
+    }`
     await this.mediaDirectoryService.moveMediaFiles(
       { siteName, accessToken, currentCommitSha, treeSha },
       {

--- a/newroutes/mediaCategories.js
+++ b/newroutes/mediaCategories.js
@@ -1,0 +1,138 @@
+const autoBind = require("auto-bind")
+const express = require("express")
+
+// Import middleware
+const { BadRequestError } = require("@errors/BadRequestError")
+
+const {
+  attachReadRouteHandlerWrapper,
+  attachRollbackRouteHandlerWrapper,
+} = require("@middleware/routeHandler")
+
+const {
+  CreateMediaDirectoryRequestSchema,
+  RenameMediaDirectoryRequestSchema,
+  MoveMediaDirectoryFilesRequestSchema,
+} = require("@validators/RequestSchema")
+
+class MediaCategoriesRouter {
+  constructor({ mediaDirectoryService }) {
+    this.mediaDirectoryService = mediaDirectoryService
+    // We need to bind all methods because we don't invoke them from the class directly
+    autoBind(this)
+  }
+
+  // List files in a resource category
+  async listMediaDirectoryFiles(req, res) {
+    const { accessToken } = req
+
+    const { siteName, mediaType, directoryName } = req.params
+    const listResp = await this.mediaDirectoryService.listFiles(
+      { siteName, accessToken },
+      { mediaType, directoryName }
+    )
+    return res.status(200).json(listResp)
+  }
+
+  // Create new media directory
+  async createMediaDirectory(req, res) {
+    const { accessToken } = req
+
+    const { siteName, mediaType } = req.params
+    const { error } = CreateMediaDirectoryRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error.message)
+    const { newDirectoryName } = req.body
+    const createResp = await this.mediaDirectoryService.createMediaDirectory(
+      { siteName, accessToken },
+      {
+        directoryName: newDirectoryName,
+      }
+    )
+
+    return res.status(200).json(createResp)
+  }
+
+  // Rename resource category
+  async renameMediaDirectory(req, res) {
+    const { accessToken, currentCommitSha, treeSha } = req
+
+    const { siteName, mediaType, directoryName } = req.params
+    const { error } = RenameMediaDirectoryRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error.message)
+    const { newDirectoryName } = req.body
+    await this.mediaDirectoryService.renameMediaDirectory(
+      { siteName, accessToken, currentCommitSha, treeSha },
+      {
+        directoryName,
+        newDirectoryName,
+      }
+    )
+
+    return res.status(200).send("OK")
+  }
+
+  // Delete resource category
+  async deleteMediaDirectory(req, res) {
+    const { accessToken, currentCommitSha, treeSha } = req
+
+    const { siteName, mediaType, directoryName } = req.params
+    await this.mediaDirectoryService.deleteMediaDirectory(
+      { siteName, accessToken, currentCommitSha, treeSha },
+      {
+        directoryName,
+      }
+    )
+    return res.status(200).send("OK")
+  }
+
+  // Move resource category
+  async moveMediaFiles(req, res) {
+    const { accessToken } = req
+
+    const { siteName, mediaType, directoryName } = req.params
+    const { error } = MoveMediaDirectoryFilesRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error.message)
+    const {
+      items,
+      target: { directoryName: targetDirectoryName },
+    } = req.body
+    await this.mediaDirectoryService.moveMediaFiles(
+      { siteName, accessToken },
+      {
+        directoryName,
+        targetDirectoryName,
+        objArray: items,
+      }
+    )
+    return res.status(200).send("OK")
+  }
+
+  getRouter() {
+    const router = express.Router()
+
+    router.get(
+      "/:siteName/media/:mediaType/:directoryName",
+      attachReadRouteHandlerWrapper(this.listMediaDirectoryFiles)
+    )
+    router.post(
+      "/:siteName/media/:mediaType",
+      attachRollbackRouteHandlerWrapper(this.createMediaDirectory)
+    )
+    router.post(
+      "/:siteName/media/:mediaType/:directoryName",
+      attachRollbackRouteHandlerWrapper(this.renameMediaDirectory)
+    )
+    router.delete(
+      "/:siteName/media/:mediaType/:directoryName",
+      attachRollbackRouteHandlerWrapper(this.deleteMediaDirectory)
+    )
+    router.post(
+      "/:siteName/media/:mediaType/:directoryName/move",
+      attachRollbackRouteHandlerWrapper(this.moveMediaFiles)
+    )
+
+    return router
+  }
+}
+
+module.exports = { MediaCategoriesRouter }

--- a/newroutes/mediaFiles.js
+++ b/newroutes/mediaFiles.js
@@ -26,7 +26,7 @@ class MediaFilesRouter {
   async createMediaFile(req, res) {
     const { accessToken } = req
 
-    const { siteName, mediaType, directoryName } = req.params
+    const { siteName, directoryName } = req.params
     const { error } = CreateMediaFileRequestSchema.validate(req.body)
     if (error) throw new BadRequestError(error.message)
     const { content, newFileName } = req.body
@@ -44,13 +44,12 @@ class MediaFilesRouter {
   async readMediaFile(req, res) {
     const { accessToken } = req
 
-    const { siteName, fileName, mediaType, directoryName } = req.params
+    const { siteName, fileName, directoryName } = req.params
 
     const reqDetails = { siteName, accessToken }
     const readResp = await this.mediaFileService.read(reqDetails, {
       fileName,
       directoryName,
-      mediaType,
     })
     return res.status(200).json(readResp)
   }
@@ -59,7 +58,7 @@ class MediaFilesRouter {
   async updateMediaFile(req, res) {
     const { accessToken, currentCommitSha, treeSha } = req
 
-    const { siteName, fileName, mediaType, directoryName } = req.params
+    const { siteName, fileName, directoryName } = req.params
     const { error } = UpdateMediaFileRequestSchema.validate(req.body)
     if (error) throw new BadRequestError(error)
     const { content, sha, newFileName } = req.body
@@ -88,7 +87,7 @@ class MediaFilesRouter {
   async deleteMediaFile(req, res) {
     const { accessToken } = req
 
-    const { siteName, fileName, mediaType, directoryName } = req.params
+    const { siteName, fileName, directoryName } = req.params
     const { error } = DeleteMediaFileRequestSchema.validate(req.body)
     if (error) throw new BadRequestError(error)
     const { sha } = req.body
@@ -106,19 +105,19 @@ class MediaFilesRouter {
     const router = express.Router()
 
     router.post(
-      "/:siteName/media/:mediaType/:directoryName/pages",
+      "/:siteName/media/:directoryName/pages",
       attachRollbackRouteHandlerWrapper(this.createMediaFile)
     )
     router.get(
-      "/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+      "/:siteName/media/:directoryName/pages/:fileName",
       attachReadRouteHandlerWrapper(this.readMediaFile)
     )
     router.post(
-      "/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+      "/:siteName/media/:directoryName/pages/:fileName",
       attachRollbackRouteHandlerWrapper(this.updateMediaFile)
     )
     router.delete(
-      "/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+      "/:siteName/media/:directoryName/pages/:fileName",
       attachRollbackRouteHandlerWrapper(this.deleteMediaFile)
     )
 

--- a/newroutes/mediaFiles.js
+++ b/newroutes/mediaFiles.js
@@ -1,0 +1,129 @@
+const autoBind = require("auto-bind")
+const express = require("express")
+
+// Import middleware
+const { BadRequestError } = require("@errors/BadRequestError")
+
+const {
+  attachReadRouteHandlerWrapper,
+  attachRollbackRouteHandlerWrapper,
+} = require("@middleware/routeHandler")
+
+const {
+  CreateMediaFileRequestSchema,
+  UpdateMediaFileRequestSchema,
+  DeleteMediaFileRequestSchema,
+} = require("@validators/RequestSchema")
+
+class MediaFilesRouter {
+  constructor({ mediaFileService }) {
+    this.mediaFileService = mediaFileService
+    // We need to bind all methods because we don't invoke them from the class directly
+    autoBind(this)
+  }
+
+  // Create new page in collection
+  async createMediaFile(req, res) {
+    const { accessToken } = req
+
+    const { siteName, mediaType, directoryName } = req.params
+    const { error } = CreateMediaFileRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error.message)
+    const { content, newFileName } = req.body
+    const reqDetails = { siteName, accessToken }
+    const createResp = await this.mediaFileService.create(reqDetails, {
+      fileName: newFileName,
+      directoryName,
+      content,
+    })
+
+    return res.status(200).json(createResp)
+  }
+
+  // Read page in collection
+  async readMediaFile(req, res) {
+    const { accessToken } = req
+
+    const { siteName, fileName, mediaType, directoryName } = req.params
+
+    const reqDetails = { siteName, accessToken }
+    const readResp = await this.mediaFileService.read(reqDetails, {
+      fileName,
+      directoryName,
+      mediaType,
+    })
+    return res.status(200).json(readResp)
+  }
+
+  // Update page in collection
+  async updateMediaFile(req, res) {
+    const { accessToken } = req
+
+    const { siteName, fileName, mediaType, directoryName } = req.params
+    const { error } = UpdateMediaFileRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error)
+    const { content, sha, newFileName } = req.body
+    const reqDetails = { siteName, accessToken }
+    let updateResp
+    if (newFileName) {
+      updateResp = await this.mediaFileService.rename(reqDetails, {
+        oldFileName: fileName,
+        newFileName,
+        directoryName,
+        content,
+        sha,
+      })
+    } else {
+      updateResp = await this.mediaFileService.update(reqDetails, {
+        fileName,
+        directoryName,
+        content,
+        sha,
+      })
+    }
+    return res.status(200).json(updateResp)
+  }
+
+  // Delete page in collection
+  async deleteMediaFile(req, res) {
+    const { accessToken } = req
+
+    const { siteName, fileName, mediaType, directoryName } = req.params
+    const { error } = DeleteMediaFileRequestSchema.validate(req.body)
+    if (error) throw new BadRequestError(error)
+    const { sha } = req.body
+    const reqDetails = { siteName, accessToken }
+    await this.mediaFileService.delete(reqDetails, {
+      fileName,
+      directoryName,
+      sha,
+    })
+
+    return res.status(200).send("OK")
+  }
+
+  getRouter() {
+    const router = express.Router()
+
+    router.post(
+      "/:siteName/media/:mediaType/:directoryName/pages",
+      attachRollbackRouteHandlerWrapper(this.createMediaFile)
+    )
+    router.get(
+      "/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+      attachReadRouteHandlerWrapper(this.readMediaFile)
+    )
+    router.post(
+      "/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+      attachRollbackRouteHandlerWrapper(this.updateMediaFile)
+    )
+    router.delete(
+      "/:siteName/media/:mediaType/:directoryName/pages/:fileName",
+      attachRollbackRouteHandlerWrapper(this.deleteMediaFile)
+    )
+
+    return router
+  }
+}
+
+module.exports = { MediaFilesRouter }

--- a/newroutes/mediaFiles.js
+++ b/newroutes/mediaFiles.js
@@ -57,13 +57,13 @@ class MediaFilesRouter {
 
   // Update page in collection
   async updateMediaFile(req, res) {
-    const { accessToken } = req
+    const { accessToken, currentCommitSha, treeSha } = req
 
     const { siteName, fileName, mediaType, directoryName } = req.params
     const { error } = UpdateMediaFileRequestSchema.validate(req.body)
     if (error) throw new BadRequestError(error)
     const { content, sha, newFileName } = req.body
-    const reqDetails = { siteName, accessToken }
+    const reqDetails = { siteName, accessToken, currentCommitSha, treeSha }
     let updateResp
     if (newFileName) {
       updateResp = await this.mediaFileService.rename(reqDetails, {

--- a/newroutes/resourcePages.js
+++ b/newroutes/resourcePages.js
@@ -146,7 +146,7 @@ class ResourcePagesRouter {
     )
     router.post(
       "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategoryName/pages/:pageName",
-      attachWriteRouteHandlerWrapper(this.updateResourcePage)
+      attachRollbackRouteHandlerWrapper(this.updateResourcePage)
     )
     router.delete(
       "/:siteName/resourceRoom/:resourceRoomName/resources/:resourceCategoryName/pages/:pageName",

--- a/newroutes/unlinkedPages.js
+++ b/newroutes/unlinkedPages.js
@@ -168,7 +168,7 @@ class UnlinkedPagesRouter {
     )
     router.post(
       "/:siteName/pages/pages/:pageName",
-      attachWriteRouteHandlerWrapper(this.updateUnlinkedPage)
+      attachRollbackRouteHandlerWrapper(this.updateUnlinkedPage)
     )
     router.delete(
       "/:siteName/pages/pages/:pageName",

--- a/server.js
+++ b/server.js
@@ -66,6 +66,9 @@ const {
   CollectionDirectoryService,
 } = require("@services/directoryServices/CollectionDirectoryService")
 const {
+  MediaDirectoryService,
+} = require("@services/directoryServices/MediaDirectoryService")
+const {
   ResourceDirectoryService,
 } = require("@services/directoryServices/ResourceDirectoryService")
 const {
@@ -84,6 +87,9 @@ const {
   HomepagePageService,
 } = require("@services/fileServices/MdPageServices/HomepagePageService")
 const {
+  MediaFileService,
+} = require("@services/fileServices/MdPageServices/MediaFileService")
+const {
   ResourcePageService,
 } = require("@services/fileServices/MdPageServices/ResourcePageService")
 const {
@@ -99,6 +105,8 @@ const { MoverService } = require("@services/moverServices/MoverService")
 
 const { CollectionPagesRouter } = require("./newroutes/collectionPages")
 const { CollectionsRouter } = require("./newroutes/collections")
+const { MediaCategoriesRouter } = require("./newroutes/mediaCategories")
+const { MediaFilesRouter } = require("./newroutes/mediaFiles")
 const { ResourceCategoriesRouter } = require("./newroutes/resourceCategories")
 const { ResourcePagesRouter } = require("./newroutes/resourcePages")
 const { ResourceRoomRouter } = require("./newroutes/resourceRoom")
@@ -121,6 +129,7 @@ const subcollectionPageService = new SubcollectionPageService({
 })
 const unlinkedPageService = new UnlinkedPageService({ gitHubService })
 const resourcePageService = new ResourcePageService({ gitHubService })
+const mediaFileService = new MediaFileService({ gitHubService })
 const moverService = new MoverService({
   unlinkedPageService,
   collectionPageService,
@@ -153,6 +162,10 @@ const resourceRoomDirectoryService = new ResourceRoomDirectoryService({
   configYmlService,
   gitHubService,
 })
+const mediaDirectoryService = new MediaDirectoryService({
+  baseDirectoryService,
+  gitHubService,
+})
 const settingsService = new SettingsService({
   homepagePageService,
   configYmlService,
@@ -177,6 +190,12 @@ const resourcePagesV2Router = new ResourcePagesRouter({
 })
 const resourceDirectoryV2Router = new ResourceCategoriesRouter({
   resourceDirectoryService,
+})
+const mediaFilesV2Router = new MediaFilesRouter({
+  mediaFileService,
+})
+const mediaDirectoryV2Router = new MediaCategoriesRouter({
+  mediaDirectoryService,
 })
 const resourceRoomV2Router = new ResourceRoomRouter({
   resourceRoomDirectoryService,
@@ -229,6 +248,8 @@ app.use("/v2/sites", unlinkedPagesRouter.getRouter())
 app.use("/v2/sites", collectionsV2Router.getRouter())
 app.use("/v2/sites", resourcePagesV2Router.getRouter())
 app.use("/v2/sites", resourceDirectoryV2Router.getRouter())
+app.use("/v2/sites", mediaFilesV2Router.getRouter())
+app.use("/v2/sites", mediaDirectoryV2Router.getRouter())
 app.use("/v2/sites", resourceRoomV2Router.getRouter())
 app.use("/v2/sites", settingsV2Router.getRouter())
 

--- a/services/db/GitHubService.js
+++ b/services/db/GitHubService.js
@@ -27,6 +27,10 @@ class GitHubService {
     )}`
   }
 
+  getBlobPath({ siteName, fileSha }) {
+    return `${siteName}/git/blobs/${fileSha}`
+  }
+
   getFolderPath({ siteName, directoryName }) {
     const encodedDirPath = directoryName
       .split("/")
@@ -82,6 +86,34 @@ class GitHubService {
 
     const { content: encodedContent, sha } = resp.data
     const content = Base64.decode(encodedContent)
+
+    return { content, sha }
+  }
+
+  async readMedia({ accessToken, siteName }, { fileSha }) {
+    /**
+     * Files that are bigger than 1 MB needs to be retrieved
+     * via Github Blob API. The content can only be retrieved through
+     * the `sha` of the file.
+     */
+    const params = {
+      ref: BRANCH_REF,
+    }
+
+    const blobEndpoint = this.getBlobPath({ siteName, fileSha })
+
+    const resp = await this.axiosInstance.get(blobEndpoint, {
+      validateStatus,
+      params,
+      headers: {
+        Authorization: `token ${accessToken}`,
+      },
+    })
+
+    if (resp.status === 404)
+      throw new NotFoundError("Media file does not exist")
+
+    const { content, sha } = resp.data
 
     return { content, sha }
   }
@@ -183,6 +215,23 @@ class GitHubService {
         )
       throw err
     }
+  }
+
+  async getRepoInfo({ accessToken, siteName }) {
+    const endpoint = `${siteName}`
+    const headers = {
+      Authorization: `token ${accessToken}`,
+    }
+    const params = {
+      ref: BRANCH_REF,
+    }
+    // Get the commits of the repo
+    const { data } = await this.axiosInstance.get(endpoint, {
+      params,
+      headers,
+    })
+
+    return data
   }
 
   async getRepoState({ accessToken, siteName }) {

--- a/services/db/GitHubService.js
+++ b/services/db/GitHubService.js
@@ -41,11 +41,12 @@ class GitHubService {
 
   async create(
     { accessToken, siteName },
-    { content, fileName, directoryName }
+    { content, fileName, directoryName, isMedia = false }
   ) {
     try {
       const endpoint = this.getFilePath({ siteName, fileName, directoryName })
-      const encodedContent = Base64.encode(content)
+      // Validation and sanitisation of media already done
+      const encodedContent = isMedia ? content : Base64.encode(content)
 
       const params = {
         message: `Create file: ${fileName}`,

--- a/services/db/__tests__/GitHubService.spec.js
+++ b/services/db/__tests__/GitHubService.spec.js
@@ -195,6 +195,53 @@ describe("Github Service", () => {
     })
   })
 
+  describe("ReadMedia", () => {
+    const endpoint = `${siteName}/git/blobs/${sha}`
+    const params = {
+      ref: BRANCH_REF,
+    }
+
+    it("Reading a media file works correctly", async () => {
+      const resp = {
+        data: {
+          content,
+          sha,
+        },
+      }
+      mockAxiosInstance.get.mockResolvedValueOnce(resp)
+      await expect(
+        service.readMedia(reqDetails, {
+          fileSha: sha,
+        })
+      ).resolves.toMatchObject({
+        content,
+        sha,
+      })
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(endpoint, {
+        validateStatus,
+        params,
+        headers: authHeader.headers,
+      })
+    })
+
+    it("Read throws the correct error if file cannot be found", async () => {
+      const resp = {
+        status: 404,
+      }
+      mockAxiosInstance.get.mockResolvedValueOnce(resp)
+      await expect(
+        service.readMedia(reqDetails, {
+          fileSha: sha,
+        })
+      ).rejects.toThrowError(NotFoundError)
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(endpoint, {
+        validateStatus,
+        params,
+        headers: authHeader.headers,
+      })
+    })
+  })
+
   describe("ReadDirectory", () => {
     const endpoint = `${siteName}/contents/${directoryName}`
     const params = {
@@ -399,6 +446,30 @@ describe("Github Service", () => {
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(endpoint, {
         params,
         headers: authHeader.headers,
+      })
+    })
+  })
+
+  describe("GetRepoInfo", () => {
+    const endpoint = `${siteName}`
+    const headers = {
+      Authorization: `token ${accessToken}`,
+    }
+    const params = {
+      ref: BRANCH_REF,
+    }
+
+    it("Getting a repo state works correctly", async () => {
+      const resp = {
+        data: {
+          private: true,
+        },
+      }
+      mockAxiosInstance.get.mockResolvedValueOnce(resp)
+      await service.getRepoInfo(reqDetails)
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(endpoint, {
+        params,
+        headers,
       })
     })
   })

--- a/services/db/__tests__/GitHubService.spec.js
+++ b/services/db/__tests__/GitHubService.spec.js
@@ -122,6 +122,35 @@ describe("Github Service", () => {
       )
     })
 
+    it("Creating a media file does not encode it", async () => {
+      const resp = {
+        data: {
+          content: {
+            sha,
+          },
+        },
+      }
+      mockAxiosInstance.put.mockResolvedValueOnce(resp)
+      await expect(
+        service.create(reqDetails, {
+          content,
+          fileName,
+          directoryName,
+          isMedia: true,
+        })
+      ).resolves.toMatchObject({
+        sha,
+      })
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith(
+        endpoint,
+        {
+          ...params,
+          content,
+        },
+        authHeader
+      )
+    })
+
     it("Create parses and throws the correct error in case of a conflict", async () => {
       mockAxiosInstance.put.mockImplementation(() => {
         const err = new Error()

--- a/services/directoryServices/BaseDirectoryService.js
+++ b/services/directoryServices/BaseDirectoryService.js
@@ -1,5 +1,7 @@
 const _ = require("lodash")
 
+const { ConflictError } = require("@errors/ConflictError")
+
 // Job is to deal with directory level operations to and from GitHub
 class BaseDirectoryService {
   constructor({ gitHubService }) {
@@ -33,7 +35,9 @@ class BaseDirectoryService {
     const newGitTree = []
 
     gitTree.forEach((item) => {
-      if (item.path === oldDirectoryName && item.type === "tree") {
+      if (item.path === newDirectoryName && item.type === "tree") {
+        throw new ConflictError("Target directory already exists")
+      } else if (item.path === oldDirectoryName && item.type === "tree") {
         // Rename old subdirectory to new name
         newGitTree.push({
           ...item,
@@ -96,10 +100,27 @@ class BaseDirectoryService {
     const newGitTree = []
     gitTree.forEach((item) => {
       if (
+        item.path.startsWith(`${newDirectoryName}/`) &&
+        item.type !== "tree"
+      ) {
+        const fileName = item.path
+          .split(`${newDirectoryName}/`)
+          .slice(1)
+          .join(`${newDirectoryName}/`)
+        console.log(fileName)
+        if (targetFiles.includes(fileName)) {
+          // Conflicting file
+          throw new ConflictError("File already exists in target directory")
+        }
+      }
+      if (
         item.path.startsWith(`${oldDirectoryName}/`) &&
         item.type !== "tree"
       ) {
-        const fileName = item.path.split(`${oldDirectoryName}/`)[1]
+        const fileName = item.path
+          .split(`${oldDirectoryName}/`)
+          .slice(1)
+          .join(`${oldDirectoryName}/`)
         if (targetFiles.includes(fileName)) {
           // Add file to target directory
           newGitTree.push({

--- a/services/directoryServices/MediaDirectoryService.js
+++ b/services/directoryServices/MediaDirectoryService.js
@@ -1,5 +1,4 @@
 const { BadRequestError } = require("@errors/BadRequestError")
-const { NotFoundError } = require("@errors/NotFoundError")
 
 const { GITHUB_ORG_NAME } = process.env
 

--- a/services/directoryServices/MediaDirectoryService.js
+++ b/services/directoryServices/MediaDirectoryService.js
@@ -66,11 +66,6 @@ class MediaDirectoryService {
       throw new BadRequestError("Cannot create root media directory")
     }
 
-    await this.gitHubService.create(reqDetails, {
-      content: "",
-      fileName: PLACEHOLDER_FILE_NAME,
-      directoryName,
-    })
     if (objArray && objArray.length !== 0) {
       // We can't perform these operations concurrently because of conflict issues
       /* eslint-disable no-await-in-loop, no-restricted-syntax */
@@ -84,6 +79,14 @@ class MediaDirectoryService {
         message: `Moving media files from ${oldDirectoryName} to ${directoryName}`,
       })
     }
+
+    // We do this step later because the git tree operation overrides it otherwise
+    await this.gitHubService.create(reqDetails, {
+      content: "",
+      fileName: PLACEHOLDER_FILE_NAME,
+      directoryName,
+    })
+
     return {
       newDirectoryName: directoryName,
     }

--- a/services/directoryServices/MediaDirectoryService.js
+++ b/services/directoryServices/MediaDirectoryService.js
@@ -26,6 +26,12 @@ class MediaDirectoryService {
     })
     const resp = []
     for (const curr of files) {
+      if (curr.type === "dir") {
+        resp.push({
+          name: curr.name,
+          type: "dir",
+        })
+      }
       if (curr.type !== "file") continue
       const fileData = {
         mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${

--- a/services/directoryServices/MediaDirectoryService.js
+++ b/services/directoryServices/MediaDirectoryService.js
@@ -13,11 +13,12 @@ class MediaDirectoryService {
     this.gitHubService = gitHubService
   }
 
-  async listFiles(reqDetails, { directoryName, mediaType }) {
+  async listFiles(reqDetails, { directoryName }) {
     // TODO: file preview handling
     const { siteName } = reqDetails
     if (!isMediaPathValid({ path: directoryName }))
       throw new BadRequestError("Invalid media folder name")
+    const mediaType = directoryName.split("/")[0]
     const { private: isPrivate } = await this.gitHubService.getRepoInfo(
       reqDetails
     )
@@ -64,6 +65,9 @@ class MediaDirectoryService {
     if (directoryName === "images" || directoryName === "files") {
       throw new BadRequestError("Cannot create root media directory")
     }
+    const tokens = directoryName.split("/")
+    const mediaType = tokens[0]
+    const mediaDirectoryName = tokens.slice(1).join("/")
 
     await this.gitHubService.create(reqDetails, {
       content: "",
@@ -84,7 +88,8 @@ class MediaDirectoryService {
       })
     }
     return {
-      newDirectoryName: directoryName,
+      mediaType,
+      mediaDirectoryName,
     }
   }
 

--- a/services/directoryServices/MediaDirectoryService.js
+++ b/services/directoryServices/MediaDirectoryService.js
@@ -70,7 +70,7 @@ class MediaDirectoryService {
       fileName: PLACEHOLDER_FILE_NAME,
       directoryName,
     })
-    if (objArray) {
+    if (objArray && objArray.length !== 0) {
       // We can't perform these operations concurrently because of conflict issues
       /* eslint-disable no-await-in-loop, no-restricted-syntax */
       const pathTokens = directoryName.split("/")

--- a/services/directoryServices/MediaDirectoryService.js
+++ b/services/directoryServices/MediaDirectoryService.js
@@ -1,0 +1,111 @@
+const { BadRequestError } = require("@errors/BadRequestError")
+const { NotFoundError } = require("@errors/NotFoundError")
+
+const { GITHUB_ORG_NAME } = process.env
+
+const PLACEHOLDER_FILE_NAME = ".keep"
+
+const { isMediaPathValid } = require("@validators/validators")
+
+class MediaDirectoryService {
+  constructor({ baseDirectoryService, gitHubService }) {
+    this.baseDirectoryService = baseDirectoryService
+    this.gitHubService = gitHubService
+  }
+
+  async listFiles(reqDetails, { directoryName, mediaType }) {
+    // TODO: file preview handling
+    const { siteName } = reqDetails
+    if (!isMediaPathValid({ path: directoryName }))
+      throw new BadRequestError("Invalid media folder name")
+    const { private: isPrivate } = await this.gitHubService.getRepoInfo(
+      reqDetails
+    )
+    const files = await this.baseDirectoryService.list(reqDetails, {
+      directoryName,
+    })
+
+    const resp = []
+    for (const curr of files) {
+      if (curr.type !== "file") continue
+      const fileData = {
+        mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${
+          curr.path
+        }${curr.path.endsWith(".svg") ? "?sanitize=true" : ""}`,
+        name: curr.name,
+        sha: curr.sha,
+      }
+      if (mediaType === "images" && isPrivate) {
+        // Generate blob url
+        const imageExt = curr.name.slice(curr.name.lastIndexOf(".") + 1)
+        const contentType = `image/${imageExt === "svg" ? "svg+xml" : imageExt}`
+        const { content } = await this.gitHubService.readMedia(reqDetails, {
+          fileSha: curr.sha,
+        })
+        const blobURL = `data:${contentType};base64,${content}`
+        fileData.mediaUrl = blobURL
+      }
+      resp.push(fileData)
+    }
+    return resp
+  }
+
+  async createMediaDirectory(reqDetails, { directoryName }) {
+    if (!isMediaPathValid({ path: directoryName }))
+      throw new BadRequestError(
+        "Special characters not allowed in media folder name"
+      )
+    await this.gitHubService.create(reqDetails, {
+      content: "",
+      fileName: PLACEHOLDER_FILE_NAME,
+      directoryName,
+    })
+    return {
+      newDirectoryName: directoryName,
+    }
+  }
+
+  async renameMediaDirectory(reqDetails, { directoryName, newDirectoryName }) {
+    if (!isMediaPathValid({ path: newDirectoryName }))
+      throw new BadRequestError(
+        "Special characters not allowed in media folder name"
+      )
+    await this.baseDirectoryService.rename(reqDetails, {
+      oldDirectoryName: directoryName,
+      newDirectoryName,
+      message: `Renaming media folder ${directoryName} to ${newDirectoryName}`,
+    })
+  }
+
+  async deleteMediaDirectory(reqDetails, { directoryName }) {
+    if (!isMediaPathValid({ path: directoryName }))
+      throw new BadRequestError("Invalid media folder name")
+    await this.baseDirectoryService.delete(reqDetails, {
+      directoryName,
+      message: `Deleting media folder ${directoryName}`,
+    })
+  }
+
+  async moveMediaFiles(
+    reqDetails,
+    { directoryName, targetDirectoryName, objArray }
+  ) {
+    if (
+      !isMediaPathValid({ path: directoryName }) ||
+      !isMediaPathValid({ path: targetDirectoryName })
+    )
+      throw new BadRequestError(
+        "Special characters not allowed in media folder name"
+      )
+    const targetFiles = objArray.map((item) => item.name)
+
+    await this.baseDirectoryService.moveFiles(reqDetails, {
+      oldDirectoryName: directoryName,
+      newDirectoryName: targetDirectoryName,
+      targetFiles,
+      message: `Moving media files from ${directoryName} to ${targetDirectoryName}`,
+    })
+  }
+}
+
+module.exports = { MediaDirectoryService }

--- a/services/directoryServices/MediaDirectoryService.js
+++ b/services/directoryServices/MediaDirectoryService.js
@@ -33,6 +33,7 @@ class MediaDirectoryService {
         }${curr.path.endsWith(".svg") ? "?sanitize=true" : ""}`,
         name: curr.name,
         sha: curr.sha,
+        mediaPath: `${directoryName}/${curr.name}`,
       }
       if (mediaType === "images" && isPrivate) {
         // Generate blob url

--- a/services/directoryServices/MediaDirectoryService.js
+++ b/services/directoryServices/MediaDirectoryService.js
@@ -40,6 +40,7 @@ class MediaDirectoryService {
         name: curr.name,
         sha: curr.sha,
         mediaPath: `${directoryName}/${curr.name}`,
+        type: curr.type,
       }
       if (mediaType === "images" && isPrivate) {
         // Generate blob url
@@ -64,9 +65,6 @@ class MediaDirectoryService {
     if (directoryName === "images" || directoryName === "files") {
       throw new BadRequestError("Cannot create root media directory")
     }
-    const tokens = directoryName.split("/")
-    const mediaType = tokens[0]
-    const mediaDirectoryName = tokens.slice(1).join("/")
 
     await this.gitHubService.create(reqDetails, {
       content: "",
@@ -87,8 +85,7 @@ class MediaDirectoryService {
       })
     }
     return {
-      mediaType,
-      mediaDirectoryName,
+      newDirectoryName: directoryName,
     }
   }
 

--- a/services/directoryServices/MediaDirectoryService.js
+++ b/services/directoryServices/MediaDirectoryService.js
@@ -32,7 +32,7 @@ class MediaDirectoryService {
           type: "dir",
         })
       }
-      if (curr.type !== "file") continue
+      if (curr.type !== "file" || curr.name === PLACEHOLDER_FILE_NAME) continue
       const fileData = {
         mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${
           curr.path

--- a/services/directoryServices/MediaDirectoryService.js
+++ b/services/directoryServices/MediaDirectoryService.js
@@ -34,9 +34,10 @@ class MediaDirectoryService {
       }
       if (curr.type !== "file" || curr.name === PLACEHOLDER_FILE_NAME) continue
       const fileData = {
-        mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${
-          curr.path
-        }${curr.path.endsWith(".svg") ? "?sanitize=true" : ""}`,
+        mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${curr.path
+          .split("/")
+          .map((v) => encodeURIComponent(v))
+          .join("/")}${curr.path.endsWith(".svg") ? "?sanitize=true" : ""}`,
         name: curr.name,
         sha: curr.sha,
         mediaPath: `${directoryName}/${curr.name}`,

--- a/services/directoryServices/__tests__/MediaDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/MediaDirectoryService.spec.js
@@ -1,5 +1,4 @@
 const { BadRequestError } = require("@errors/BadRequestError")
-const { NotFoundError } = require("@errors/NotFoundError")
 
 const { GITHUB_ORG_NAME } = process.env
 

--- a/services/directoryServices/__tests__/MediaDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/MediaDirectoryService.spec.js
@@ -80,9 +80,13 @@ describe("Media Directory Service", () => {
       size: 10,
       type: "file",
     }
+    const dir = {
+      name: "dir",
+      type: "dir",
+    }
 
-    const readImgDirResp = [testImg1, testImg2]
-    const readFileDirResp = [testFile1, testFile2]
+    const readImgDirResp = [testImg1, testImg2, dir]
+    const readFileDirResp = [testFile1, testFile2, dir]
     mockGitHubService.getRepoInfo.mockResolvedValueOnce({
       private: false,
     })
@@ -100,6 +104,10 @@ describe("Media Directory Service", () => {
           name: testImg2.name,
           sha: testImg2.sha,
           mediaPath: `${imageDirectoryName}/${testImg2.name}`,
+        },
+        {
+          name: dir.name,
+          type: dir.type,
         },
       ]
       await expect(
@@ -137,6 +145,10 @@ describe("Media Directory Service", () => {
           sha: testImg2.sha,
           mediaPath: `${imageDirectoryName}/${testImg2.name}`,
         },
+        {
+          name: dir.name,
+          type: dir.type,
+        },
       ]
       await expect(
         service.listFiles(reqDetails, {
@@ -166,6 +178,10 @@ describe("Media Directory Service", () => {
           name: testFile2.name,
           sha: testFile2.sha,
           mediaPath: `${fileDirectoryName}/${testFile2.name}`,
+        },
+        {
+          name: dir.name,
+          type: dir.type,
         },
       ]
       await expect(

--- a/services/directoryServices/__tests__/MediaDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/MediaDirectoryService.spec.js
@@ -93,11 +93,13 @@ describe("Media Directory Service", () => {
           mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${testImg1.path}`,
           name: testImg1.name,
           sha: testImg1.sha,
+          mediaPath: `${imageDirectoryName}/${testImg1.name}`,
         },
         {
           mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${testImg2.path}?sanitize=true`,
           name: testImg2.name,
           sha: testImg2.sha,
+          mediaPath: `${imageDirectoryName}/${testImg2.name}`,
         },
       ]
       await expect(
@@ -127,11 +129,13 @@ describe("Media Directory Service", () => {
           mediaUrl: `data:image/png;base64,${mockContent1}`,
           name: testImg1.name,
           sha: testImg1.sha,
+          mediaPath: `${imageDirectoryName}/${testImg1.name}`,
         },
         {
           mediaUrl: `data:image/svg+xml;base64,${mockContent2}`,
           name: testImg2.name,
           sha: testImg2.sha,
+          mediaPath: `${imageDirectoryName}/${testImg2.name}`,
         },
       ]
       await expect(
@@ -155,11 +159,13 @@ describe("Media Directory Service", () => {
           mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${testFile1.path}`,
           name: testFile1.name,
           sha: testFile1.sha,
+          mediaPath: `${fileDirectoryName}/${testFile1.name}`,
         },
         {
           mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${testFile2.path}`,
           name: testFile2.name,
           sha: testFile2.sha,
+          mediaPath: `${fileDirectoryName}/${testFile2.name}`,
         },
       ]
       await expect(

--- a/services/directoryServices/__tests__/MediaDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/MediaDirectoryService.spec.js
@@ -84,9 +84,13 @@ describe("Media Directory Service", () => {
       name: "dir",
       type: "dir",
     }
+    const placeholder = {
+      name: PLACEHOLDER_FILE_NAME,
+      type: "file",
+    }
 
-    const readImgDirResp = [testImg1, testImg2, dir]
-    const readFileDirResp = [testFile1, testFile2, dir]
+    const readImgDirResp = [testImg1, testImg2, dir, placeholder]
+    const readFileDirResp = [testFile1, testFile2, dir, placeholder]
     mockGitHubService.getRepoInfo.mockResolvedValueOnce({
       private: false,
     })

--- a/services/directoryServices/__tests__/MediaDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/MediaDirectoryService.spec.js
@@ -8,8 +8,10 @@ const PLACEHOLDER_FILE_NAME = ".keep"
 describe("Media Directory Service", () => {
   const siteName = "test-site"
   const accessToken = "test-token"
-  const imageDirectoryName = "images/imageDir"
-  const fileDirectoryName = "files/fileDir"
+  const imageSubdirectory = "imageDir"
+  const imageDirectoryName = `images/${imageSubdirectory}`
+  const fileSubdirectory = "fileDir"
+  const fileDirectoryName = `files/${fileSubdirectory}`
 
   const objArray = [
     {
@@ -218,7 +220,8 @@ describe("Media Directory Service", () => {
           objArray: undefined,
         })
       ).resolves.toMatchObject({
-        newDirectoryName: imageDirectoryName,
+        mediaDirectoryName: imageSubdirectory,
+        mediaType: "images",
       })
       expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
         content: "",
@@ -228,8 +231,7 @@ describe("Media Directory Service", () => {
     })
 
     it("Creating a directory with specified files works correctly", async () => {
-      const oldDirectoryName = "files/newFolder"
-      const newDirectoryName = `${oldDirectoryName}/newSubfolder`
+      const newDirectoryName = `${fileDirectoryName}/newSubfolder`
       const objArray = [
         {
           name: `fileName`,
@@ -246,7 +248,8 @@ describe("Media Directory Service", () => {
           objArray,
         })
       ).resolves.toMatchObject({
-        newDirectoryName,
+        mediaDirectoryName: `${fileSubdirectory}/newSubfolder`,
+        mediaType: "files",
       })
       expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
         content: "",
@@ -256,10 +259,10 @@ describe("Media Directory Service", () => {
       expect(mockBaseDirectoryService.moveFiles).toHaveBeenCalledWith(
         reqDetails,
         {
-          oldDirectoryName,
+          oldDirectoryName: fileDirectoryName,
           newDirectoryName,
           targetFiles: objArray.map((file) => file.name),
-          message: `Moving media files from ${oldDirectoryName} to ${newDirectoryName}`,
+          message: `Moving media files from ${fileDirectoryName} to ${newDirectoryName}`,
         }
       )
     })

--- a/services/directoryServices/__tests__/MediaDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/MediaDirectoryService.spec.js
@@ -1,0 +1,260 @@
+const { BadRequestError } = require("@errors/BadRequestError")
+const { NotFoundError } = require("@errors/NotFoundError")
+
+const { GITHUB_ORG_NAME } = process.env
+
+const PLACEHOLDER_FILE_NAME = ".keep"
+
+describe("Media Directory Service", () => {
+  const siteName = "test-site"
+  const accessToken = "test-token"
+  const imageDirectoryName = "images/imageDir"
+  const fileDirectoryName = "files/fileDir"
+
+  const objArray = [
+    {
+      type: "file",
+      name: "file.pdf",
+    },
+    {
+      type: "file",
+      name: `file2.pdf`,
+    },
+  ]
+
+  const reqDetails = { siteName, accessToken }
+
+  const mockBaseDirectoryService = {
+    list: jest.fn(),
+    rename: jest.fn(),
+    delete: jest.fn(),
+    moveFiles: jest.fn(),
+  }
+
+  const mockGitHubService = {
+    create: jest.fn(),
+    readMedia: jest.fn(),
+    getRepoInfo: jest.fn(),
+  }
+
+  const {
+    MediaDirectoryService,
+  } = require("@services/directoryServices/MediaDirectoryService")
+  const service = new MediaDirectoryService({
+    baseDirectoryService: mockBaseDirectoryService,
+    gitHubService: mockGitHubService,
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("ListFiles", () => {
+    const mockContent1 = "mock-content-1"
+    const mockContent2 = "mock-content-2"
+    const testImg1 = {
+      name: "test-name.png",
+      path: "test-path/test-name.png",
+      sha: "test-sha-1",
+      size: 10,
+      type: "file",
+    }
+    const testImg2 = {
+      name: "test-name.svg",
+      path: "test-path/test-name.svg",
+      sha: "test-sha-2",
+      size: 10,
+      type: "file",
+    }
+    const testFile1 = {
+      name: "test-name.pdf",
+      path: "test-path/test-name.pdf",
+      sha: "test-sha-1",
+      size: 10,
+      type: "file",
+    }
+    const testFile2 = {
+      name: "test-name.pdf",
+      path: "test-path/test-name.pdf",
+      sha: "test-sha-2",
+      size: 10,
+      type: "file",
+    }
+
+    const readImgDirResp = [testImg1, testImg2]
+    const readFileDirResp = [testFile1, testFile2]
+    mockGitHubService.getRepoInfo.mockResolvedValueOnce({
+      private: false,
+    })
+    mockBaseDirectoryService.list.mockResolvedValueOnce(readImgDirResp)
+    it("ListFiles for an image directory in a public repo returns all images properly formatted", async () => {
+      const expectedResp = [
+        {
+          mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${testImg1.path}`,
+          name: testImg1.name,
+          sha: testImg1.sha,
+        },
+        {
+          mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${testImg2.path}?sanitize=true`,
+          name: testImg2.name,
+          sha: testImg2.sha,
+        },
+      ]
+      await expect(
+        service.listFiles(reqDetails, {
+          mediaType: "images",
+          directoryName: imageDirectoryName,
+        })
+      ).resolves.toMatchObject(expectedResp)
+      expect(mockGitHubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+        directoryName: imageDirectoryName,
+      })
+    })
+    mockGitHubService.getRepoInfo.mockResolvedValueOnce({
+      private: true,
+    })
+    mockBaseDirectoryService.list.mockResolvedValueOnce(readImgDirResp)
+    mockGitHubService.readMedia.mockResolvedValueOnce({
+      content: mockContent1,
+    })
+    mockGitHubService.readMedia.mockResolvedValueOnce({
+      content: mockContent2,
+    })
+    it("ListFiles for an image directory in a private repo returns all images properly formatted", async () => {
+      const expectedResp = [
+        {
+          mediaUrl: `data:image/png;base64,${mockContent1}`,
+          name: testImg1.name,
+          sha: testImg1.sha,
+        },
+        {
+          mediaUrl: `data:image/svg+xml;base64,${mockContent2}`,
+          name: testImg2.name,
+          sha: testImg2.sha,
+        },
+      ]
+      await expect(
+        service.listFiles(reqDetails, {
+          mediaType: "images",
+          directoryName: imageDirectoryName,
+        })
+      ).resolves.toMatchObject(expectedResp)
+      expect(mockGitHubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+        directoryName: imageDirectoryName,
+      })
+    })
+    mockGitHubService.getRepoInfo.mockResolvedValueOnce({
+      private: false,
+    })
+    mockBaseDirectoryService.list.mockResolvedValueOnce(readFileDirResp)
+    it("ListFiles for a file directory in a public repo returns all files properly formatted", async () => {
+      const expectedResp = [
+        {
+          mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${testFile1.path}`,
+          name: testFile1.name,
+          sha: testFile1.sha,
+        },
+        {
+          mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${testFile2.path}`,
+          name: testFile2.name,
+          sha: testFile2.sha,
+        },
+      ]
+      await expect(
+        service.listFiles(reqDetails, {
+          mediaType: "files",
+          directoryName: fileDirectoryName,
+        })
+      ).resolves.toMatchObject(expectedResp)
+      expect(mockGitHubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+        directoryName: fileDirectoryName,
+      })
+    })
+  })
+
+  describe("CreateMediaDirectory", () => {
+    it("rejects directories with special characters", async () => {
+      await expect(
+        service.createMediaDirectory(reqDetails, {
+          directoryName: "dir/dir",
+        })
+      ).rejects.toThrowError(BadRequestError)
+    })
+
+    it("Creating a directory with no specified files works correctly", async () => {
+      await expect(
+        service.createMediaDirectory(reqDetails, {
+          directoryName: imageDirectoryName,
+        })
+      ).resolves.toMatchObject({
+        newDirectoryName: imageDirectoryName,
+      })
+    })
+  })
+
+  describe("RenameMediaDirectory", () => {
+    const newDirectoryName = "images/new dir"
+    it("rejects names with special characters", async () => {
+      await expect(
+        service.renameMediaDirectory(reqDetails, {
+          directoryName: imageDirectoryName,
+          newDirectoryName: "dir/dir",
+        })
+      ).rejects.toThrowError(BadRequestError)
+    })
+
+    it("Renaming a media directory works correctly", async () => {
+      await expect(
+        service.renameMediaDirectory(reqDetails, {
+          directoryName: imageDirectoryName,
+          newDirectoryName,
+        })
+      ).resolves.not.toThrowError()
+      expect(mockBaseDirectoryService.rename).toHaveBeenCalledWith(reqDetails, {
+        oldDirectoryName: imageDirectoryName,
+        newDirectoryName,
+        message: `Renaming media folder ${imageDirectoryName} to ${newDirectoryName}`,
+      })
+    })
+  })
+
+  describe("DeleteMediaDirectory", () => {
+    it("Deleting a directory works correctly", async () => {
+      await expect(
+        service.deleteMediaDirectory(reqDetails, {
+          directoryName: imageDirectoryName,
+        })
+      ).resolves.not.toThrowError()
+      expect(mockBaseDirectoryService.delete).toHaveBeenCalledWith(reqDetails, {
+        directoryName: imageDirectoryName,
+        message: `Deleting media folder ${imageDirectoryName}`,
+      })
+    })
+  })
+
+  describe("MoveMediaFiles", () => {
+    const targetDirectoryName = "files/target directory"
+    const targetFiles = objArray.map((item) => item.name)
+    it("Moving media in a media directory to another media directory works correctly", async () => {
+      await expect(
+        service.moveMediaFiles(reqDetails, {
+          directoryName: fileDirectoryName,
+          targetDirectoryName,
+          objArray,
+        })
+      ).resolves.not.toThrowError()
+      expect(mockBaseDirectoryService.moveFiles).toHaveBeenCalledWith(
+        reqDetails,
+        {
+          oldDirectoryName: fileDirectoryName,
+          newDirectoryName: targetDirectoryName,
+          targetFiles,
+          message: `Moving media files from ${fileDirectoryName} to ${targetDirectoryName}`,
+        }
+      )
+    })
+  })
+})

--- a/services/directoryServices/__tests__/MediaDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/MediaDirectoryService.spec.js
@@ -180,6 +180,7 @@ describe("Media Directory Service", () => {
       await expect(
         service.createMediaDirectory(reqDetails, {
           directoryName: "dir/dir",
+          objArray: undefined,
         })
       ).rejects.toThrowError(BadRequestError)
     })
@@ -188,10 +189,53 @@ describe("Media Directory Service", () => {
       await expect(
         service.createMediaDirectory(reqDetails, {
           directoryName: imageDirectoryName,
+          objArray: undefined,
         })
       ).resolves.toMatchObject({
         newDirectoryName: imageDirectoryName,
       })
+      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: "",
+        fileName: PLACEHOLDER_FILE_NAME,
+        directoryName: imageDirectoryName,
+      })
+    })
+
+    it("Creating a directory with specified files works correctly", async () => {
+      const oldDirectoryName = "files/newFolder"
+      const newDirectoryName = `${oldDirectoryName}/newSubfolder`
+      const objArray = [
+        {
+          name: `fileName`,
+          type: `file`,
+        },
+        {
+          name: `fileName2`,
+          type: `file`,
+        },
+      ]
+      await expect(
+        service.createMediaDirectory(reqDetails, {
+          directoryName: newDirectoryName,
+          objArray,
+        })
+      ).resolves.toMatchObject({
+        newDirectoryName,
+      })
+      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: "",
+        fileName: PLACEHOLDER_FILE_NAME,
+        directoryName: newDirectoryName,
+      })
+      expect(mockBaseDirectoryService.moveFiles).toHaveBeenCalledWith(
+        reqDetails,
+        {
+          oldDirectoryName,
+          newDirectoryName,
+          targetFiles: objArray.map((file) => file.name),
+          message: `Moving media files from ${oldDirectoryName} to ${newDirectoryName}`,
+        }
+      )
     })
   })
 

--- a/services/fileServices/MdPageServices/MediaFileService.js
+++ b/services/fileServices/MdPageServices/MediaFileService.js
@@ -36,10 +36,14 @@ class MediaFileService {
 
   async read(reqDetails, { fileName, directoryName, mediaType }) {
     const { siteName } = reqDetails
-    const { sha } = await this.gitHubService.read(reqDetails, {
-      fileName,
+    const directoryData = await this.gitHubService.readDirectory(reqDetails, {
       directoryName,
     })
+
+    const targetFile = directoryData.find(
+      (fileOrDir) => fileOrDir.name === fileName
+    )
+    const { sha } = targetFile
     const { private: isPrivate } = await this.gitHubService.getRepoInfo(
       reqDetails
     )

--- a/services/fileServices/MdPageServices/MediaFileService.js
+++ b/services/fileServices/MdPageServices/MediaFileService.js
@@ -29,6 +29,7 @@ class MediaFileService {
       content: sanitizedContent,
       fileName,
       directoryName,
+      isMedia: true,
     })
     return { fileName, content: sanitizedContent, sha }
   }

--- a/services/fileServices/MdPageServices/MediaFileService.js
+++ b/services/fileServices/MdPageServices/MediaFileService.js
@@ -31,7 +31,7 @@ class MediaFileService {
       directoryName,
       isMedia: true,
     })
-    return { fileName, content: sanitizedContent, sha }
+    return { name: fileName, content, sha }
   }
 
   async read(reqDetails, { fileName, directoryName }) {
@@ -87,8 +87,8 @@ class MediaFileService {
       isMedia: true,
     })
     return {
-      fileName,
-      content: sanitizedContent,
+      name: fileName,
+      content,
       oldSha: sha,
       newSha,
     }
@@ -138,9 +138,9 @@ class MediaFileService {
     })
 
     return {
-      fileName: newFileName,
+      name: newFileName,
       oldSha: sha,
-      newSha: sha,
+      sha,
     }
   }
 }

--- a/services/fileServices/MdPageServices/MediaFileService.js
+++ b/services/fileServices/MdPageServices/MediaFileService.js
@@ -1,0 +1,121 @@
+const { BadRequestError } = require("@errors/BadRequestError")
+const { MediaTypeError } = require("@errors/MediaTypeError")
+
+const { GITHUB_ORG_NAME } = process.env
+
+const { validateAndSanitizeFileUpload } = require("@utils/file-upload-utils")
+
+const { isMediaPathValid } = require("@validators/validators")
+
+class MediaFileService {
+  constructor({ gitHubService }) {
+    this.gitHubService = gitHubService
+  }
+
+  mediaNameChecks({ directoryName, fileName }) {
+    if (!isMediaPathValid({ path: directoryName }))
+      throw new BadRequestError("Invalid media path")
+    if (!isMediaPathValid({ path: fileName, isFile: true }))
+      throw new BadRequestError("Special characters not allowed in file name")
+  }
+
+  async create(reqDetails, { fileName, directoryName, content }) {
+    this.mediaNameChecks({ directoryName, fileName })
+    const sanitizedContent = await validateAndSanitizeFileUpload(content)
+    if (!sanitizedContent) {
+      throw new MediaTypeError(`File extension is not within the approved list`)
+    }
+    const { sha } = await this.gitHubService.create(reqDetails, {
+      content: sanitizedContent,
+      fileName,
+      directoryName,
+    })
+    return { fileName, content: sanitizedContent, sha }
+  }
+
+  async read(reqDetails, { fileName, directoryName, mediaType }) {
+    const { siteName } = reqDetails
+    const { sha } = await this.gitHubService.read(reqDetails, {
+      fileName,
+      directoryName,
+    })
+    const { private: isPrivate } = await this.gitHubService.getRepoInfo(
+      reqDetails
+    )
+    const fileData = {
+      mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${directoryName}/${fileName}${
+        fileName.endsWith(".svg") ? "?sanitize=true" : ""
+      }`,
+      name: fileName,
+      sha,
+    }
+    if (mediaType === "images" && isPrivate) {
+      // Generate blob url
+      const imageExt = fileName.slice(fileName.lastIndexOf(".") + 1)
+      const contentType = `image/${imageExt === "svg" ? "svg+xml" : imageExt}`
+      const { content } = await this.gitHubService.readMedia(reqDetails, {
+        fileSha: sha,
+      })
+      const blobURL = `data:${contentType};base64,${content}`
+      fileData.mediaUrl = blobURL
+    }
+    return fileData
+  }
+
+  async update(reqDetails, { fileName, directoryName, content, sha }) {
+    this.mediaNameChecks({ directoryName, fileName })
+    const sanitizedContent = await validateAndSanitizeFileUpload(content)
+    if (!sanitizedContent) {
+      throw new MediaTypeError(`File extension is not within the approved list`)
+    }
+    const { newSha } = await this.gitHubService.update(reqDetails, {
+      fileContent: sanitizedContent,
+      sha,
+      fileName,
+      directoryName,
+    })
+    return {
+      fileName,
+      content: sanitizedContent,
+      oldSha: sha,
+      newSha,
+    }
+  }
+
+  async delete(reqDetails, { fileName, directoryName, sha }) {
+    this.mediaNameChecks({ directoryName, fileName })
+    return this.gitHubService.delete(reqDetails, {
+      sha,
+      fileName,
+      directoryName,
+    })
+  }
+
+  async rename(
+    reqDetails,
+    { oldFileName, newFileName, directoryName, content, sha }
+  ) {
+    this.mediaNameChecks({ directoryName, fileName: oldFileName })
+    this.mediaNameChecks({ directoryName, fileName: newFileName })
+
+    await this.gitHubService.delete(reqDetails, {
+      sha,
+      fileName: oldFileName,
+      directoryName,
+    })
+
+    const { sha: newSha } = await this.gitHubService.create(reqDetails, {
+      content,
+      fileName: newFileName,
+      directoryName,
+    })
+    return {
+      fileName: newFileName,
+      content,
+      oldSha: sha,
+      newSha,
+    }
+  }
+}
+
+module.exports = { MediaFileService }

--- a/services/fileServices/MdPageServices/MediaFileService.js
+++ b/services/fileServices/MdPageServices/MediaFileService.js
@@ -49,7 +49,10 @@ class MediaFileService {
       reqDetails
     )
     const fileData = {
-      mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${directoryName}/${fileName}${
+      mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${directoryName
+        .split("/")
+        .map((v) => encodeURIComponent(v))
+        .join("/")}/${fileName}${
         fileName.endsWith(".svg") ? "?sanitize=true" : ""
       }`,
       name: fileName,

--- a/services/fileServices/MdPageServices/MediaFileService.js
+++ b/services/fileServices/MdPageServices/MediaFileService.js
@@ -34,11 +34,12 @@ class MediaFileService {
     return { fileName, content: sanitizedContent, sha }
   }
 
-  async read(reqDetails, { fileName, directoryName, mediaType }) {
+  async read(reqDetails, { fileName, directoryName }) {
     const { siteName } = reqDetails
     const directoryData = await this.gitHubService.readDirectory(reqDetails, {
       directoryName,
     })
+    const mediaType = directoryName.split("/")[0]
 
     const targetFile = directoryData.find(
       (fileOrDir) => fileOrDir.name === fileName

--- a/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
+++ b/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
@@ -1,0 +1,276 @@
+const { BadRequestError } = require("@errors/BadRequestError")
+
+const { GITHUB_ORG_NAME } = process.env
+
+describe("Media File Service", () => {
+  const siteName = "test-site"
+  const accessToken = "test-token"
+  const imageName = "test image.png"
+  const fileName = "test file.pdf"
+  const directoryName = "images/subfolder"
+  const mockContent = "test"
+  const mockSanitizedContent = "sanitized-test"
+  const sha = "12345"
+
+  const reqDetails = { siteName, accessToken }
+
+  const mockGithubService = {
+    create: jest.fn(),
+    read: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    getRepoInfo: jest.fn(),
+    readMedia: jest.fn(),
+  }
+
+  jest.mock("@utils/file-upload-utils", () => ({
+    validateAndSanitizeFileUpload: jest
+      .fn()
+      .mockReturnValue(mockSanitizedContent),
+  }))
+  const {
+    MediaFileService,
+  } = require("@services/fileServices/MdPageServices/MediaFileService")
+  const service = new MediaFileService({
+    gitHubService: mockGithubService,
+  })
+  const { validateAndSanitizeFileUpload } = require("@utils/file-upload-utils")
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("Create", () => {
+    it("rejects page names with special characters", async () => {
+      await expect(
+        service.create(reqDetails, {
+          fileName: "file/file.pdf",
+          directoryName,
+          content: mockContent,
+        })
+      ).rejects.toThrowError(BadRequestError)
+    })
+
+    mockGithubService.create.mockResolvedValueOnce({ sha })
+    it("Creating pages works correctly", async () => {
+      await expect(
+        service.create(reqDetails, {
+          fileName,
+          directoryName,
+          content: mockContent,
+        })
+      ).resolves.toMatchObject({
+        fileName,
+        content: mockSanitizedContent,
+        sha,
+      })
+      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: mockSanitizedContent,
+        fileName,
+        directoryName,
+      })
+      expect(validateAndSanitizeFileUpload).toHaveBeenCalledWith(mockContent)
+    })
+  })
+
+  describe("Read", () => {
+    // TODO: file tests when file handling is implemented
+    mockGithubService.read.mockResolvedValueOnce({
+      content: "",
+      sha,
+    }),
+      mockGithubService.getRepoInfo.mockResolvedValueOnce({
+        private: false,
+      }),
+      mockGithubService.readMedia.mockResolvedValueOnce({
+        content: mockContent,
+      }),
+      it("Reading image files in public repos works correctly", async () => {
+        const expectedResp = {
+          mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${directoryName}/${imageName}`,
+          name: imageName,
+          sha,
+        }
+        await expect(
+          service.read(reqDetails, {
+            fileName: imageName,
+            directoryName,
+            mediaType: "images",
+          })
+        ).resolves.toMatchObject(expectedResp)
+        expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+          fileName: imageName,
+          directoryName,
+        })
+        expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
+      })
+    mockGithubService.read.mockResolvedValueOnce({
+      content: "",
+      sha,
+    }),
+      mockGithubService.getRepoInfo.mockResolvedValueOnce({
+        private: false,
+      }),
+      it("Reading svg files in public repos adds sanitisation", async () => {
+        const svgName = "image.svg"
+        const expectedResp = {
+          mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${directoryName}/${svgName}?sanitize=true`,
+          name: svgName,
+          sha,
+        }
+        await expect(
+          service.read(reqDetails, {
+            fileName: svgName,
+            directoryName,
+            mediaType: "images",
+          })
+        ).resolves.toMatchObject(expectedResp)
+        expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+          fileName: svgName,
+          directoryName,
+        })
+        expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
+      })
+    mockGithubService.read.mockResolvedValueOnce({
+      content: "",
+      sha,
+    }),
+      mockGithubService.getRepoInfo.mockResolvedValueOnce({
+        private: true,
+      }),
+      it("Reading image files in private repos works correctly", async () => {
+        const expectedResp = {
+          mediaUrl: `data:image/png;base64,${mockContent}`,
+          name: imageName,
+          sha,
+        }
+        await expect(
+          service.read(reqDetails, {
+            fileName: imageName,
+            directoryName,
+            mediaType: "images",
+          })
+        ).resolves.toMatchObject(expectedResp)
+        expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+          fileName: imageName,
+          directoryName,
+        })
+        expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
+        expect(mockGithubService.readMedia).toHaveBeenCalledWith(reqDetails, {
+          fileSha: sha,
+        })
+      })
+    mockGithubService.read.mockResolvedValueOnce({
+      content: "",
+      sha,
+    }),
+      mockGithubService.getRepoInfo.mockResolvedValueOnce({
+        private: false,
+      }),
+      mockGithubService.readMedia.mockResolvedValueOnce({
+        content: mockContent,
+      }),
+      it("Reading files in public repos works correctly", async () => {
+        const expectedResp = {
+          mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${directoryName}/${fileName}`,
+          name: fileName,
+          sha,
+        }
+        await expect(
+          service.read(reqDetails, {
+            fileName,
+            directoryName,
+            mediaType: "files",
+          })
+        ).resolves.toMatchObject(expectedResp)
+        expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+          fileName,
+          directoryName,
+        })
+        expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
+      })
+  })
+
+  describe("Update", () => {
+    const oldSha = "54321"
+    mockGithubService.update.mockResolvedValueOnce({ newSha: sha })
+    it("Updating media file content works correctly", async () => {
+      await expect(
+        service.update(reqDetails, {
+          fileName,
+          directoryName,
+          content: mockContent,
+          sha: oldSha,
+        })
+      ).resolves.toMatchObject({
+        fileName,
+        content: mockSanitizedContent,
+        oldSha,
+        newSha: sha,
+      })
+      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+        fileName,
+        directoryName,
+        fileContent: mockSanitizedContent,
+        sha: oldSha,
+      })
+      expect(validateAndSanitizeFileUpload).toHaveBeenCalledWith(mockContent)
+    })
+  })
+
+  describe("Delete", () => {
+    it("Deleting pages works correctly", async () => {
+      await expect(
+        service.delete(reqDetails, { fileName, directoryName, sha })
+      ).resolves.not.toThrow()
+      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+        fileName,
+        directoryName,
+        sha,
+      })
+    })
+  })
+
+  describe("Rename", () => {
+    const oldSha = "54321"
+    const oldFileName = "test old file.pdf"
+    mockGithubService.create.mockResolvedValueOnce({ sha })
+
+    it("rejects renaming to page names with special characters", async () => {
+      await expect(
+        service.rename(reqDetails, {
+          oldFileName,
+          newFileName: "file/file.pdf",
+          directoryName,
+          content: mockContent,
+        })
+      ).rejects.toThrowError(BadRequestError)
+    })
+    it("Renaming pages works correctly", async () => {
+      await expect(
+        service.rename(reqDetails, {
+          oldFileName,
+          newFileName: fileName,
+          directoryName,
+          content: mockContent,
+          sha: oldSha,
+        })
+      ).resolves.toMatchObject({
+        fileName,
+        content: mockContent,
+        oldSha,
+        newSha: sha,
+      })
+      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+        fileName: oldFileName,
+        directoryName,
+        sha: oldSha,
+      })
+      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: mockContent,
+        fileName,
+        directoryName,
+      })
+    })
+  })
+})

--- a/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
+++ b/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
@@ -68,6 +68,7 @@ describe("Media File Service", () => {
         content: mockSanitizedContent,
         fileName,
         directoryName,
+        isMedia: true,
       })
       expect(validateAndSanitizeFileUpload).toHaveBeenCalledWith(mockContent)
     })

--- a/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
+++ b/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
@@ -117,7 +117,6 @@ describe("Media File Service", () => {
         service.read(reqDetails, {
           fileName: imageName,
           directoryName,
-          mediaType: "images",
         })
       ).resolves.toMatchObject(expectedResp)
       expect(mockGithubService.readDirectory).toHaveBeenCalledWith(reqDetails, {

--- a/utils/file-upload-utils.js
+++ b/utils/file-upload-utils.js
@@ -16,7 +16,8 @@ const ALLOWED_FILE_EXTENSIONS = [
   "ico",
 ]
 
-const validateAndSanitizeFileUpload = async (content) => {
+const validateAndSanitizeFileUpload = async (data) => {
+  const [schema, content] = data.split(",")
   const fileBuffer = Buffer.from(content, "base64")
   const detectedFileType = await FileType.fromBuffer(fileBuffer)
 

--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -124,7 +124,8 @@ const RenameMediaDirectoryRequestSchema = Joi.object().keys({
 const MoveMediaDirectoryFilesRequestSchema = Joi.object().keys({
   target: Joi.object()
     .keys({
-      directoryName: Joi.string().required(),
+      mediaType: Joi.string().required(),
+      mediaDirectoryName: Joi.string(),
     })
     .required(),
   items: Joi.array().items(FileSchema).required(),

--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -110,6 +110,23 @@ const MoveResourceDirectoryPagesRequestSchema = Joi.object().keys({
     .required(),
   items: Joi.array().items(FileSchema).required(),
 })
+
+// Media
+const CreateMediaFileRequestSchema = Joi.object().keys({
+  content: Joi.string().required(),
+  newFileName: Joi.string().required(),
+})
+
+const UpdateMediaFileRequestSchema = Joi.object().keys({
+  content: Joi.string().required(),
+  sha: Joi.string().required(),
+  newFileName: Joi.string(),
+})
+
+const DeleteMediaFileRequestSchema = Joi.object().keys({
+  sha: Joi.string().required(),
+})
+
 const UpdateSettingsRequestSchema = Joi.object().keys({
   colors: Joi.object().keys({
     "primary-color": Joi.string().required(),
@@ -159,5 +176,8 @@ module.exports = {
   CreateResourceDirectoryRequestSchema,
   RenameResourceDirectoryRequestSchema,
   MoveResourceDirectoryPagesRequestSchema,
+  CreateMediaFileRequestSchema,
+  UpdateMediaFileRequestSchema,
+  DeleteMediaFileRequestSchema,
   UpdateSettingsRequestSchema,
 }

--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -124,8 +124,7 @@ const RenameMediaDirectoryRequestSchema = Joi.object().keys({
 const MoveMediaDirectoryFilesRequestSchema = Joi.object().keys({
   target: Joi.object()
     .keys({
-      mediaType: Joi.string().required(),
-      mediaDirectoryName: Joi.string(),
+      directoryName: Joi.string().required(),
     })
     .required(),
   items: Joi.array().items(FileSchema).required(),

--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -112,6 +112,23 @@ const MoveResourceDirectoryPagesRequestSchema = Joi.object().keys({
 })
 
 // Media
+const CreateMediaDirectoryRequestSchema = Joi.object().keys({
+  newDirectoryName: Joi.string().required(),
+})
+
+const RenameMediaDirectoryRequestSchema = Joi.object().keys({
+  newDirectoryName: Joi.string().required(),
+})
+
+const MoveMediaDirectoryFilesRequestSchema = Joi.object().keys({
+  target: Joi.object()
+    .keys({
+      directoryName: Joi.string().required(),
+    })
+    .required(),
+  items: Joi.array().items(FileSchema).required(),
+})
+
 const CreateMediaFileRequestSchema = Joi.object().keys({
   content: Joi.string().required(),
   newFileName: Joi.string().required(),
@@ -176,6 +193,9 @@ module.exports = {
   CreateResourceDirectoryRequestSchema,
   RenameResourceDirectoryRequestSchema,
   MoveResourceDirectoryPagesRequestSchema,
+  CreateMediaDirectoryRequestSchema,
+  RenameMediaDirectoryRequestSchema,
+  MoveMediaDirectoryFilesRequestSchema,
   CreateMediaFileRequestSchema,
   UpdateMediaFileRequestSchema,
   DeleteMediaFileRequestSchema,

--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -114,6 +114,7 @@ const MoveResourceDirectoryPagesRequestSchema = Joi.object().keys({
 // Media
 const CreateMediaDirectoryRequestSchema = Joi.object().keys({
   newDirectoryName: Joi.string().required(),
+  items: Joi.array().items(FileSchema),
 })
 
 const RenameMediaDirectoryRequestSchema = Joi.object().keys({

--- a/validators/RequestSchema.js
+++ b/validators/RequestSchema.js
@@ -135,7 +135,7 @@ const CreateMediaFileRequestSchema = Joi.object().keys({
 })
 
 const UpdateMediaFileRequestSchema = Joi.object().keys({
-  content: Joi.string().required(),
+  content: Joi.string(),
   sha: Joi.string().required(),
   newFileName: Joi.string(),
 })

--- a/validators/validators.js
+++ b/validators/validators.js
@@ -1,6 +1,9 @@
 const specialCharactersRegexTest = /[~%^*_+\-./\\`;~{}[\]"<>]/
 const dateRegexTest = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/
 
+const mediaSpecialCharactersRegexTest = /[~%^*_+\./\\`;~{}[\]"<>]/ // Allows dashes
+const mediaSubfolderRegexText = /^(images|files|(images|files)\/[^~%^*_+\-.\\`;~{}[\]"<>]+)$/
+
 const titleSpecialCharCheck = ({ title, isFile = false }) => {
   let testTitle = title
   if (isFile) {
@@ -12,7 +15,18 @@ const titleSpecialCharCheck = ({ title, isFile = false }) => {
 
 const isDateValid = (date) => dateRegexTest.test(date)
 
+const isMediaPathValid = ({ path, isFile = false }) => {
+  if (isFile) {
+    // Remove extensions
+    let testTitle = path
+    testTitle = path.replace(/\.[a-zA-Z]{3,4}$/, "")
+    return !mediaSpecialCharactersRegexTest.test(testTitle)
+  }
+  return mediaSubfolderRegexText.test(path)
+}
+
 module.exports = {
   titleSpecialCharCheck,
   isDateValid,
+  isMediaPathValid,
 }

--- a/validators/validators.js
+++ b/validators/validators.js
@@ -1,7 +1,7 @@
 const specialCharactersRegexTest = /[~%^*_+\-./\\`;~{}[\]"<>]/
 const dateRegexTest = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/
 
-const mediaSpecialCharactersRegexTest = /[~%^*+\./\\`;~{}[\]"<>]/ // Allows dashes
+const mediaSpecialCharactersRegexTest = /[~%^#*+\./\\`;~{}[\]"<>]/ // Allows dashes
 const mediaSubfolderRegexText = /^(images|files|(images|files)\/[^~%^*+\.\\`;~{}[\]"<>]+)$/
 
 const titleSpecialCharCheck = ({ title, isFile = false }) => {

--- a/validators/validators.js
+++ b/validators/validators.js
@@ -1,8 +1,8 @@
 const specialCharactersRegexTest = /[~%^*_+\-./\\`;~{}[\]"<>]/
 const dateRegexTest = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/
 
-const mediaSpecialCharactersRegexTest = /[~%^*_+\./\\`;~{}[\]"<>]/ // Allows dashes
-const mediaSubfolderRegexText = /^(images|files|(images|files)\/[^~%^*_+\-.\\`;~{}[\]"<>]+)$/
+const mediaSpecialCharactersRegexTest = /[~%^*+\./\\`;~{}[\]"<>]/ // Allows dashes
+const mediaSubfolderRegexText = /^(images|files|(images|files)\/[^~%^*+\.\\`;~{}[\]"<>]+)$/
 
 const titleSpecialCharCheck = ({ title, isFile = false }) => {
   let testTitle = title


### PR DESCRIPTION
This PR refactors the resources room flow. It adds several new components:

- Media directory and media files router
- Media directory and media file services

**Overview**
The media categories router contains the following endpoints:

- GET /:siteName/media/:directoryName - get the files in a media category
- POST /:siteName/media- Create a media category
- POST /:siteName/media/:directoryName - Rename an existing media category
- DELETE /:siteName/media/:directoryName- Delete an existing media category
- POST /:siteName/media/:directoryName/move - Move files in a media category to another media category

The media files router contains the following endpoints:

- GET /:siteName/media/:directoryName/pages/:fileName - get information about a media file
- POST /:siteName/media/:directoryName/pages - Create a media file
- POST /:siteName/media/:directoryName/pages/:fileName - Rename/Update an existing media file
- DELETE /:siteName/media/:directoryName/pages/:fileName - Delete an existing media file

The `GithubService` has also been updated with new methods to support the identification of private repos and the retrieval of image files.

This PR also introduces tests for the newly added routes and services.

**Bug fixes**
This PR also fixes the following bugs:

- Route handler for update pages
  - Previously, we were erroneously using the `WriteRouteHandlerWrapper` for updating pages, even though multiple github operations were being done. We have corrected this to use the `RollbackRouteHandlerWrapper` instead.
- Conflict check for git tree operations
  - Previously, we did not check for duplicate names with git tree operations, causing duplicate file names to override existing files or directories. We have added in a check for this to throw a `ConflictError` in this scenario.


**Notes**

The `getMedia` implementation is inefficient, and is done by calling a `listDirectory` endpoint, due to fileShas not being able to be directly queried for large (>1mb) files. Our current workaround is for the frontend to cache the results as much as possible, as the sha of each file is obtained when retrieving the list of files in a media directory, and this endpoint should be called as little as possible. 