### PR TITLE
chore(app): replace custom properties on req with res.locals

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -117,9 +117,7 @@ const whoamiAuth = (req, res, next) => {
 // Replace access token with site access token if it is available
 const useSiteAccessTokenIfAvailable = async (req, res, next) => {
   const { authService, sitesService } = identityServices
-  const {
-    locals: { userId, accessToken: userAccessToken },
-  } = res
+  const { userId, accessToken: userAccessToken } = res.locals
   const { siteName } = req.params
 
   // Check if site is onboarded to Isomer identity, otherwise continue using user access token

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -58,7 +58,7 @@ const verifyJwt = (req, res, next) => {
   const isValidE2E = verifyE2E(req)
 
   if (isValidE2E) {
-    req.accessToken = E2E_TEST_GH_TOKEN
+    res.locals.accessToken = E2E_TEST_GH_TOKEN
     res.locals.userId = E2E_TEST_USER
   } else {
     try {
@@ -74,7 +74,7 @@ const verifyJwt = (req, res, next) => {
         throw notLoggedInError
       }
 
-      req.accessToken = jwtUtils.decryptToken(retrievedToken)
+      res.locals.accessToken = jwtUtils.decryptToken(retrievedToken)
       res.locals.userId = retrievedId
     } catch (err) {
       logger.error("Authentication error")
@@ -95,7 +95,7 @@ const whoamiAuth = (req, res, next) => {
   const isValidE2E = verifyE2E(req)
 
   if (isValidE2E) {
-    req.accessToken = E2E_TEST_GH_TOKEN
+    res.locals.accessToken = E2E_TEST_GH_TOKEN
     res.locals.userId = E2E_TEST_USER
   } else {
     let retrievedToken
@@ -107,7 +107,7 @@ const whoamiAuth = (req, res, next) => {
     } catch (err) {
       retrievedToken = undefined
     } finally {
-      req.accessToken = retrievedToken
+      res.locals.accessToken = retrievedToken
     }
   }
 
@@ -117,9 +117,8 @@ const whoamiAuth = (req, res, next) => {
 // Replace access token with site access token if it is available
 const useSiteAccessTokenIfAvailable = async (req, res, next) => {
   const { authService, sitesService } = identityServices
-  const { accessToken: userAccessToken } = req
   const {
-    locals: { userId },
+    locals: { userId, accessToken: userAccessToken },
   } = res
   const { siteName } = req.params
 
@@ -140,7 +139,7 @@ const useSiteAccessTokenIfAvailable = async (req, res, next) => {
   const siteAccessToken = await sitesService.getSiteAccessToken(siteName)
 
   if (siteAccessToken) {
-    req.accessToken = siteAccessToken
+    res.locals.accessToken = siteAccessToken
     logger.info(
       `User ${userId} has access to ${siteName}. Using site access token ${site.apiTokenName}.`
     )

--- a/middleware/routeHandler.js
+++ b/middleware/routeHandler.js
@@ -46,8 +46,8 @@ const attachRollbackRouteHandlerWrapper = (routeHandler) => async (
       accessToken
     )
 
-    req.currentCommitSha = currentCommitSha
-    req.treeSha = treeSha
+    res.locals.currentCommitSha = currentCommitSha
+    res.locals.treeSha = treeSha
 
     originalCommitSha = currentCommitSha
   } catch (err) {

--- a/middleware/routeHandler.js
+++ b/middleware/routeHandler.js
@@ -34,7 +34,7 @@ const attachRollbackRouteHandlerWrapper = (routeHandler) => async (
   res,
   next
 ) => {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   await lock(siteName)

--- a/newmiddleware/auth.js
+++ b/newmiddleware/auth.js
@@ -34,9 +34,7 @@ class AuthMiddleware {
     const {
       params: { siteName },
     } = req
-    const {
-      locals: { userId, accessToken: userAccessToken },
-    } = res
+    const { userId, accessToken: userAccessToken } = res.locals
 
     const siteAccessToken = await this.authMiddlewareService.retrieveSiteAccessTokenIfAvailable(
       { siteName, userAccessToken, userId }

--- a/newmiddleware/auth.js
+++ b/newmiddleware/auth.js
@@ -32,11 +32,10 @@ class AuthMiddleware {
   // Replace access token with site access token if it is available
   async useSiteAccessTokenIfAvailable(req, res, next) {
     const {
-      accessToken: userAccessToken,
       params: { siteName },
     } = req
     const {
-      locals: { userId },
+      locals: { userId, accessToken: userAccessToken },
     } = res
 
     const siteAccessToken = await this.authMiddlewareService.retrieveSiteAccessTokenIfAvailable(

--- a/newmiddleware/auth.js
+++ b/newmiddleware/auth.js
@@ -13,7 +13,7 @@ class AuthMiddleware {
       cookies,
       url,
     })
-    req.accessToken = accessToken
+    res.locals.accessToken = accessToken
     res.locals.userId = userId
     return next()
   }
@@ -24,7 +24,7 @@ class AuthMiddleware {
       cookies,
       url,
     })
-    req.accessToken = accessToken
+    res.locals.accessToken = accessToken
     if (userId) res.locals.userId = userId
     return next()
   }
@@ -43,7 +43,7 @@ class AuthMiddleware {
       { siteName, userAccessToken, userId }
     )
 
-    if (siteAccessToken) req.accessToken = siteAccessToken
+    if (siteAccessToken) res.locals.accessToken = siteAccessToken
 
     return next()
   }

--- a/newroutes/auth.js
+++ b/newroutes/auth.js
@@ -78,7 +78,7 @@ class AuthRouter {
   }
 
   async whoami(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const userInfo = await this.authService.getUserInfo({ accessToken })
     if (!userInfo) {

--- a/newroutes/authenticated/sites.js
+++ b/newroutes/authenticated/sites.js
@@ -19,12 +19,9 @@ class SitesRouter {
 
   async checkHasAccess(req, res) {
     const {
-      accessToken,
       params: { siteName },
     } = req
-    const {
-      locals: { userId },
-    } = res
+    const { userId, accessToken } = res.locals
 
     await this.sitesService.checkHasAccess(
       {
@@ -38,9 +35,9 @@ class SitesRouter {
 
   async getLastUpdated(req, res) {
     const {
-      accessToken,
       params: { siteName },
     } = req
+    const { accessToken } = res.locals
     const lastUpdated = await this.sitesService.getLastUpdated({
       accessToken,
       siteName,
@@ -50,9 +47,9 @@ class SitesRouter {
 
   async getStagingUrl(req, res) {
     const {
-      accessToken,
       params: { siteName },
     } = req
+    const { accessToken } = res.locals
 
     const stagingUrl = await this.sitesService.getStagingUrl({
       accessToken,

--- a/newroutes/authenticated/sites.js
+++ b/newroutes/authenticated/sites.js
@@ -12,7 +12,7 @@ class SitesRouter {
   }
 
   async getSites(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
     const siteNames = await this.sitesService.getSites({ accessToken })
     return res.status(200).json({ siteNames })
   }

--- a/newroutes/authenticatedSites/collectionPages.js
+++ b/newroutes/authenticatedSites/collectionPages.js
@@ -25,7 +25,7 @@ class CollectionPagesRouter {
 
   // Create new page in collection
   async createCollectionPage(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, collectionName, subcollectionName } = req.params
     const { error } = CreatePageRequestSchema.validate(req.body)
@@ -58,7 +58,7 @@ class CollectionPagesRouter {
 
   // Read page in collection
   async readCollectionPage(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, pageName, collectionName, subcollectionName } = req.params
 
@@ -81,7 +81,7 @@ class CollectionPagesRouter {
 
   // Update page in collection
   async updateCollectionPage(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, pageName, collectionName, subcollectionName } = req.params
     const { error } = UpdatePageRequestSchema.validate(req.body)
@@ -141,7 +141,7 @@ class CollectionPagesRouter {
 
   // Delete page in collection
   async deleteCollectionPage(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, pageName, collectionName, subcollectionName } = req.params
     const { error } = DeletePageRequestSchema.validate(req.body)

--- a/newroutes/authenticatedSites/collections.js
+++ b/newroutes/authenticatedSites/collections.js
@@ -26,7 +26,7 @@ class CollectionsRouter {
 
   // List all collections
   async listAllCollections(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName } = req.params
     const listResp = await this.collectionDirectoryService.listAllCollections({
@@ -39,7 +39,7 @@ class CollectionsRouter {
 
   // List files in a collection/subcollection
   async listCollectionDirectoryFiles(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, collectionName, subcollectionName } = req.params
     let listResp
@@ -59,7 +59,7 @@ class CollectionsRouter {
 
   // Create new collection/subcollection
   async createCollectionDirectory(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, collectionName } = req.params
     const { error } = CreateDirectoryRequestSchema.validate(req.body)
@@ -92,7 +92,7 @@ class CollectionsRouter {
 
   // Rename collection/subcollection
   async renameCollectionDirectory(req, res) {
-    const { accessToken, currentCommitSha, treeSha } = req
+    const { accessToken, currentCommitSha, treeSha } = res.locals
 
     const { siteName, collectionName, subcollectionName } = req.params
     const { error } = RenameDirectoryRequestSchema.validate(req.body)
@@ -122,7 +122,7 @@ class CollectionsRouter {
 
   // Delete collection/subcollection
   async deleteCollectionDirectory(req, res) {
-    const { accessToken, currentCommitSha, treeSha } = req
+    const { accessToken, currentCommitSha, treeSha } = res.locals
 
     const { siteName, collectionName, subcollectionName } = req.params
     if (subcollectionName) {
@@ -146,7 +146,7 @@ class CollectionsRouter {
 
   // Reorder collection/subcollection
   async reorderCollectionDirectory(req, res) {
-    const { accessToken, currentCommitSha, treeSha } = req
+    const { accessToken, currentCommitSha, treeSha } = res.locals
 
     const { siteName, collectionName, subcollectionName } = req.params
     const { error } = ReorderDirectoryRequestSchema.validate(req.body)
@@ -176,7 +176,7 @@ class CollectionsRouter {
 
   // Move collection/subcollection pages
   async moveCollectionDirectoryPages(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, collectionName, subcollectionName } = req.params
     const { error } = MoveDirectoryPagesRequestSchema.validate(req.body)

--- a/newroutes/authenticatedSites/mediaCategories.js
+++ b/newroutes/authenticatedSites/mediaCategories.js
@@ -24,7 +24,7 @@ class MediaCategoriesRouter {
 
   // List files in a resource category
   async listMediaDirectoryFiles(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, directoryName } = req.params
     const listResp = await this.mediaDirectoryService.listFiles(
@@ -36,7 +36,7 @@ class MediaCategoriesRouter {
 
   // Create new media directory
   async createMediaDirectory(req, res) {
-    const { accessToken, currentCommitSha, treeSha } = req
+    const { accessToken, currentCommitSha, treeSha } = res.locals
 
     const { siteName } = req.params
     const { error } = CreateMediaDirectoryRequestSchema.validate(req.body)
@@ -55,7 +55,7 @@ class MediaCategoriesRouter {
 
   // Rename resource category
   async renameMediaDirectory(req, res) {
-    const { accessToken, currentCommitSha, treeSha } = req
+    const { accessToken, currentCommitSha, treeSha } = res.locals
 
     const { siteName, directoryName } = req.params
     const { error } = RenameMediaDirectoryRequestSchema.validate(req.body)
@@ -74,7 +74,7 @@ class MediaCategoriesRouter {
 
   // Delete resource category
   async deleteMediaDirectory(req, res) {
-    const { accessToken, currentCommitSha, treeSha } = req
+    const { accessToken, currentCommitSha, treeSha } = res.locals
 
     const { siteName, directoryName } = req.params
     await this.mediaDirectoryService.deleteMediaDirectory(
@@ -88,7 +88,7 @@ class MediaCategoriesRouter {
 
   // Move resource category
   async moveMediaFiles(req, res) {
-    const { accessToken, currentCommitSha, treeSha } = req
+    const { accessToken, currentCommitSha, treeSha } = res.locals
 
     const { siteName, directoryName } = req.params
     const { error } = MoveMediaDirectoryFilesRequestSchema.validate(req.body)

--- a/newroutes/authenticatedSites/mediaFiles.js
+++ b/newroutes/authenticatedSites/mediaFiles.js
@@ -24,7 +24,7 @@ class MediaFilesRouter {
 
   // Create new page in collection
   async createMediaFile(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, directoryName } = req.params
     const { error } = CreateMediaFileRequestSchema.validate(req.body)
@@ -42,7 +42,7 @@ class MediaFilesRouter {
 
   // Read page in collection
   async readMediaFile(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, fileName, directoryName } = req.params
 
@@ -56,7 +56,7 @@ class MediaFilesRouter {
 
   // Update page in collection
   async updateMediaFile(req, res) {
-    const { accessToken, currentCommitSha, treeSha } = req
+    const { accessToken, currentCommitSha, treeSha } = res.locals
 
     const { siteName, fileName, directoryName } = req.params
     const { error } = UpdateMediaFileRequestSchema.validate(req.body)
@@ -85,7 +85,7 @@ class MediaFilesRouter {
 
   // Delete page in collection
   async deleteMediaFile(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, fileName, directoryName } = req.params
     const { error } = DeleteMediaFileRequestSchema.validate(req.body)

--- a/newroutes/authenticatedSites/resourceCategories.js
+++ b/newroutes/authenticatedSites/resourceCategories.js
@@ -24,7 +24,7 @@ class ResourceCategoriesRouter {
 
   // List files in a resource category
   async listResourceDirectoryFiles(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, resourceRoomName, resourceCategoryName } = req.params
     const listResp = await this.resourceDirectoryService.listFiles(
@@ -36,7 +36,7 @@ class ResourceCategoriesRouter {
 
   // Create new resource category
   async createResourceDirectory(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, resourceRoomName } = req.params
     const { error } = CreateResourceDirectoryRequestSchema.validate(req.body)
@@ -55,7 +55,7 @@ class ResourceCategoriesRouter {
 
   // Rename resource category
   async renameResourceDirectory(req, res) {
-    const { accessToken, currentCommitSha, treeSha } = req
+    const { accessToken, currentCommitSha, treeSha } = res.locals
 
     const { siteName, resourceRoomName, resourceCategoryName } = req.params
     const { error } = RenameResourceDirectoryRequestSchema.validate(req.body)
@@ -75,7 +75,7 @@ class ResourceCategoriesRouter {
 
   // Delete resource category
   async deleteResourceDirectory(req, res) {
-    const { accessToken, currentCommitSha, treeSha } = req
+    const { accessToken, currentCommitSha, treeSha } = res.locals
 
     const { siteName, resourceRoomName, resourceCategoryName } = req.params
     await this.resourceDirectoryService.deleteResourceDirectory(
@@ -90,7 +90,7 @@ class ResourceCategoriesRouter {
 
   // Move resource category
   async moveResourceDirectoryPages(req, res) {
-    const { accessToken, currentCommitSha, treeSha } = req
+    const { accessToken, currentCommitSha, treeSha } = res.locals
 
     const { siteName, resourceRoomName, resourceCategoryName } = req.params
     const { error } = MoveResourceDirectoryPagesRequestSchema.validate(req.body)

--- a/newroutes/authenticatedSites/resourcePages.js
+++ b/newroutes/authenticatedSites/resourcePages.js
@@ -25,7 +25,7 @@ class ResourcePagesRouter {
 
   // Create new page in resource category
   async createResourcePage(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, resourceRoomName, resourceCategoryName } = req.params
     const { error } = CreateResourcePageRequestSchema.validate(req.body)
@@ -48,7 +48,7 @@ class ResourcePagesRouter {
 
   // Read page in resource category
   async readResourcePage(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const {
       siteName,
@@ -69,7 +69,7 @@ class ResourcePagesRouter {
 
   // Update page in resource category
   async updateResourcePage(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const {
       siteName,
@@ -111,7 +111,7 @@ class ResourcePagesRouter {
 
   // Delete page in resource category
   async deleteResourcePage(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const {
       siteName,

--- a/newroutes/authenticatedSites/resourceRoom.js
+++ b/newroutes/authenticatedSites/resourceRoom.js
@@ -23,7 +23,7 @@ class ResourceRoomRouter {
 
   // Get resource room name
   async getResourceRoomDirectoryName(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName } = req.params
     const getResp = await this.resourceRoomDirectoryService.getResourceRoomDirectoryName(
@@ -35,7 +35,7 @@ class ResourceRoomRouter {
 
   // List all resource categories
   async listAllResourceCategories(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, resourceRoomName } = req.params
     const listResp = await this.resourceRoomDirectoryService.listAllResourceCategories(
@@ -53,7 +53,7 @@ class ResourceRoomRouter {
 
   // Create new resource room
   async createResourceRoomDirectory(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName } = req.params
     const { error } = CreateResourceDirectoryRequestSchema.validate(req.body)
@@ -71,7 +71,7 @@ class ResourceRoomRouter {
 
   // Rename resource room
   async renameResourceRoomDirectory(req, res) {
-    const { accessToken, currentCommitSha, treeSha } = req
+    const { accessToken, currentCommitSha, treeSha } = res.locals
 
     const { siteName, resourceRoomName } = req.params
     const { error } = RenameResourceDirectoryRequestSchema.validate(req.body)
@@ -90,7 +90,7 @@ class ResourceRoomRouter {
 
   // Delete resource room
   async deleteResourceRoomDirectory(req, res) {
-    const { accessToken, currentCommitSha, treeSha } = req
+    const { accessToken, currentCommitSha, treeSha } = res.locals
 
     const { siteName, resourceRoomName } = req.params
     await this.resourceRoomDirectoryService.deleteResourceRoomDirectory(

--- a/newroutes/authenticatedSites/settings.js
+++ b/newroutes/authenticatedSites/settings.js
@@ -22,7 +22,7 @@ class SettingsRouter {
   }
 
   async readSettingsPage(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
     const { siteName } = req.params
     const reqDetails = { siteName, accessToken }
 
@@ -40,7 +40,8 @@ class SettingsRouter {
   }
 
   async updateSettingsPage(req, res) {
-    const { accessToken, body } = req
+    const { body } = req
+    const { accessToken } = res.locals
     const { siteName } = req.params
 
     const { error } = UpdateSettingsRequestSchema.validate(req.body)

--- a/newroutes/authenticatedSites/unlinkedPages.js
+++ b/newroutes/authenticatedSites/unlinkedPages.js
@@ -25,7 +25,7 @@ class UnlinkedPagesRouter {
   }
 
   async listAllUnlinkedPages(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName } = req.params
     const listResp = await this.unlinkedPagesDirectoryService.listAllUnlinkedPages(
@@ -36,7 +36,7 @@ class UnlinkedPagesRouter {
   }
 
   async createUnlinkedPage(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName } = req.params
     const { error } = CreatePageRequestSchema.validate(req.body)
@@ -58,7 +58,7 @@ class UnlinkedPagesRouter {
   }
 
   async readUnlinkedPage(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, pageName } = req.params
     const { sha, content } = await this.unlinkedPageService.read(
@@ -70,7 +70,7 @@ class UnlinkedPagesRouter {
   }
 
   async updateUnlinkedPage(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, pageName } = req.params
     const { error } = UpdatePageRequestSchema.validate(req.body)
@@ -109,7 +109,7 @@ class UnlinkedPagesRouter {
   }
 
   async deleteUnlinkedPage(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName, pageName } = req.params
     const { error } = DeletePageRequestSchema.validate(req.body)
@@ -127,7 +127,7 @@ class UnlinkedPagesRouter {
   }
 
   async moveUnlinkedPages(req, res) {
-    const { accessToken } = req
+    const { accessToken } = res.locals
 
     const { siteName } = req.params
     const { error } = MoveDirectoryPagesRequestSchema.validate(req.body)

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -141,7 +141,7 @@ async function logout(req, res) {
 }
 
 async function whoami(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   // Make a call to github
   const endpoint = "https://api.github.com/user"

--- a/routes/authenticated/sites.js
+++ b/routes/authenticated/sites.js
@@ -104,9 +104,7 @@ async function getSites(req, res) {
 /* Checks if a user has access to a repo. */
 async function checkHasAccess(req, res) {
   const { accessToken } = res.locals
-  const {
-    locals: { userId },
-  } = res
+  const { userId } = res.locals
   const { siteName } = req.params
   const endpoint = `https://api.github.com/repos/${ISOMER_GITHUB_ORG_NAME}/${siteName}/collaborators/${userId}`
 

--- a/routes/authenticated/sites.js
+++ b/routes/authenticated/sites.js
@@ -50,7 +50,7 @@ const timeDiff = (lastUpdated) => {
 /* Returns a list of all sites (repos) that the user has access to on Isomer. */
 // TO-DO: Paginate properly
 async function getSites(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const endpoint = `https://api.github.com/orgs/${ISOMER_GITHUB_ORG_NAME}/repos`
 
@@ -103,7 +103,7 @@ async function getSites(req, res) {
 
 /* Checks if a user has access to a repo. */
 async function checkHasAccess(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const {
     locals: { userId },
   } = res
@@ -129,7 +129,7 @@ async function checkHasAccess(req, res) {
 
 /* Gets the last updated time of the repo. */
 async function getLastUpdated(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   const endpoint = `https://api.github.com/repos/${ISOMER_GITHUB_ORG_NAME}/${siteName}`
@@ -146,7 +146,7 @@ async function getLastUpdated(req, res) {
 /* Gets the link to the staging site for a repo. */
 async function getStagingUrl(req, res) {
   // TODO: reconsider how we can retrieve url - we can store this in _config.yml or a dynamodb
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   const endpoint = `https://api.github.com/repos/${ISOMER_GITHUB_ORG_NAME}/${siteName}`

--- a/routes/authenticatedSites/collectionPages.js
+++ b/routes/authenticatedSites/collectionPages.js
@@ -25,7 +25,7 @@ const router = express.Router({ mergeParams: true })
 
 // List pages in collection
 async function listCollectionPages(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName, collectionName } = req.params
 
   // TO-DO: Verify that collection exists
@@ -40,7 +40,7 @@ async function listCollectionPages(req, res) {
 
 // Get details on all pages in a collection
 async function listCollectionPagesDetails(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName, collectionName } = req.params
 
   // Verify that collection exists
@@ -115,7 +115,7 @@ async function listCollectionPagesDetails(req, res) {
 
 // // Create new page in collection
 async function createCollectionPage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, collectionName, pageName: encodedPageName } = req.params
   const { content: pageContent } = req.body
@@ -134,7 +134,7 @@ async function createCollectionPage(req, res) {
 
 // Read page in collection
 async function readCollectionPage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, pageName: encodedPageName, collectionName } = req.params
   const pageName = decodeURIComponent(encodedPageName)
@@ -153,7 +153,7 @@ async function readCollectionPage(req, res) {
 
 // Update page in collection
 async function updateCollectionPage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, pageName: encodedPageName, collectionName } = req.params
   const { content: pageContent, sha } = req.body
@@ -178,7 +178,7 @@ async function updateCollectionPage(req, res) {
 
 // Delete page in collection
 async function deleteCollectionPage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, pageName: encodedPageName, collectionName } = req.params
   const { sha } = req.body
@@ -203,7 +203,7 @@ async function deleteCollectionPage(req, res) {
 
 // Rename page in collection
 async function renameCollectionPage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const {
     siteName,

--- a/routes/authenticatedSites/collections.js
+++ b/routes/authenticatedSites/collections.js
@@ -19,7 +19,7 @@ const router = express.Router({ mergeParams: true })
 
 // List collections
 async function listCollections(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   const IsomerCollection = new Collection(accessToken, siteName)
@@ -30,7 +30,7 @@ async function listCollections(req, res) {
 
 // Create new collection
 async function createNewCollection(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
   const { collectionName } = req.body
 
@@ -45,7 +45,7 @@ async function deleteCollection(req, res) {
   // TO-DO: Verify that collection exists
 
   // Remove collection from config file
-  const { accessToken, currentCommitSha, treeSha } = req
+  const { accessToken, currentCommitSha, treeSha } = res.locals
   const { siteName, collectionName } = req.params
 
   const IsomerCollection = new Collection(accessToken, siteName)
@@ -59,7 +59,7 @@ async function renameCollection(req, res) {
   // TO-DO: Verify that collection exists
 
   // Remove collection from config file
-  const { accessToken, currentCommitSha, treeSha } = req
+  const { accessToken, currentCommitSha, treeSha } = res.locals
   const { siteName, collectionName, newCollectionName } = req.params
 
   const IsomerCollection = new Collection(accessToken, siteName)
@@ -75,7 +75,7 @@ async function renameCollection(req, res) {
 
 // Move files in collection
 async function moveFiles(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName, collectionPath, targetPath } = req.params
   const { files } = req.body
   const processedCollectionPathTokens = decodeURIComponent(

--- a/routes/authenticatedSites/directory.js
+++ b/routes/authenticatedSites/directory.js
@@ -9,7 +9,7 @@ const { Directory, FolderType } = require("@classes/Directory.js")
 
 // List pages and directories in folder
 async function listDirectoryContent(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName, path } = req.params
 
   const decodedPath = decodeURIComponent(path)

--- a/routes/authenticatedSites/documents.js
+++ b/routes/authenticatedSites/documents.js
@@ -35,7 +35,7 @@ const extractDirectoryAndFileName = (documentName) => {
 
 // List documents
 async function listDocuments(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   const IsomerFile = new File(accessToken, siteName)
@@ -48,7 +48,7 @@ async function listDocuments(req, res) {
 
 // Create new document
 async function createNewDocument(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName } = req.params
   const { documentName, documentDirectory, content } = req.body
@@ -65,7 +65,7 @@ async function createNewDocument(req, res) {
 
 // Read document
 async function readDocument(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName, documentName } = req.params
 
   // get document directory
@@ -85,7 +85,7 @@ async function readDocument(req, res) {
 
 // Update document
 async function updateDocument(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, documentName } = req.params
   const { content, sha } = req.body
@@ -103,7 +103,7 @@ async function updateDocument(req, res) {
 
 // Delete document
 async function deleteDocument(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, documentName } = req.params
   const { sha } = req.body
@@ -118,7 +118,7 @@ async function deleteDocument(req, res) {
 
 // Rename document
 async function renameDocument(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, documentName, newDocumentName } = req.params
 
@@ -148,7 +148,7 @@ async function renameDocument(req, res) {
 
 // Move document
 async function moveDocument(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, documentName, newDocumentName } = req.params
 

--- a/routes/authenticatedSites/folders.js
+++ b/routes/authenticatedSites/folders.js
@@ -22,7 +22,7 @@ const router = express.Router({ mergeParams: true })
 
 // List pages and directories from all folders
 async function listAllFolderContent(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   const IsomerCollection = new Collection(accessToken, siteName)
@@ -41,7 +41,7 @@ async function listAllFolderContent(req, res) {
 
 // Delete subfolder
 async function deleteSubfolder(req, res) {
-  const { accessToken, currentCommitSha, treeSha } = req
+  const { accessToken, currentCommitSha, treeSha } = res.locals
   const { siteName, folderName, subfolderName } = req.params
 
   // Delete subfolder
@@ -80,7 +80,7 @@ async function deleteSubfolder(req, res) {
 
 // Rename subfolder
 async function renameSubfolder(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName, folderName, subfolderName, newSubfolderName } = req.params
 
   // Rename subfolder by:

--- a/routes/authenticatedSites/homepage.js
+++ b/routes/authenticatedSites/homepage.js
@@ -16,7 +16,7 @@ const HOMEPAGE_INDEX_PATH = "index.md" // Empty string
 
 // Read homepage index file
 async function readHomepage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName } = req.params
 
@@ -36,7 +36,7 @@ async function readHomepage(req, res) {
 
 // Update homepage index file
 async function updateHomepage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName } = req.params
   const { content, sha } = req.body

--- a/routes/authenticatedSites/images.js
+++ b/routes/authenticatedSites/images.js
@@ -36,7 +36,7 @@ const extractDirectoryAndFileName = (imageName) => {
 
 // List images
 async function listImages(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   const IsomerFile = new File(accessToken, siteName)
@@ -49,7 +49,7 @@ async function listImages(req, res) {
 
 // Create new image
 async function createNewImage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName } = req.params
   const { imageName, imageDirectory, content } = req.body
@@ -66,7 +66,7 @@ async function createNewImage(req, res) {
 
 // Read image
 async function readImage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, imageName } = req.params
 
@@ -88,7 +88,7 @@ async function readImage(req, res) {
 
 // Update image
 async function updateImage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, imageName } = req.params
   const { content, sha } = req.body
@@ -106,7 +106,7 @@ async function updateImage(req, res) {
 
 // Delete image
 async function deleteImage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, imageName } = req.params
   const { sha } = req.body
@@ -121,7 +121,7 @@ async function deleteImage(req, res) {
 
 // Rename image
 async function renameImage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, imageName, newImageName } = req.params
 
@@ -150,7 +150,7 @@ async function renameImage(req, res) {
 
 // Move image
 async function moveImage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, imageName, newImageName } = req.params
 

--- a/routes/authenticatedSites/mediaSubfolder.js
+++ b/routes/authenticatedSites/mediaSubfolder.js
@@ -13,7 +13,7 @@ const { MediaSubfolder } = require("@classes/MediaSubfolder")
 
 // Create new collection
 async function createSubfolder(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName, mediaType, folderPath } = req.params
 
   const processedFolderPath = decodeURIComponent(folderPath)
@@ -30,7 +30,7 @@ async function createSubfolder(req, res) {
 
 // Delete collection
 async function deleteSubfolder(req, res) {
-  const { accessToken, currentCommitSha, treeSha } = req
+  const { accessToken, currentCommitSha, treeSha } = res.locals
   const { siteName, mediaType, folderPath } = req.params
 
   const processedFolderPath = decodeURIComponent(folderPath)
@@ -51,7 +51,7 @@ async function deleteSubfolder(req, res) {
 
 // Rename collection
 async function renameSubfolder(req, res) {
-  const { accessToken, currentCommitSha, treeSha } = req
+  const { accessToken, currentCommitSha, treeSha } = res.locals
   const { siteName, mediaType, oldFolderPath, newFolderPath } = req.params
 
   const processedOldFolderPath = decodeURIComponent(oldFolderPath)

--- a/routes/authenticatedSites/navigation.js
+++ b/routes/authenticatedSites/navigation.js
@@ -15,7 +15,7 @@ const { File, DataType } = require("@classes/File.js")
 const NAVIGATION_PATH = "navigation.yml"
 
 async function getNavigation(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName } = req.params
 
@@ -31,7 +31,7 @@ async function getNavigation(req, res) {
 }
 
 async function updateNavigation(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   const { content, sha } = req.body

--- a/routes/authenticatedSites/netlifyToml.js
+++ b/routes/authenticatedSites/netlifyToml.js
@@ -11,7 +11,7 @@ const router = express.Router({ mergeParams: true })
 
 // List resources
 async function getNetlifyToml(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   const netlifyTomlFile = new NetlifyToml(accessToken, siteName)

--- a/routes/authenticatedSites/pages.js
+++ b/routes/authenticatedSites/pages.js
@@ -19,7 +19,7 @@ const { deslugifyCollectionName } = require("@utils/utils")
 const router = express.Router({ mergeParams: true })
 
 async function listPages(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   const IsomerFile = new File(accessToken, siteName)
@@ -31,7 +31,7 @@ async function listPages(req, res) {
 }
 
 async function createPage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, pageName: encodedPageName } = req.params
   const { content: pageContent } = req.body
@@ -47,7 +47,7 @@ async function createPage(req, res) {
 
 // Read page
 async function readPage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, pageName: encodedPageName } = req.params
   const pageName = decodeURIComponent(encodedPageName)
@@ -67,7 +67,7 @@ async function readPage(req, res) {
 
 // Update page
 async function updatePage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, pageName: encodedPageName } = req.params
   const { content: pageContent, sha } = req.body
@@ -90,7 +90,7 @@ async function updatePage(req, res) {
 
 // Delete page
 async function deletePage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, pageName: encodedPageName } = req.params
   const { sha } = req.body
@@ -106,7 +106,7 @@ async function deletePage(req, res) {
 
 // Rename page
 async function renamePage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const {
     siteName,
@@ -136,7 +136,7 @@ async function renamePage(req, res) {
 
 // Move unlinked pages
 async function moveUnlinkedPages(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName, newPagePath } = req.params
   const { files } = req.body
   const processedTargetPathTokens = decodeURIComponent(newPagePath).split("/")

--- a/routes/authenticatedSites/resourcePages.js
+++ b/routes/authenticatedSites/resourcePages.js
@@ -18,7 +18,7 @@ const { ResourceRoom } = require("@classes/ResourceRoom.js")
 
 // List pages in resource
 async function listResourcePages(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName, resourceName } = req.params
 
   const ResourceRoomInstance = new ResourceRoom(accessToken, siteName)
@@ -45,7 +45,7 @@ async function listResourcePages(req, res) {
 
 // Create new page in resource
 async function createNewResourcePage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, resourceName, pageName } = req.params
   const { content: pageContent } = req.body
@@ -74,7 +74,7 @@ async function createNewResourcePage(req, res) {
 
 // Read page in resource
 async function readResourcePage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, pageName, resourceName } = req.params
 
@@ -96,7 +96,7 @@ async function readResourcePage(req, res) {
 
 // Update page in resource
 async function updateResourcePage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, pageName, resourceName } = req.params
   const { content: pageContent, sha } = req.body
@@ -122,7 +122,7 @@ async function updateResourcePage(req, res) {
 
 // Delete page in resource
 async function deleteResourcePage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, pageName, resourceName } = req.params
   const { sha } = req.body
@@ -139,7 +139,7 @@ async function deleteResourcePage(req, res) {
 
 // Rename page in resource
 async function renameResourcePage(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
 
   const { siteName, pageName, resourceName, newPageName } = req.params
   const { sha, content: pageContent } = req.body

--- a/routes/authenticatedSites/resourceRoom.js
+++ b/routes/authenticatedSites/resourceRoom.js
@@ -12,7 +12,7 @@ const { ResourceRoom } = require("@classes/ResourceRoom.js")
 
 // Get resource room name
 async function getResourceRoomName(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   const IsomerResourceRoom = new ResourceRoom(accessToken, siteName)
@@ -23,7 +23,7 @@ async function getResourceRoomName(req, res) {
 
 // Create resource room
 async function createResourceRoom(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
   const { resourceRoom } = req.body
 
@@ -38,7 +38,7 @@ async function createResourceRoom(req, res) {
 
 // Rename resource room name
 async function renameResourceRoom(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName, resourceRoom } = req.params
 
   // TO-DO:
@@ -52,7 +52,7 @@ async function renameResourceRoom(req, res) {
 
 // Delete resource room
 async function deleteResourceRoom(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   const IsomerResourceRoom = new ResourceRoom(accessToken, siteName)

--- a/routes/authenticatedSites/resources.js
+++ b/routes/authenticatedSites/resources.js
@@ -19,7 +19,7 @@ const { ResourceRoom } = require("@classes/ResourceRoom")
 
 // List resources
 async function listResources(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   const IsomerResourceRoom = new ResourceRoom(accessToken, siteName)
@@ -33,7 +33,7 @@ async function listResources(req, res) {
 
 // Create new resource
 async function createNewResource(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
   const { resourceName } = req.body
 
@@ -48,7 +48,7 @@ async function createNewResource(req, res) {
 
 // Delete resource
 async function deleteResource(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName, resourceName } = req.params
 
   const IsomerResourceRoom = new ResourceRoom(accessToken, siteName)
@@ -62,7 +62,7 @@ async function deleteResource(req, res) {
 
 // Rename resource
 async function renameResource(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName, resourceName, newResourceName } = req.params
 
   const IsomerResourceRoom = new ResourceRoom(accessToken, siteName)
@@ -78,7 +78,7 @@ async function renameResource(req, res) {
 /* eslint-disable no-await-in-loop, no-restricted-syntax */
 // Move resource
 async function moveResources(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName, resourceName, newResourceName } = req.params
   const { files } = req.body
 

--- a/routes/authenticatedSites/settings.js
+++ b/routes/authenticatedSites/settings.js
@@ -12,7 +12,7 @@ const {
 const { Settings } = require("@classes/Settings.js")
 
 async function getSettings(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   const settingsFile = new Settings(accessToken, siteName)
@@ -21,7 +21,7 @@ async function getSettings(req, res) {
 }
 
 async function updateSettings(req, res) {
-  const { accessToken } = req
+  const { accessToken } = res.locals
   const { siteName } = req.params
 
   const settings = new Settings(accessToken, siteName)

--- a/services/identity/__tests__/AuthService.spec.ts
+++ b/services/identity/__tests__/AuthService.spec.ts
@@ -63,7 +63,7 @@ describe("Auth Service", () => {
   it("should call axios successfully and bubble the error when the status is not 403 or 404", async () => {
     // Arrange
     const expected = {
-      response: { status: 400 },
+      response: { status: "400" },
     }
     mockGitHubService.checkHasAccess.mockRejectedValueOnce(
       new BadRequestError(expected)
@@ -77,7 +77,7 @@ describe("Auth Service", () => {
     )
 
     // Assert
-    expect(actual).rejects.toThrowError(new BadRequestError(expected))
+    await expect(actual).rejects.toThrow(BadRequestError)
     expect(mockGitHubService.checkHasAccess).toHaveBeenCalledWith(
       mockReqDetails,
       mockParams

--- a/services/utilServices/AuthService.js
+++ b/services/utilServices/AuthService.js
@@ -89,9 +89,7 @@ class AuthService {
     return token
   }
 
-  async getUserInfo(reqDetails) {
-    const { accessToken } = reqDetails
-
+  async getUserInfo({ accessToken }) {
     // Make a call to github
     const endpoint = "https://api.github.com/user"
 


### PR DESCRIPTION
## Problem
Application code previously used to set custom properties on the `req` object of express. This is acceptable in javascript but as express typings doesn't expose such properties on the request object, will prove to be troublesome to type in typescript.

Express instead has a [`res.locals` ](https://expressjs.com/en/api.html#res.locals) property (and a corresponding type parameter in the `RequestHandler` type) that is used for such custom properties. We should instead be using this for ease of transition to typescript.

Part of #403
Closes #379 

## Solution
1. change existing declarations of `req.property = some_value` into `res.locals.property = some_value`
2. update call sites of `req.property` to `res.locals.property`
