### PR TITLE
Fix/move pages on old format

### DIFF
--- a/services/fileServices/MdPageServices/CollectionPageService.js
+++ b/services/fileServices/MdPageServices/CollectionPageService.js
@@ -13,8 +13,14 @@ class CollectionPageService {
     this.collectionYmlService = collectionYmlService
   }
 
-  async create(reqDetails, { fileName, collectionName, content, frontMatter }) {
-    if (titleSpecialCharCheck({ title: fileName, isFile: true }))
+  async create(
+    reqDetails,
+    { fileName, collectionName, content, frontMatter, shouldIgnoreCheck }
+  ) {
+    if (
+      !shouldIgnoreCheck &&
+      titleSpecialCharCheck({ title: fileName, isFile: true })
+    )
       throw new BadRequestError("Special characters not allowed in file name")
     const parsedCollectionName = `_${collectionName}`
 

--- a/services/fileServices/MdPageServices/SubcollectionPageService.js
+++ b/services/fileServices/MdPageServices/SubcollectionPageService.js
@@ -17,9 +17,19 @@ class SubcollectionPageService {
 
   async create(
     reqDetails,
-    { fileName, collectionName, subcollectionName, content, frontMatter }
+    {
+      fileName,
+      collectionName,
+      subcollectionName,
+      content,
+      frontMatter,
+      shouldIgnoreCheck,
+    }
   ) {
-    if (titleSpecialCharCheck({ title: fileName, isFile: true }))
+    if (
+      !shouldIgnoreCheck &&
+      titleSpecialCharCheck({ title: fileName, isFile: true })
+    )
       throw new BadRequestError("Special characters not allowed in file name")
     const parsedDirectoryName = `_${collectionName}/${subcollectionName}`
 

--- a/services/fileServices/MdPageServices/UnlinkedPageService.js
+++ b/services/fileServices/MdPageServices/UnlinkedPageService.js
@@ -14,9 +14,15 @@ class UnlinkedPageService {
     this.gitHubService = gitHubService
   }
 
-  async create(reqDetails, { fileName, content, frontMatter }) {
+  async create(
+    reqDetails,
+    { fileName, content, frontMatter, shouldIgnoreCheck }
+  ) {
     // Ensure that third_nav_title is removed for files that are being moved from collections
-    if (titleSpecialCharCheck({ title: fileName, isFile: true }))
+    if (
+      !shouldIgnoreCheck &&
+      titleSpecialCharCheck({ title: fileName, isFile: true })
+    )
       throw new BadRequestError("Special characters not allowed in file name")
     delete frontMatter.third_nav_title
     const newContent = convertDataToMarkdown(frontMatter, content)

--- a/services/fileServices/MdPageServices/__tests__/CollectionPageService.spec.js
+++ b/services/fileServices/MdPageServices/__tests__/CollectionPageService.spec.js
@@ -93,6 +93,39 @@ describe("Collection Page Service", () => {
         directoryName,
       })
     })
+
+    it("Creating pages skips the check for special characters if specified", async () => {
+      const specialName = "test-name.md"
+      await expect(
+        service.create(reqDetails, {
+          fileName: specialName,
+          collectionName,
+          content: mockContent,
+          frontMatter: { ...mockFrontMatter },
+          shouldIgnoreCheck: true,
+        })
+      ).resolves.toMatchObject({
+        fileName: specialName,
+        content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+        sha,
+      })
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        { ...mockFrontMatter },
+        mockContent
+      )
+      expect(mockCollectionYmlService.addItemToOrder).toHaveBeenCalledWith(
+        reqDetails,
+        {
+          ...collectionYmlObj,
+          item: specialName,
+        }
+      )
+      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: mockMarkdownContent,
+        fileName: specialName,
+        directoryName,
+      })
+    })
     it("Creating a page which specifies a third nav in the front matter removes the third_nav_title parameter", async () => {
       const mockFrontMatterWithThirdNav = {
         ...mockFrontMatter,

--- a/services/fileServices/MdPageServices/__tests__/UnlinkedPageService.spec.js
+++ b/services/fileServices/MdPageServices/__tests__/UnlinkedPageService.spec.js
@@ -77,6 +77,31 @@ describe("Unlinked Page Service", () => {
         directoryName,
       })
     })
+
+    it("Creating pages skips the check for special characters if specified", async () => {
+      const specialName = "test-name.md"
+      await expect(
+        service.create(reqDetails, {
+          fileName: specialName,
+          content: mockContent,
+          frontMatter: { ...mockFrontMatter },
+          shouldIgnoreCheck: true,
+        })
+      ).resolves.toMatchObject({
+        fileName: specialName,
+        content: { frontMatter: mockFrontMatter, pageBody: mockContent },
+        sha,
+      })
+      expect(convertDataToMarkdown).toHaveBeenCalledWith(
+        { ...mockFrontMatter },
+        mockContent
+      )
+      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+        content: mockMarkdownContent,
+        fileName: specialName,
+        directoryName,
+      })
+    })
   })
 
   describe("Read", () => {

--- a/services/moverServices/MoverService.js
+++ b/services/moverServices/MoverService.js
@@ -73,6 +73,7 @@ class MoverService {
         subcollectionName: newFileSubcollection,
         content: fileBody,
         frontMatter: fileFrontMatter,
+        shouldIgnoreCheck: true,
       })
     } else if (newFileCollection) {
       createResp = await this.collectionPageService.create(reqDetails, {
@@ -80,12 +81,14 @@ class MoverService {
         collectionName: newFileCollection,
         content: fileBody,
         frontMatter: fileFrontMatter,
+        shouldIgnoreCheck: true,
       })
     } else {
       createResp = await this.unlinkedPageService.create(reqDetails, {
         fileName,
         content: fileBody,
         frontMatter: fileFrontMatter,
+        shouldIgnoreCheck: true,
       })
     }
     return createResp

--- a/services/moverServices/__tests__/MoverService.spec.js
+++ b/services/moverServices/__tests__/MoverService.spec.js
@@ -91,6 +91,7 @@ describe("Mover Service", () => {
           frontMatter: mockFrontMatter,
           fileName,
           collectionName,
+          shouldIgnoreCheck: true,
         }
       )
     })
