### PR TITLE
fix: order of ping

### DIFF
--- a/server.js
+++ b/server.js
@@ -257,6 +257,8 @@ app.use("/v2/sites", mediaDirectoryV2Router.getRouter())
 app.use("/v2/sites", resourceRoomV2Router.getRouter())
 app.use("/v2/sites", settingsV2Router.getRouter())
 
+app.use("/v2/ping", (req, res, next) => res.status(200).send("Ok"))
+
 // catch unknown routes
 app.use((req, res, next) => {
   if (!req.route) {
@@ -264,8 +266,6 @@ app.use((req, res, next) => {
   }
   return next()
 })
-
-app.use("/v2/ping", (req, res, next) => res.status(200).send("Ok"))
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => {


### PR DESCRIPTION
## Problem

Our auth refactor made the health check endpoint (`/v2/ping`) inaccessible as it was placed after the unknown route check - this PR fixes the issue by rearranging their order.