### PR TITLE
fix: update image for homepage if shareicon changes

### DIFF
--- a/services/configServices/SettingsService.js
+++ b/services/configServices/SettingsService.js
@@ -73,6 +73,8 @@ class SettingsService {
         if (updatedConfigContent.description)
           updatedHomepageFrontMatter.description =
             updatedConfigContent.description
+        if (updatedConfigContent.shareicon)
+          updatedHomepageFrontMatter.image = updatedConfigContent.shareicon
         await this.homepagePageService.update(reqDetails, {
           content: homepage.content.pageBody,
           frontMatter: updatedHomepageFrontMatter,
@@ -109,7 +111,9 @@ class SettingsService {
       (updatedConfigContent.title &&
         configContent.title !== updatedConfigContent.title) ||
       (updatedConfigContent.description &&
-        configContent.description !== updatedConfigContent.description)
+        configContent.description !== updatedConfigContent.description) ||
+      (updatedConfigContent.shareicon &&
+        configContent.shareicon !== updatedConfigContent.shareicon)
     )
       return true
     return false


### PR DESCRIPTION
This PR fixes a bug in which users who changed the shareicon of their site would not have it reflected for the homepage.

Newly created sites start off with a default image used by the homepage which shows up for social media previews - this is stored as the `image` field in the `index.md` files in newly created repos. The repo would draw from this field when determining the image preview for the site, in the absence of a `shareicon` field in the `_config.yml` file. 

In one of our recent PRs, we introduced the ability to modify the `shareicon` of a site, which would override the image specified in the index file for all files which did not themselves specify an image. However, there was no way to modify the image in the original `index.md`, and it would have a higher priority than the general `shareicon` specified for the site for the homepage, so users would never be able to edit the image seen on social media previews for their homepage.

To fix this issue, we now update the image field in the homepage if the `shareicon` has been modified in settings.

As discussed offline, we have decided that this should be a temporary fix until a proper frontend flow has been decided for changing the homepage image, see https://github.com/isomerpages/isomercms-backend/issues/338 for more details.