### PR TITLE
Refactor/sites

### DIFF
--- a/fixtures/repoInfo.js
+++ b/fixtures/repoInfo.js
@@ -1,0 +1,66 @@
+const repoInfo = {
+  name: "repo",
+  private: false,
+  description:
+    "Staging: https://repo-staging.netlify.app | Production: https://repo-prod.netlify.app",
+  updated_at: "2021-09-09T02:41:37Z",
+  permissions: {
+    admin: true,
+    maintain: true,
+    push: true,
+    triage: true,
+    pull: true,
+  },
+}
+
+const repoInfo2 = {
+  name: "repo2",
+  private: false,
+  description:
+    "Staging: https://repo2-staging.netlify.app | Production: https://repo2-prod.netlify.app",
+  updated_at: "2021-09-09T02:41:37Z",
+  permissions: {
+    admin: true,
+    maintain: true,
+    push: true,
+    triage: true,
+    pull: true,
+  },
+}
+
+const adminRepo = {
+  name: "isomercms-backend",
+  private: false,
+  description:
+    "Staging: https://isomercms-backend-staging.netlify.app | Production: https://isomercms-backend-prod.netlify.app",
+  updated_at: "2021-09-09T02:41:37Z",
+  permissions: {
+    admin: true,
+    maintain: true,
+    push: true,
+    triage: true,
+    pull: true,
+  },
+}
+
+const noAccessRepo = {
+  name: "noaccess",
+  private: false,
+  description:
+    "Staging: https://noaccess-staging.netlify.app | Production: https://noaccess-prod.netlify.app",
+  updated_at: "2021-09-09T02:41:37Z",
+  permissions: {
+    admin: false,
+    maintain: false,
+    push: false,
+    triage: false,
+    pull: true,
+  },
+}
+
+module.exports = {
+  repoInfo,
+  repoInfo2,
+  adminRepo,
+  noAccessRepo,
+}

