### PR TITLE
refactor(mailclient): pass api key explicitly

### DIFF
--- a/services/identity/MailClient.ts
+++ b/services/identity/MailClient.ts
@@ -2,18 +2,13 @@ import axios from "axios"
 
 import logger from "@logger/logger"
 
-const { POSTMAN_API_KEY } = process.env
 const POSTMAN_API_URL = "https://api.postman.gov.sg/v1"
 
 class MailClient {
   POSTMAN_API_KEY: string
 
-  constructor() {
-    if (!POSTMAN_API_KEY) {
-      throw new Error("Postman.gov.sg API key cannot be empty.")
-    }
-
-    this.POSTMAN_API_KEY = POSTMAN_API_KEY
+  constructor(apiKey: string) {
+    this.POSTMAN_API_KEY = apiKey
   }
 
   async sendMail(recipient: string, body: string): Promise<void> {
@@ -29,7 +24,7 @@ class MailClient {
     try {
       await axios.post(endpoint, email, {
         headers: {
-          Authorization: `Bearer ${POSTMAN_API_KEY}`,
+          Authorization: `Bearer ${this.POSTMAN_API_KEY}`,
         },
       })
     } catch (err) {

--- a/services/identity/__tests__/MailClient.spec.ts
+++ b/services/identity/__tests__/MailClient.spec.ts
@@ -10,7 +10,7 @@ import _MailClient from "../MailClient"
 
 const mockEndpoint = "https://api.postman.gov.sg/v1/transactional/email/send"
 
-const MailClient = new _MailClient()
+const MailClient = new _MailClient(process.env.POSTMAN_API_KEY!)
 
 const generateEmail = (recipient: string, body: string) => ({
   subject: "One-Time Password (OTP) for IsomerCMS",
@@ -21,20 +21,6 @@ const generateEmail = (recipient: string, body: string) => ({
 })
 
 describe("Mail Client", () => {
-  const OLD_ENV = process.env
-
-  beforeEach(() => {
-    // Clears the cache so imports in tests uses a fresh copy
-    jest.resetModules()
-    // Make a copy of existing environment
-    process.env = { ...OLD_ENV }
-  })
-
-  afterAll(() => {
-    // Restore old environment
-    process.env = OLD_ENV
-  })
-
   afterEach(() => mockAxios.reset())
 
   it("should return the result successfully when all parameters are valid", async () => {
@@ -51,27 +37,6 @@ describe("Mail Client", () => {
       generateEmail(mockRecipient, mockBody),
       mockBearerTokenHeaders
     )
-  })
-
-  it("should throw an error on initialization when the env var is not set", async () => {
-    // Arrange
-    // Store the API key and set it later so that other tests are not affected
-    const curApiKey = process.env.POSTMAN_API_KEY
-    process.env.POSTMAN_API_KEY = ""
-    // NOTE: This is because of typescript transpiling down to raw js
-    // Export default compiles down to module.exports.default, which is also
-    // done by babel.
-    // Read more here: https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports
-    const _MailClientWithoutKey = (await import("../MailClient")).default
-
-    // Act
-    // NOTE: We require a new instance because the old one would already have the API key bound
-    const actual = () => new _MailClientWithoutKey()
-
-    // Assert
-    expect(actual).toThrowError("Postman.gov.sg API key cannot be empty")
-    process.env.POSTMAN_API_KEY = curApiKey
-    expect(process.env.POSTMAN_API_KEY).toBe(curApiKey)
   })
 
   it("should return an error when a network error occurs", async () => {

--- a/services/identity/index.ts
+++ b/services/identity/index.ts
@@ -40,7 +40,7 @@ const totpGenerator = new TotpGenerator({
   expiry: parseInt(OTP_EXPIRY!, 10) ?? undefined,
 })
 
-if (!POSTMAN_API_KEY) {
+if (!POSTMAN_API_KEY && !IS_LOCAL_DEV) {
   throw new Error(
     "Please ensure that you have set POSTMAN_API_KEY in your env vars and that you have sourced them!"
   )
@@ -49,7 +49,7 @@ if (!POSTMAN_API_KEY) {
 const mockMailer = {
   sendMail: (_email: string, html: string) => logger.info(html),
 } as MailClient
-const mailer = IS_LOCAL_DEV ? mockMailer : new MailClient(POSTMAN_API_KEY)
+const mailer = IS_LOCAL_DEV ? mockMailer : new MailClient(POSTMAN_API_KEY!)
 
 const smsClient = IS_LOCAL_DEV
   ? ({


### PR DESCRIPTION
## Problem
see #395 for an associated write-up on the problem. 

Closes #395

## Solution
1. pass the api key explicitly in the constructor \