### PR TITLE
docs: add instructions to run DB migrations on remote DB

### DIFF
--- a/README
+++ b/README
@@ -14,3 +14,26 @@ Run the following on the release branch to tag and push changes automatically:
 npm run release --isomer_update=<versionType>
 ```
 where versionType corresponds to npm version types. This only works on non-Windows platforms, for Windows, modify the release script to use %npm_config_update% instead of $npm_config_update.
+
+### Running migrations on a remote database in a private subnet of a VPC
+
+The following steps are needed before you can run migrations on a remote database in a private subnet of an AWS VPC. 
+
+First, you will need to ensure that your current device IP address is whitelisted to use the EC2 instance. 
+- Log into the AWS console and navigate to the EC2 Dashboard.
+- Navigate to the Security Groups tab by looking at the Network & Security section in the left pane and clicking on the Security Groups tab.
+- Look for the security group titled `cms-bastion-<ENVIRONMENT>`, where `<ENVIRONMENT>` is either staging or production. Click on the security group and then the Inbound rules tab.
+- If you see your IP address in the Inbound rules whitelist, you are done with this step.
+- If your IP address does not exist in the Inbound rules whitelist, click on the Edit inbound rules button.
+- Click on the Add rule button. Select SSH as the Type, and select My IP as the Source. Give a meaningful description for the security rule, e.g. WeWork City House. Click on Save rules to complete this step.
+
+Next, you need to set up a local port-forwarding service that forwards traffic from a specific local port, e.g. 5433, to the database via the bastion host (remember: the bastion host resides in the public subnet of the VPC and thus can be contactable from your computer).
+- Open a terminal window and run the following command: ```ssh -L 5433:<DB_HOST>:5432 <SSH_USER>@<SSH_HOST> -i <PATH_TO_SSH_HOST_PEM_FILE>```
+- The `DB_HOST`, `SSH_USER`, `SSH_HOST`, and `PEM_FILE` values can be found in the `CMS <ENVIRONMENT> Database` file in the `Isomer - Admin` 1Password vault.
+- The `PEM_FILE` (the actual file) can be found in the `Isomer - Admin` 1Password vault as well. Download the file and save it to your computer. and update the file value for `PATH_TO_SSH_HOST_PEM_FILE`.
+
+Finally, we want to run the migration script.
+- Modify the `DB_URI` in the `.env` file so that Sequelize connects to the local port-forwarding service at port 5433: `postgres://<DB_USER>:<DB_PASS>@127.0.0.1:5433/<DB_NAME>`
+- Open another terminal window.
+- Run `source .env`
+- Run `npx sequelize-cli db:migrate`


### PR DESCRIPTION
This PR adds instructions to run database migrations on a remote RDS database in a private subnet of either the staging or production VPC.