### PR TITLE
Fix: remove footer links if empty

### DIFF
--- a/services/configServices/SettingsService.js
+++ b/services/configServices/SettingsService.js
@@ -82,7 +82,7 @@ class SettingsService {
     }
 
     if (!_.isEmpty(updatedFooterContent)) {
-      const mergedFooterContent = this.mergeUpdatedData(
+      const mergedFooterContent = this.mergeUpdatedFooterData(
         footer.content,
         updatedFooterContent
       )
@@ -119,6 +119,29 @@ class SettingsService {
     const clonedCurrentData = _.cloneDeep(currentData)
     Object.keys(updatedData).forEach((field) => {
       clonedCurrentData[field] = updatedData[field]
+    })
+    return clonedCurrentData
+  }
+
+  mergeUpdatedFooterData(currentData, updatedData) {
+    // Special configuration to remove empty footer settings entirely so they don't show up in the actual site
+    const clonedCurrentData = _.cloneDeep(currentData)
+    Object.keys(updatedData).forEach((field) => {
+      if (field === "social_media") {
+        const socials = updatedData[field]
+        Object.keys(socials).forEach((social) => {
+          if (!socials[social]) {
+            delete clonedCurrentData[field][social]
+          } else {
+            clonedCurrentData[field] = updatedData[field]
+          }
+        })
+      } else if (updatedData[field] === "") {
+        // Check for empty string because false value exists
+        delete clonedCurrentData[field]
+      } else {
+        clonedCurrentData[field] = updatedData[field]
+      }
     })
     return clonedCurrentData
   }


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/isomerpages/isomercms-backend/pull/282. In the process of our refactor for the settings flow, we reintroduced a bug in which footer settings which had been deleted (indicated via an empty string for the field sent by the frontend) were being stored as the empty string - this caused an issue with the appearance of icons and links on the footer to empty pages, as our template only checks for the existence of the field before rendering the appropriate icon/link. This PR adds additional checks to remove the appropriate fields in the footer if the user has deleted them.