### PR TITLE
Fix/handle empty directories

### DIFF
--- a/services/directoryServices/MediaDirectoryService.js
+++ b/services/directoryServices/MediaDirectoryService.js
@@ -12,15 +12,11 @@ class MediaDirectoryService {
     this.gitHubService = gitHubService
   }
 
-  async listFiles(reqDetails, { directoryName }) {
-    // TODO: file preview handling
-    const { siteName } = reqDetails
-    if (!isMediaPathValid({ path: directoryName }))
-      throw new BadRequestError("Invalid media folder name")
-    const mediaType = directoryName.split("/")[0]
-    const { private: isPrivate } = await this.gitHubService.getRepoInfo(
-      reqDetails
-    )
+  /**
+   * Lists files in directory. Returns empty array if directory does not exist
+   * - useful for base media directories which do not have placeholder files
+   */
+  async listWithDefault(reqDetails, { directoryName }) {
     let files = []
     try {
       const retrievedFiles = await this.baseDirectoryService.list(reqDetails, {
@@ -31,6 +27,20 @@ class MediaDirectoryService {
       // return an empty list if directory does not exist
       if (error.status !== 404) throw error
     }
+    return files
+  }
+
+  async listFiles(reqDetails, { directoryName }) {
+    // TODO: file preview handling
+    const { siteName } = reqDetails
+    if (!isMediaPathValid({ path: directoryName }))
+      throw new BadRequestError("Invalid media folder name")
+    const mediaType = directoryName.split("/")[0]
+    const { private: isPrivate } = await this.gitHubService.getRepoInfo(
+      reqDetails
+    )
+    const files = await this.listWithDefault(reqDetails, { directoryName })
+    console.log(files)
 
     const resp = []
     for (const curr of files) {

--- a/services/directoryServices/MediaDirectoryService.js
+++ b/services/directoryServices/MediaDirectoryService.js
@@ -21,9 +21,17 @@ class MediaDirectoryService {
     const { private: isPrivate } = await this.gitHubService.getRepoInfo(
       reqDetails
     )
-    const files = await this.baseDirectoryService.list(reqDetails, {
-      directoryName,
-    })
+    let files = []
+    try {
+      const retrievedFiles = await this.baseDirectoryService.list(reqDetails, {
+        directoryName,
+      })
+      files = retrievedFiles
+    } catch (error) {
+      // return an empty list if directory does not exist
+      if (error.status !== 404) throw error
+    }
+
     const resp = []
     for (const curr of files) {
       if (curr.type === "dir") {

--- a/services/directoryServices/MediaDirectoryService.js
+++ b/services/directoryServices/MediaDirectoryService.js
@@ -40,7 +40,6 @@ class MediaDirectoryService {
       reqDetails
     )
     const files = await this.listWithDefault(reqDetails, { directoryName })
-    console.log(files)
 
     const resp = []
     for (const curr of files) {

--- a/services/directoryServices/__tests__/MediaDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/MediaDirectoryService.spec.js
@@ -219,8 +219,7 @@ describe("Media Directory Service", () => {
           objArray: undefined,
         })
       ).resolves.toMatchObject({
-        mediaDirectoryName: imageSubdirectory,
-        mediaType: "images",
+        newDirectoryName: `images/${imageSubdirectory}`,
       })
       expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
         content: "",
@@ -247,8 +246,7 @@ describe("Media Directory Service", () => {
           objArray,
         })
       ).resolves.toMatchObject({
-        mediaDirectoryName: `${fileSubdirectory}/newSubfolder`,
-        mediaType: "files",
+        newDirectoryName,
       })
       expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
         content: "",

--- a/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
+++ b/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
@@ -64,8 +64,8 @@ describe("Media File Service", () => {
           content: mockContent,
         })
       ).resolves.toMatchObject({
-        fileName,
-        content: mockSanitizedContent,
+        name: fileName,
+        content: mockContent,
         sha,
       })
       expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
@@ -217,8 +217,8 @@ describe("Media File Service", () => {
           sha: oldSha,
         })
       ).resolves.toMatchObject({
-        fileName,
-        content: mockSanitizedContent,
+        name: fileName,
+        content: mockContent,
         oldSha,
         newSha: sha,
       })
@@ -300,9 +300,9 @@ describe("Media File Service", () => {
           sha,
         })
       ).resolves.toMatchObject({
-        fileName,
+        name: fileName,
         oldSha: sha,
-        newSha: sha,
+        sha,
       })
       expect(mockGithubService.getTree).toHaveBeenCalledWith(reqDetails, {
         isRecursive: true,

--- a/validators/validators.js
+++ b/validators/validators.js
@@ -2,6 +2,7 @@ const specialCharactersRegexTest = /[~%^*_+\-./\\`;~{}[\]"<>]/
 const dateRegexTest = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/
 
 const mediaSpecialCharactersRegexTest = /[~%^#*+\./\\`;~{}[\]"<>]/ // Allows dashes
+// Allows only media root folders (/images or /files) and media subdirectories (images/subdir) with no banned characters
 const mediaSubfolderRegexText = /^(images|files|(images|files)\/[^#?~%^*+\.\\`;~{}[\]"<>]+)$/
 
 const titleSpecialCharCheck = ({ title, isFile = false }) => {

--- a/validators/validators.js
+++ b/validators/validators.js
@@ -2,7 +2,7 @@ const specialCharactersRegexTest = /[~%^*_+\-./\\`;~{}[\]"<>]/
 const dateRegexTest = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/
 
 const mediaSpecialCharactersRegexTest = /[~%^#*+\./\\`;~{}[\]"<>]/ // Allows dashes
-// Allows only media root folders (/images or /files) and media subdirectories (images/subdir) with no banned characters
+// Allows only media root folders (/images or /files) and media subdirectories (/images/subdir or /files/subdir) with no banned characters
 const mediaSubfolderRegexText = /^(images|files|(images|files)\/[^#?~%^*+\.\\`;~{}[\]"<>]+)$/
 
 const titleSpecialCharCheck = ({ title, isFile = false }) => {

--- a/validators/validators.js
+++ b/validators/validators.js
@@ -2,7 +2,7 @@ const specialCharactersRegexTest = /[~%^*_+\-./\\`;~{}[\]"<>]/
 const dateRegexTest = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/
 
 const mediaSpecialCharactersRegexTest = /[~%^#*+\./\\`;~{}[\]"<>]/ // Allows dashes
-const mediaSubfolderRegexText = /^(images|files|(images|files)\/[^~%^*+\.\\`;~{}[\]"<>]+)$/
+const mediaSubfolderRegexText = /^(images|files|(images|files)\/[^#?~%^*+\.\\`;~{}[\]"<>]+)$/
 
 const titleSpecialCharCheck = ({ title, isFile = false }) => {
   let testTitle = title


### PR DESCRIPTION
This PR fixes a bug involving empty media folders, where we would return a 404 if the directory requested did not exist - this caused an issue for the base media folders (`/images` and `/files`), especially since repos start off with no `/files` directory. We have changed the behaviour on query to return an empty array instead of a 404 error.

This PR also updates the regex to disallow # and ? in media folder names and fixes a few failing tests.