### PR TITLE
Fix: use originalUrl instead of url

### DIFF
--- a/newmiddleware/auth.js
+++ b/newmiddleware/auth.js
@@ -8,7 +8,7 @@ class AuthMiddleware {
   }
 
   verifyJwt(req, res, next) {
-    const { cookies, url } = req
+    const { cookies, originalUrl: url } = req
     const { accessToken, userId } = this.authMiddlewareService.verifyJwt({
       cookies,
       url,
@@ -19,7 +19,7 @@ class AuthMiddleware {
   }
 
   whoamiAuth(req, res, next) {
-    const { cookies, url } = req
+    const { cookies, originalUrl: url } = req
     const { accessToken, userId } = this.authMiddlewareService.whoamiAuth({
       cookies,
       url,


### PR DESCRIPTION
## Problem

This PR fixes a bug introduced in #328 - due to the injection of middleware directly into each router, when querying the `req.url`, we now only receive the truncated version of the url that the router processes, i.e. `/v1/auth/whoami` in the `/v1/auth` router would now only return `/whoami` instead of `/v1/auth/whoami` as its `req.url`. The solution is to use `req.originalUrl` instead to preserve the original state of the url.
