### PR TITLE
Fix/retrieve last updated time

### DIFF
--- a/routes/sites.js
+++ b/routes/sites.js
@@ -76,7 +76,7 @@ async function getSites(req, res) {
     return resp.data
       .map((repoData) => {
         const {
-          updated_at: updatedAt,
+          pushed_at: updatedAt,
           permissions,
           name,
           private: isPrivate,

--- a/routes/sites.js
+++ b/routes/sites.js
@@ -136,7 +136,7 @@ async function getLastUpdated(req, res) {
       "Content-Type": "application/json",
     },
   })
-  const { updated_at: updatedAt } = resp.data
+  const { pushed_at: updatedAt } = resp.data
   return res.status(200).json({ lastUpdated: timeDiff(updatedAt) })
 }
 


### PR DESCRIPTION
**Bug Fixes**:

This PR fixes a bug in which we were not retrieving the correct last updated time for repos. Previously, we were using the `updated_at` parameter to retrieve the time of last edit for a repo. However, this is actually only updated when the repository object is updated, e.g. when the description of the repository is updated, and not when a new commit is pushed to the repo. Instead, we should use the `pushed_at` parameter.