### PR TITLE
Fix: rearrange order of file and directory operations

### DIFF
--- a/services/directoryServices/ResourceDirectoryService.js
+++ b/services/directoryServices/ResourceDirectoryService.js
@@ -133,20 +133,21 @@ class ResourceDirectoryService {
     const { frontMatter, pageContent } = retrieveDataFromMarkdown(rawContent)
     frontMatter.title = newDirectoryName
     const newContent = convertDataToMarkdown(frontMatter, pageContent)
-    await this.gitHubService.update(reqDetails, {
-      fileContent: newContent,
-      sha,
-      fileName: INDEX_FILE_NAME,
-      directoryName: oldDirectoryName,
+    const newDirectoryPath = this.getResourceDirectoryPath({
+      resourceRoomName,
+      resourceCategoryName: slugifiedNewResourceCategoryName,
     })
 
     await this.baseDirectoryService.rename(reqDetails, {
       oldDirectoryName,
-      newDirectoryName: this.getResourceDirectoryPath({
-        resourceRoomName,
-        resourceCategoryName: slugifiedNewResourceCategoryName,
-      }),
+      newDirectoryName: newDirectoryPath,
       message: `Renaming resource category ${resourceCategoryName} to ${slugifiedNewResourceCategoryName}`,
+    })
+    await this.gitHubService.update(reqDetails, {
+      fileContent: newContent,
+      sha,
+      fileName: INDEX_FILE_NAME,
+      directoryName: newDirectoryPath,
     })
   }
 

--- a/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
@@ -273,16 +273,16 @@ describe("Resource Directory Service", () => {
         },
         mockContent
       )
-      expect(mockGitHubService.update).toHaveBeenCalledWith(reqDetails, {
-        fileContent: mockMarkdownContent,
-        sha,
-        fileName: INDEX_FILE_NAME,
-        directoryName,
-      })
       expect(mockBaseDirectoryService.rename).toHaveBeenCalledWith(reqDetails, {
         oldDirectoryName: directoryName,
         newDirectoryName: `${resourceRoomName}/${newDirectoryName}`,
         message: `Renaming resource category ${resourceCategoryName} to ${newDirectoryName}`,
+      })
+      expect(mockGitHubService.update).toHaveBeenCalledWith(reqDetails, {
+        fileContent: mockMarkdownContent,
+        sha,
+        fileName: INDEX_FILE_NAME,
+        directoryName: `${resourceRoomName}/${newDirectoryName}`,
       })
     })
     mockGitHubService.read.mockResolvedValueOnce({
@@ -311,16 +311,16 @@ describe("Resource Directory Service", () => {
         },
         mockContent
       )
-      expect(mockGitHubService.update).toHaveBeenCalledWith(reqDetails, {
-        fileContent: mockMarkdownContent,
-        sha,
-        fileName: INDEX_FILE_NAME,
-        directoryName,
-      })
       expect(mockBaseDirectoryService.rename).toHaveBeenCalledWith(reqDetails, {
         oldDirectoryName: directoryName,
         newDirectoryName: `${resourceRoomName}/${slugifiedResourceCategory}`,
         message: `Renaming resource category ${resourceCategoryName} to ${slugifiedResourceCategory}`,
+      })
+      expect(mockGitHubService.update).toHaveBeenCalledWith(reqDetails, {
+        fileContent: mockMarkdownContent,
+        sha,
+        fileName: INDEX_FILE_NAME,
+        directoryName: `${resourceRoomName}/${slugifiedResourceCategory}`,
       })
     })
   })


### PR DESCRIPTION
## Problem
This PR fixes a bug in the resource category renaming - the breadcrumb of renamed resource categories were not being modified correctly due to the `index.html` file not being modified correctly. The reason for this issue was that our directory level operations use a snapshot of the existing state when making operations - this means that any modification to individual files before a directory level operation gets overwritten.

## Solution

 This PR rearranges the order to fix this issue.