@@ -119,6 +120,7 @@ describe("Mover Service", () => {
           fileName,
           collectionName,
           subcollectionName,
+          shouldIgnoreCheck: true,
         }
       )
     })
@@ -148,6 +150,7 @@ describe("Mover Service", () => {
         content: mockContent,
         frontMatter: mockFrontMatter,
         fileName,
+        shouldIgnoreCheck: true,
       })
     })
     it("Moving collection page to another collection works correctly", async () => {
@@ -179,6 +182,7 @@ describe("Mover Service", () => {
           frontMatter: mockFrontMatter,
           fileName,
           collectionName,
+          shouldIgnoreCheck: true,
         }
       )
     })
@@ -212,6 +216,7 @@ describe("Mover Service", () => {
           fileName,
           collectionName,
           subcollectionName,
+          shouldIgnoreCheck: true,
         }
       )
     })
@@ -244,6 +249,7 @@ describe("Mover Service", () => {
         content: mockContent,
         frontMatter: mockFrontMatter,
         fileName,
+        shouldIgnoreCheck: true,
       })
     })
     it("Moving subcollection page to a collection works correctly", async () => {
@@ -279,6 +285,7 @@ describe("Mover Service", () => {
           frontMatter: mockFrontMatter,
           fileName,
           collectionName,
+          shouldIgnoreCheck: true,
         }
       )
     })
@@ -317,6 +324,7 @@ describe("Mover Service", () => {
           fileName,
           collectionName,
           subcollectionName,
+          shouldIgnoreCheck: true,
         }
       )
     })


### PR DESCRIPTION
This PR fixes an issue when moving files still on the old slugified format (e.g. `page-title.md`). As the move methods make use of the individual create methods of each `PageService`, this causes the movement to fail when the dashes in the slugified file titles were detected. As we have decided not to touch pages on the old formatting, we have implemented a bypass for the file title check, to only be used by the mover service.