--- a/fixtures/repoInfo.js
+++ b/fixtures/repoInfo.js
@@ -3,7 +3,7 @@ const repoInfo = {
   private: false,
   description:
     "Staging: https://repo-staging.netlify.app | Production: https://repo-prod.netlify.app",
-  updated_at: "2021-09-09T02:41:37Z",
+  pushed_at: "2021-09-09T02:41:37Z",
   permissions: {
     admin: true,
     maintain: true,
@@ -18,7 +18,7 @@ const repoInfo2 = {
   private: false,
   description:
     "Staging: https://repo2-staging.netlify.app | Production: https://repo2-prod.netlify.app",
-  updated_at: "2021-09-09T02:41:37Z",
+  pushed_at: "2021-09-09T02:41:37Z",
   permissions: {
     admin: true,
     maintain: true,
@@ -33,7 +33,7 @@ const adminRepo = {
   private: false,
   description:
     "Staging: https://isomercms-backend-staging.netlify.app | Production: https://isomercms-backend-prod.netlify.app",
-  updated_at: "2021-09-09T02:41:37Z",
+  pushed_at: "2021-09-09T02:41:37Z",
   permissions: {
     admin: true,
     maintain: true,
@@ -48,7 +48,7 @@ const noAccessRepo = {
   private: false,
   description:
     "Staging: https://noaccess-staging.netlify.app | Production: https://noaccess-prod.netlify.app",
-  updated_at: "2021-09-09T02:41:37Z",
+  pushed_at: "2021-09-09T02:41:37Z",
   permissions: {
     admin: false,
     maintain: false,

--- a/newroutes/__tests__/Sites.spec.js
+++ b/newroutes/__tests__/Sites.spec.js
@@ -17,7 +17,7 @@ const siteName = "siteName"
 
 const reqDetails = { siteName, accessToken }
 
-describe("Unlinked Pages Router", () => {
+describe("Sites Router", () => {
   const mockSitesService = {
     getSites: jest.fn(),
     checkHasAccess: jest.fn(),
@@ -76,7 +76,7 @@ describe("Unlinked Pages Router", () => {
       })
     })
 
-    it("allows if user has no access to a site", async () => {
+    it("allows if user has access to a site", async () => {
       await request(app).get(`/${siteName}`).expect(200)
 
       expect(mockSitesService.checkHasAccess).toHaveBeenCalledWith(reqDetails, {

--- a/newroutes/__tests__/Sites.spec.js
+++ b/newroutes/__tests__/Sites.spec.js
@@ -1,0 +1,104 @@
+const cookieParser = require("cookie-parser")
+const express = require("express")
+const request = require("supertest")
+
+const { NotFoundError } = require("@errors/NotFoundError")
+
+const { errorHandler } = require("@middleware/errorHandler")
+const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
+
+const { SitesRouter } = require("../sites")
+
+// Can't set request fields - will always be undefined
+const userId = undefined
+const accessToken = undefined
+
+const siteName = "siteName"
+
+const reqDetails = { siteName, accessToken }
+
+describe("Unlinked Pages Router", () => {
+  const mockSitesService = {
+    getSites: jest.fn(),
+    checkHasAccess: jest.fn(),
+    getLastUpdated: jest.fn(),
+    getStagingUrl: jest.fn(),
+  }
+
+  const router = new SitesRouter({
+    sitesService: mockSitesService,
+  })
+
+  const app = express()
+  app.use(express.json({ limit: "7mb" }))
+  app.use(express.urlencoded({ extended: false }))
+  app.use(cookieParser())
+
+  // We can use read route handler here because we don't need to lock the repo
+  app.get("/", attachReadRouteHandlerWrapper(router.getSites))
+  app.get("/:siteName", attachReadRouteHandlerWrapper(router.checkHasAccess))
+  app.get(
+    "/:siteName/lastUpdated",
+    attachReadRouteHandlerWrapper(router.getLastUpdated)
+  )
+  app.get(
+    "/:siteName/stagingUrl",
+    attachReadRouteHandlerWrapper(router.getStagingUrl)
+  )
+  app.use(errorHandler)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("getSites", () => {
+    it("returns the list of sites accessible to the user", async () => {
+      const sitesResp = ["site1", "site2"]
+      mockSitesService.getSites.mockResolvedValueOnce(sitesResp)
+      const resp = await request(app).get(`/`).expect(200)
+      expect(resp.body).toStrictEqual({ siteNames: sitesResp })
+      expect(mockSitesService.getSites).toHaveBeenCalledWith({ accessToken })
+    })
+  })
+
+  describe("checkHasAccess", () => {
+    it("rejects if user has no access to a site", async () => {
+      mockSitesService.checkHasAccess.mockRejectedValueOnce(
+        new NotFoundError("")
+      )
+      await request(app).get(`/${siteName}`).expect(404)
+      expect(mockSitesService.checkHasAccess).toHaveBeenCalledWith(reqDetails, {
+        userId,
+      })
+    })
+
+    it("allows if user has no access to a site", async () => {
+      await request(app).get(`/${siteName}`).expect(200)
+      expect(mockSitesService.checkHasAccess).toHaveBeenCalledWith(reqDetails, {
+        userId,
+      })
+    })
+  })
+
+  describe("getLastUpdated", () => {
+    it("returns the last updated time", async () => {
+      const lastUpdated = "last-updated"
+      mockSitesService.getLastUpdated.mockResolvedValueOnce(lastUpdated)
+      const resp = await request(app)
+        .get(`/${siteName}/lastUpdated`)
+        .expect(200)
+      expect(resp.body).toStrictEqual({ lastUpdated })
+      expect(mockSitesService.getLastUpdated).toHaveBeenCalledWith(reqDetails)
+    })
+  })
+
+  describe("getStagingUrl", () => {
+    it("returns the last updated time", async () => {
+      const stagingUrl = "staging-url"
+      mockSitesService.getStagingUrl.mockResolvedValueOnce(stagingUrl)
+      const resp = await request(app).get(`/${siteName}/stagingUrl`).expect(200)
+      expect(resp.body).toStrictEqual({ stagingUrl })
+      expect(mockSitesService.getStagingUrl).toHaveBeenCalledWith(reqDetails)
+    })
+  })
+})

--- a/newroutes/__tests__/Sites.spec.js
+++ b/newroutes/__tests__/Sites.spec.js
@@ -55,7 +55,9 @@ describe("Unlinked Pages Router", () => {
     it("returns the list of sites accessible to the user", async () => {
       const sitesResp = ["site1", "site2"]
       mockSitesService.getSites.mockResolvedValueOnce(sitesResp)
+
       const resp = await request(app).get(`/`).expect(200)
+
       expect(resp.body).toStrictEqual({ siteNames: sitesResp })
       expect(mockSitesService.getSites).toHaveBeenCalledWith({ accessToken })
     })
@@ -66,7 +68,9 @@ describe("Unlinked Pages Router", () => {
       mockSitesService.checkHasAccess.mockRejectedValueOnce(
         new NotFoundError("")
       )
+
       await request(app).get(`/${siteName}`).expect(404)
+
       expect(mockSitesService.checkHasAccess).toHaveBeenCalledWith(reqDetails, {
         userId,
       })
@@ -74,6 +78,7 @@ describe("Unlinked Pages Router", () => {
 
     it("allows if user has no access to a site", async () => {
       await request(app).get(`/${siteName}`).expect(200)
+
       expect(mockSitesService.checkHasAccess).toHaveBeenCalledWith(reqDetails, {
         userId,
       })
@@ -84,9 +89,11 @@ describe("Unlinked Pages Router", () => {
     it("returns the last updated time", async () => {
       const lastUpdated = "last-updated"
       mockSitesService.getLastUpdated.mockResolvedValueOnce(lastUpdated)
+
       const resp = await request(app)
         .get(`/${siteName}/lastUpdated`)
         .expect(200)
+
       expect(resp.body).toStrictEqual({ lastUpdated })
       expect(mockSitesService.getLastUpdated).toHaveBeenCalledWith(reqDetails)
     })
@@ -96,7 +103,9 @@ describe("Unlinked Pages Router", () => {
     it("returns the last updated time", async () => {
       const stagingUrl = "staging-url"
       mockSitesService.getStagingUrl.mockResolvedValueOnce(stagingUrl)
+
       const resp = await request(app).get(`/${siteName}/stagingUrl`).expect(200)
+
       expect(resp.body).toStrictEqual({ stagingUrl })
       expect(mockSitesService.getStagingUrl).toHaveBeenCalledWith(reqDetails)
     })

--- a/newroutes/sites.js
+++ b/newroutes/sites.js
@@ -31,7 +31,7 @@ class SitesRouter {
       },
       { userId }
     )
-    return res.status(200)
+    return res.status(200).send("OK")
   }
 
   async getLastUpdated(req, res) {

--- a/newroutes/sites.js
+++ b/newroutes/sites.js
@@ -18,8 +18,11 @@ class SitesRouter {
   }
 
   async checkHasAccess(req, res) {
-    const { accessToken, userId } = req
-    const { siteName } = req.params
+    const {
+      accessToken,
+      userId,
+      params: { siteName },
+    } = req
 
     await this.sitesService.checkHasAccess(
       {
@@ -32,8 +35,10 @@ class SitesRouter {
   }
 
   async getLastUpdated(req, res) {
-    const { accessToken } = req
-    const { siteName } = req.params
+    const {
+      accessToken,
+      params: { siteName },
+    } = req
     const lastUpdated = await this.sitesService.getLastUpdated({
       accessToken,
       siteName,
@@ -42,8 +47,10 @@ class SitesRouter {
   }
 
   async getStagingUrl(req, res) {
-    const { accessToken } = req
-    const { siteName } = req.params
+    const {
+      accessToken,
+      params: { siteName },
+    } = req
 
     const stagingUrl = await this.sitesService.getStagingUrl({
       accessToken,

--- a/newroutes/sites.js
+++ b/newroutes/sites.js
@@ -31,7 +31,7 @@ class SitesRouter {
       },
       { userId }
     )
-    return res.status(200).send("OK")
+    return res.status(200)
   }
 
   async getLastUpdated(req, res) {

--- a/newroutes/sites.js
+++ b/newroutes/sites.js
@@ -1,0 +1,73 @@
+const autoBind = require("auto-bind")
+const express = require("express")
+
+// Import middleware
+const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
+
+class SitesRouter {
+  constructor({ sitesService }) {
+    this.sitesService = sitesService
+    // We need to bind all methods because we don't invoke them from the class directly
+    autoBind(this)
+  }
+
+  async getSites(req, res) {
+    const { accessToken } = req
+    const siteNames = await this.sitesService.getSites({ accessToken })
+    return res.status(200).json({ siteNames })
+  }
+
+  async checkHasAccess(req, res) {
+    const { accessToken, userId } = req
+    const { siteName } = req.params
+
+    await this.sitesService.checkHasAccess(
+      {
+        accessToken,
+        siteName,
+      },
+      { userId }
+    )
+    return res.status(200).send("OK")
+  }
+
+  async getLastUpdated(req, res) {
+    const { accessToken } = req
+    const { siteName } = req.params
+    const lastUpdated = await this.sitesService.getLastUpdated({
+      accessToken,
+      siteName,
+    })
+    return res.status(200).json({ lastUpdated })
+  }
+
+  async getStagingUrl(req, res) {
+    const { accessToken } = req
+    const { siteName } = req.params
+
+    const stagingUrl = await this.sitesService.getStagingUrl({
+      accessToken,
+      siteName,
+    })
+    return res.status(200).json({ stagingUrl })
+  }
+
+  getRouter() {
+    const router = express.Router()
+
+    router.get("/", attachReadRouteHandlerWrapper(this.getSites))
+    router.get("/:siteName", attachReadRouteHandlerWrapper(this.checkHasAccess))
+    router.get(
+      "/:siteName/lastUpdated",
+      attachReadRouteHandlerWrapper(this.getLastUpdated)
+    )
+    router.get(
+      "/:siteName/stagingUrl",
+      attachReadRouteHandlerWrapper(this.getStagingUrl)
+    )
+
+    return router
+  }
+}
+
+module.exports = { SitesRouter }

--- a/newroutes/sites.js
+++ b/newroutes/sites.js
@@ -4,6 +4,8 @@ const express = require("express")
 // Import middleware
 const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
 
+const { authMiddleware } = require("@root/newmiddleware/index")
+
 class SitesRouter {
   constructor({ sitesService }) {
     this.sitesService = sitesService
@@ -61,6 +63,8 @@ class SitesRouter {
 
   getRouter() {
     const router = express.Router()
+
+    router.use(authMiddleware.verifyJwt)
 
     router.get("/", attachReadRouteHandlerWrapper(this.getSites))
     router.get("/:siteName", attachReadRouteHandlerWrapper(this.checkHasAccess))

--- a/server.js
+++ b/server.js
@@ -111,7 +111,9 @@ const { ResourceCategoriesRouter } = require("./newroutes/resourceCategories")
 const { ResourcePagesRouter } = require("./newroutes/resourcePages")
 const { ResourceRoomRouter } = require("./newroutes/resourceRoom")
 const { SettingsRouter } = require("./newroutes/settings")
+const { SitesRouter } = require("./newroutes/sites")
 const { UnlinkedPagesRouter } = require("./newroutes/unlinkedPages")
+const { SitesService } = require("./services/utilServices/SitesService")
 
 const authService = new AuthService()
 const gitHubService = new GitHubService({ axiosInstance })
@@ -120,6 +122,7 @@ const homepagePageService = new HomepagePageService({ gitHubService })
 const configYmlService = new ConfigYmlService({ gitHubService })
 const footerYmlService = new FooterYmlService({ gitHubService })
 const navYmlService = new NavYmlService({ gitHubService })
+const sitesService = new SitesService({ gitHubService, configYmlService })
 const collectionPageService = new CollectionPageService({
   gitHubService,
   collectionYmlService,
@@ -175,6 +178,7 @@ const settingsService = new SettingsService({
 })
 
 const authV2Router = new AuthRouter({ authService })
+const sitesV2Router = new SitesRouter({ sitesService })
 const unlinkedPagesRouter = new UnlinkedPagesRouter({
   unlinkedPageService,
   unlinkedPagesDirectoryService,
@@ -242,6 +246,7 @@ app.use("/v1/sites", navigationRouter)
 app.use("/v1/sites", netlifyTomlRouter)
 
 app.use("/v2/auth", authV2Router.getRouter())
+app.use("/v2/sites", sitesV2Router.getRouter())
 app.use("/v2/sites", collectionPagesV2Router.getRouter())
 app.use("/v2/sites", unlinkedPagesRouter.getRouter())
 app.use("/v2/sites", collectionsV2Router.getRouter())

--- a/services/db/GitHubService.js
+++ b/services/db/GitHubService.js
@@ -330,6 +330,24 @@ class GitHubService {
       { headers }
     )
   }
+
+  async checkHasAccess({ accessToken, siteName }, { userId }) {
+    const endpoint = `${siteName}/collaborators/${userId}`
+
+    const headers = {
+      Authorization: `token ${accessToken}`,
+      "Content-Type": "application/json",
+    }
+    try {
+      await this.axiosInstance.get(endpoint, { headers })
+    } catch (err) {
+      const { status } = err.response
+      // If user is unauthorized or site does not exist, show the same NotFoundError
+      if (status === 404 || status === 403)
+        throw new NotFoundError("Site does not exist")
+      throw err
+    }
+  }
 }
 
 module.exports = { GitHubService }

--- a/services/db/__tests__/GitHubService.spec.js
+++ b/services/db/__tests__/GitHubService.spec.js
@@ -649,4 +649,19 @@ describe("Github Service", () => {
       )
     })
   })
+
+  describe("checkHasAccess", () => {
+    const userId = "userId"
+    const refEndpoint = `${siteName}/collaborators/${userId}`
+    const headers = {
+      Authorization: `token ${accessToken}`,
+      "Content-Type": "application/json",
+    }
+    it("Checks whether user has write access to site", async () => {
+      await service.checkHasAccess({ accessToken, siteName }, { userId })
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(refEndpoint, {
+        headers,
+      })
+    })
+  })
 })

--- a/services/utilServices/SitesService.js
+++ b/services/utilServices/SitesService.js
@@ -44,7 +44,7 @@ class SitesService {
     )
 
     const sites = await Bluebird.map(paramsArr, async (params) => {
-      const resp = await axios.get(endpoint, {
+      const { data: respData } = await axios.get(endpoint, {
         params,
         headers: {
           Authorization: `token ${accessToken}`,
@@ -52,7 +52,7 @@ class SitesService {
         },
       })
 
-      return resp.data
+      return respData
         .map((repoData) => {
           const {
             pushed_at: updatedAt,

--- a/services/utilServices/SitesService.js
+++ b/services/utilServices/SitesService.js
@@ -2,6 +2,8 @@ const axios = require("axios")
 const Bluebird = require("bluebird")
 const _ = require("lodash")
 
+const { NotFoundError } = require("@root/errors/NotFoundError")
+
 const GH_MAX_REPO_COUNT = 100
 const ISOMERPAGES_REPO_PAGE_COUNT = process.env.ISOMERPAGES_REPO_PAGE_COUNT || 3
 const ISOMER_GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
@@ -94,18 +96,17 @@ class SitesService {
 
     const { description } = await this.githubService.getRepoInfo(reqDetails)
 
-    let stagingUrl
-
     if (description) {
       // Retrieve the url from the description - repo descriptions have varying formats, so we look for the first link
       const descTokens = description.replace("/;/g", " ").split(" ")
       // Staging urls also contain staging in their url
-      stagingUrl = descTokens.find(
+      const stagingUrl = descTokens.find(
         (token) => token.includes("http") && token.includes("staging")
       )
+      if (stagingUrl) return stagingUrl
     }
 
-    return stagingUrl
+    throw new NotFoundError(`${reqDetails.siteName} has no staging url`)
   }
 }
 

--- a/services/utilServices/SitesService.js
+++ b/services/utilServices/SitesService.js
@@ -29,22 +29,6 @@ class SitesService {
     this.configYmlService = configYmlService
   }
 
-  // timeDiff tells us when a repo was last updated in terms of days (for e.g. 2 days ago,
-  // today)
-  timeDiff(lastUpdated) {
-    const gapInUpdate = new Date().getTime() - new Date(lastUpdated).getTime()
-    const numDaysAgo = Math.floor(gapInUpdate / (1000 * 60 * 60 * 24))
-    // return a message for number of days ago repo was last updated
-    switch (numDaysAgo) {
-      case 0:
-        return "Updated today"
-      case 1:
-        return "Updated 1 day ago"
-      default:
-        return `Updated ${numDaysAgo} days ago`
-    }
-  }
-
   async getSites({ accessToken }) {
     const endpoint = `https://api.github.com/orgs/${ISOMER_GITHUB_ORG_NAME}/repos`
 
@@ -76,7 +60,7 @@ class SitesService {
           } = repoData
 
           return {
-            lastUpdated: this.timeDiff(updatedAt),
+            lastUpdated: updatedAt,
             permissions,
             repoName: name,
             isPrivate,
@@ -100,7 +84,7 @@ class SitesService {
     const { pushed_at: updatedAt } = await this.githubService.getRepoInfo(
       reqDetails
     )
-    return this.timeDiff(updatedAt)
+    return updatedAt
   }
 
   async getStagingUrl(reqDetails) {

--- a/services/utilServices/SitesService.js
+++ b/services/utilServices/SitesService.js
@@ -71,7 +71,7 @@ class SitesService {
       return resp.data
         .map((repoData) => {
           const {
-            updated_at: updatedAt,
+            pushed_at: updatedAt,
             permissions,
             name,
             private: isPrivate,
@@ -100,7 +100,7 @@ class SitesService {
   }
 
   async getLastUpdated(reqDetails) {
-    const { updated_at: updatedAt } = await this.githubService.getRepoInfo(
+    const { pushed_at: updatedAt } = await this.githubService.getRepoInfo(
       reqDetails
     )
     return this.timeDiff(updatedAt)

--- a/services/utilServices/SitesService.js
+++ b/services/utilServices/SitesService.js
@@ -2,7 +2,6 @@ const axios = require("axios")
 const Bluebird = require("bluebird")
 const _ = require("lodash")
 
-// Import error
 const GH_MAX_REPO_COUNT = 100
 const ISOMERPAGES_REPO_PAGE_COUNT = process.env.ISOMERPAGES_REPO_PAGE_COUNT || 3
 const ISOMER_GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
@@ -50,14 +49,13 @@ class SitesService {
     const endpoint = `https://api.github.com/orgs/${ISOMER_GITHUB_ORG_NAME}/repos`
 
     // Simultaneously retrieve all isomerpages repos
-    const paramsArr = []
-    for (let i = 0; i < ISOMERPAGES_REPO_PAGE_COUNT; i += 1) {
-      paramsArr.push({
+    const paramsArr = _.fill(Array(ISOMERPAGES_REPO_PAGE_COUNT), null).map(
+      (_, idx) => ({
         per_page: GH_MAX_REPO_COUNT,
         sort: "full_name",
-        page: i + 1,
+        page: idx + 1,
       })
-    }
+    )
 
     const sites = await Bluebird.map(paramsArr, async (params) => {
       const resp = await axios.get(endpoint, {
@@ -91,8 +89,7 @@ class SitesService {
         )
     })
 
-    const flattenedSites = _.flatten(sites)
-    return flattenedSites
+    return _.flatten(sites)
   }
 
   async checkHasAccess(reqDetails, { userId }) {

--- a/services/utilServices/__tests__/SitesService.spec.js
+++ b/services/utilServices/__tests__/SitesService.spec.js
@@ -1,0 +1,133 @@
+const axios = require("axios")
+
+const { BadRequestError } = require("@errors/BadRequestError")
+
+jest.mock("axios")
+
+const {
+  repoInfo,
+  repoInfo2,
+  adminRepo,
+  noAccessRepo,
+} = require("@fixtures/repoInfo")
+
+describe("Resource Page Service", () => {
+  const siteName = "test-site"
+  const accessToken = "test-token"
+  const userId = "userId"
+  const resourceRoomName = "resource-room"
+  const resourceCategoryName = "category"
+  const directoryName = `${resourceRoomName}/${resourceCategoryName}/_posts`
+  const mockContent = "test"
+  const mockMarkdownContent = "---test---"
+  const mockFrontMatter = {
+    title: "fileTitle",
+    permalink: "file/permalink",
+  }
+  const sha = "12345"
+
+  const reqDetails = { siteName, accessToken }
+
+  const gapInUpdate =
+    new Date().getTime() - new Date(repoInfo.updated_at).getTime()
+  const numDaysAgo = Math.floor(gapInUpdate / (1000 * 60 * 60 * 24))
+
+  const mockGithubService = {
+    checkHasAccess: jest.fn(),
+    getRepoInfo: jest.fn(),
+  }
+
+  const mockConfigYmlService = {
+    read: jest.fn(),
+  }
+
+  const { SitesService } = require("@services/utilServices/SitesService")
+  const service = new SitesService({
+    gitHubService: mockGithubService,
+    configYmlService: mockConfigYmlService,
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("getSites", () => {
+    it("Filters accessible sites correctly", async () => {
+      const expectedResp = [
+        {
+          lastUpdated: `Updated ${numDaysAgo} days ago`,
+          permissions: repoInfo.permissions,
+          repoName: repoInfo.name,
+          isPrivate: repoInfo.private,
+        },
+        {
+          lastUpdated: `Updated ${numDaysAgo} days ago`,
+          permissions: repoInfo2.permissions,
+          repoName: repoInfo2.name,
+          isPrivate: repoInfo2.private,
+        },
+      ]
+      axios.get.mockImplementationOnce(() => ({
+        data: [repoInfo, repoInfo2, adminRepo, noAccessRepo],
+      }))
+      axios.get.mockImplementationOnce(() => ({
+        data: [],
+      }))
+      axios.get.mockImplementationOnce(() => ({
+        data: [],
+      }))
+      await expect(service.getSites({ accessToken })).resolves.toMatchObject(
+        expectedResp
+      )
+      expect(axios.get).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe("checkHasAccess", () => {
+    it("Checks if a user has access to a site", async () => {
+      await expect(
+        service.checkHasAccess(reqDetails, { userId })
+      ).resolves.not.toThrow()
+      expect(mockGithubService.checkHasAccess).toHaveBeenCalledWith(
+        reqDetails,
+        { userId }
+      )
+    })
+  })
+
+  describe("getLastUpdated", () => {
+    it("Checks when site was last updated", async () => {
+      mockGithubService.getRepoInfo.mockResolvedValue(repoInfo)
+      await expect(service.getLastUpdated(reqDetails)).resolves.toEqual(
+        `Updated ${numDaysAgo} days ago`
+      )
+      expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
+    })
+  })
+
+  describe("getStagingUrl", () => {
+    const stagingUrl = "https://repo-staging.netlify.app"
+    it("Retrieves the staging url for a site from config if available", async () => {
+      mockConfigYmlService.read.mockResolvedValue({
+        content: {
+          staging: stagingUrl,
+        },
+      })
+      await expect(service.getStagingUrl(reqDetails)).resolves.toEqual(
+        stagingUrl
+      )
+      expect(mockConfigYmlService.read).toHaveBeenCalledWith(reqDetails)
+    })
+    it("Retrieves the staging url for a site from repo info otherwise", async () => {
+      mockConfigYmlService.read.mockResolvedValue({
+        content: {},
+      })
+      mockGithubService.getRepoInfo.mockResolvedValue(repoInfo)
+      await expect(service.getStagingUrl(reqDetails)).resolves.toEqual(
+        stagingUrl
+      )
+      expect(mockConfigYmlService.read).toHaveBeenCalledWith(reqDetails)
+      expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
+    })
+  })
+})

--- a/services/utilServices/__tests__/SitesService.spec.js
+++ b/services/utilServices/__tests__/SitesService.spec.js
@@ -1,7 +1,5 @@
 const axios = require("axios")
 
-const { BadRequestError } = require("@errors/BadRequestError")
-
 jest.mock("axios")
 
 const {
@@ -15,22 +13,8 @@ describe("Resource Page Service", () => {
   const siteName = "test-site"
   const accessToken = "test-token"
   const userId = "userId"
-  const resourceRoomName = "resource-room"
-  const resourceCategoryName = "category"
-  const directoryName = `${resourceRoomName}/${resourceCategoryName}/_posts`
-  const mockContent = "test"
-  const mockMarkdownContent = "---test---"
-  const mockFrontMatter = {
-    title: "fileTitle",
-    permalink: "file/permalink",
-  }
-  const sha = "12345"
 
   const reqDetails = { siteName, accessToken }
-
-  const gapInUpdate =
-    new Date().getTime() - new Date(repoInfo.updated_at).getTime()
-  const numDaysAgo = Math.floor(gapInUpdate / (1000 * 60 * 60 * 24))
 
   const mockGithubService = {
     checkHasAccess: jest.fn(),
@@ -55,13 +39,13 @@ describe("Resource Page Service", () => {
     it("Filters accessible sites correctly", async () => {
       const expectedResp = [
         {
-          lastUpdated: `Updated ${numDaysAgo} days ago`,
+          lastUpdated: repoInfo.pushed_at,
           permissions: repoInfo.permissions,
           repoName: repoInfo.name,
           isPrivate: repoInfo.private,
         },
         {
-          lastUpdated: `Updated ${numDaysAgo} days ago`,
+          lastUpdated: repoInfo2.pushed_at,
           permissions: repoInfo2.permissions,
           repoName: repoInfo2.name,
           isPrivate: repoInfo2.private,
@@ -99,7 +83,7 @@ describe("Resource Page Service", () => {
     it("Checks when site was last updated", async () => {
       mockGithubService.getRepoInfo.mockResolvedValue(repoInfo)
       await expect(service.getLastUpdated(reqDetails)).resolves.toEqual(
-        `Updated ${numDaysAgo} days ago`
+        repoInfo.pushed_at
       )
       expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
     })

--- a/services/utilServices/__tests__/SitesService.spec.js
+++ b/services/utilServices/__tests__/SitesService.spec.js
@@ -124,7 +124,7 @@ describe("Resource Page Service", () => {
       expect(mockConfigYmlService.read).toHaveBeenCalledWith(reqDetails)
       expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
     })
-    it("Retrieves the staging url for a site from repo info otherwise", async () => {
+    it("throws an error when the staging url for a repo is not found", async () => {
       mockConfigYmlService.read.mockResolvedValue({
         content: {},
       })

--- a/services/utilServices/__tests__/SitesService.spec.js
+++ b/services/utilServices/__tests__/SitesService.spec.js
@@ -98,12 +98,13 @@ describe("Resource Page Service", () => {
 
   describe("getStagingUrl", () => {
     const stagingUrl = "https://repo-staging.netlify.app"
-    it("Retrieves the staging url for a site from config if available", async () => {
+    it("Retrieves the staging url for a site from config if available with higher priority over the description", async () => {
       mockConfigYmlService.read.mockResolvedValue({
         content: {
           staging: stagingUrl,
         },
       })
+      mockGithubService.getRepoInfo.mockResolvedValue(repoInfo2)
 
       await expect(service.getStagingUrl(reqDetails)).resolves.toEqual(
         stagingUrl


### PR DESCRIPTION
## Overview

<!-- What problem are you trying to solve? What issue does this close? -->

This PR introduces the sites flow refactor. It introduces a newly created SitesRouter and SitesService, as well as updating the existing GithubService to have an additional checkHasAccess method.


**Breaking Changes**
- No - this PR is backwards compatible

**Features**:

Sites router
- GET / - retrieve list of all sites
- GET /:siteName - check if user has access
- GET /:siteName/lastUpdated - retrieve date of last update
- GET /:siteName/stagingUrl - retrieve staging url

**Notes**:
The SitesService uses both the existing GithubService as well as calling axios itself - this is due to the existing GithubService being tailored specifically for the sites endpoint. I'm open to discussion of whether to initialise another axios instance inside the GithubService specifically to deal with this endpoint, but I currently set it without as this is the only github endpoint with the `orgs/repo` prefix.