### PR TITLE
Chore/automated release versioning

### DIFF
--- a/README
+++ b/README
@@ -7,3 +7,10 @@ export E2E_TEST_SECRET="blahblahblah" // this should match the value of CYPRESS_
 export E2E_TEST_GH_TOKEN="" // this can be your own personal GH access token, or  the token from our 
 // specialized E2E test user
 ```
+
+### Release
+Run the following on the release branch to tag and push changes automatically:
+```
+npm run release --update=<versionType>
+```
+where versionType corresponds to npm version types. This only works on non-Windows platforms, for Windows, modify the release script to use %npm_config_update% instead of $npm_config_update.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node ./bin/www",
     "dev": "source .env && node ./bin/www",
     "test": "source .env && jest",
+    "release": "npm version $npm_config_update && git push --tags",
     "lint": "npx eslint .",
     "format": "npx prettier --write .",
     "check-format": "npx prettier --check .",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

This PR automates the release flow to automatically run `npm version` and push tags to github.

**New scripts**:

- `release --update=<versionType>` : runs `npm version <versionType> && git push --tags` to automate the release process.
