### PR TITLE
Fix: mail client test

### DIFF
--- a/services/identity/__tests__/MailClient.spec.ts
+++ b/services/identity/__tests__/MailClient.spec.ts
@@ -17,6 +17,7 @@ const generateEmail = (recipient: string, body: string) => ({
   from: "IsomerCMS <donotreply@mail.postman.gov.sg>",
   body,
   recipient,
+  reply_to: "noreply@isomer.gov.sg",
 })
 
 describe("Mail Client", () => {


### PR DESCRIPTION
## Problem

This PR fixes a minor bug in the mail client tests, where we were not checking for the `reply_to` parameter.