### PR TITLE
test(ci): update ci config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
   test:
     needs: lint
     runs-on: ubuntu-latest
-    environment: staging
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
@@ -71,7 +70,9 @@ jobs:
           path: ~/.npm
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
-      - run: npm run test
+      - run: npm run dev:services
+      - run: . .env.test && npx jest
+      - run: docker compose down
 
   gatekeep:
     name: Determine if Build & Deploy is needed

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,4 +20,5 @@ module.exports = {
   },
   globalSetup: "<rootDir>/tests/setup.ts",
   globalTeardown: "<rootDir>/tests/teardown.ts",
+  setupFilesAfterEnv: ["<rootDir>/tests/closeConnection.ts"],
 }

--- a/tests/closeConnection.ts
+++ b/tests/closeConnection.ts
@@ -1,0 +1,3 @@
+import { sequelize } from "./database"
+
+afterAll(() => sequelize.close())


### PR DESCRIPTION
## Problem
Previously, our ci configuration was not working due to a few issues. These are respectively: 
1. requiring docker containers to be setup prior to running tests (for integration testing) 
2. `source` command not existing in github runner shell
3. jest not automatically exiting

## Solution
In order, the fixes are as follows: 
1. run `npm run dev:services` command
2. change `source` to `.` 
3. This is more interesting and more detail will be provided - i think this [issue](https://github.com/sequelize/sequelize/issues/6758) covers it up pretty well and i adopted their solution. Basically all the tests pass but jest wasn't exiting and resulted in an indefinite wait. This problem is due to sequelize having a connection pool and the teardown script doesn't close all the connections, merely _one_ connection. To fix this, there's another script that's ran after every test suite and this script closes sequelize connections. Oddly enough, setting `DB_MAX_POOL = 1` in the env vars don't work for this 