### PR TITLE
test(resourceDirectory): add check for directory/file call order

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,1 @@
+import "jest-extended"

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,5 +20,8 @@ module.exports = {
   },
   globalSetup: "<rootDir>/tests/setup.ts",
   globalTeardown: "<rootDir>/tests/teardown.ts",
-  setupFilesAfterEnv: ["<rootDir>/tests/closeConnection.ts"],
+  setupFilesAfterEnv: [
+    "<rootDir>/tests/closeConnection.ts",
+    "jest-extended/all",
+  ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7360,6 +7360,16 @@
         "jest-util": "^27.5.1"
       }
     },
+    "jest-extended": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-2.0.0.tgz",
+      "integrity": "sha512-6AgjJQVaBEKGSK3FH90kOiRUWJsbzn9NWtW0pjGkAFIdH0oPilfkV/gHPJdVvJeBiqT3jMHw8TUg9pUGC1azDg==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^27.2.5",
+        "jest-get-type": "^27.0.6"
+      }
+    },
     "jest-get-type": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepare": "husky install",
     "version": "auto-changelog -p && git add CHANGELOG.md",
     "npm run db:migrate": "source .env && npx sequelize-cli db:migrate",
-    "jump:staging": "source .ssh/.env.staging && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/isomercms-staging-bastion.pem", 
+    "jump:staging": "source .ssh/.env.staging && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/isomercms-staging-bastion.pem",
     "db:migrate:staging": "npm run jump:staging && npx sequelize-cli db:migrate",
     "jump:prod": "source .ssh/.env.prod && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/isomercms-production-bastion.pem",
     "db:migrate:prod": "npm run jump:prod && npx sequelize-cli db:migrate"
@@ -93,6 +93,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "husky": "^6.0.0",
     "jest": "^27.5.1",
+    "jest-extended": "^2.0.0",
     "jest-mock-axios": "^4.5.0",
     "lint-staged": "^11.1.2",
     "prettier": "2.2.1",

--- a/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
@@ -254,8 +254,6 @@ describe("Resource Directory Service", () => {
       sha,
     })
     it("Renaming a resource category works correctly", async () => {
-      const renameResourceSpy = jest.spyOn(service, "renameResourceDirectory")
-
       await expect(
         service.renameResourceDirectory(reqDetails, {
           resourceRoomName,
@@ -287,7 +285,9 @@ describe("Resource Directory Service", () => {
         fileName: INDEX_FILE_NAME,
         directoryName: `${resourceRoomName}/${newDirectoryName}`,
       })
-      expect(renameResourceSpy).toHaveBeenCalledBefore(mockGitHubService.update)
+      expect(mockBaseDirectoryService.rename).toHaveBeenCalledBefore(
+        mockGitHubService.update
+      )
     })
 
     it("Renaming a resource category slugifies the name correctly", async () => {
@@ -297,7 +297,6 @@ describe("Resource Directory Service", () => {
       })
       const originalResourceCategory = "Test Resource"
       const slugifiedResourceCategory = "test-resource"
-      const renameResourceSpy = jest.spyOn(service, "renameResourceDirectory")
 
       await expect(
         service.renameResourceDirectory(reqDetails, {
@@ -330,7 +329,9 @@ describe("Resource Directory Service", () => {
         fileName: INDEX_FILE_NAME,
         directoryName: `${resourceRoomName}/${slugifiedResourceCategory}`,
       })
-      expect(renameResourceSpy).toHaveBeenCalledBefore(mockGitHubService.update)
+      expect(mockBaseDirectoryService.rename).toHaveBeenCalledBefore(
+        mockGitHubService.update
+      )
     })
   })
 

--- a/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
@@ -254,6 +254,8 @@ describe("Resource Directory Service", () => {
       sha,
     })
     it("Renaming a resource category works correctly", async () => {
+      const getResourceSpy = jest.spyOn(service, "getResourceDirectoryPath")
+
       await expect(
         service.renameResourceDirectory(reqDetails, {
           resourceRoomName,
@@ -261,6 +263,7 @@ describe("Resource Directory Service", () => {
           newDirectoryName,
         })
       ).resolves.not.toThrowError()
+
       expect(mockGitHubService.read).toHaveBeenCalledWith(reqDetails, {
         fileName: INDEX_FILE_NAME,
         directoryName,
@@ -284,14 +287,18 @@ describe("Resource Directory Service", () => {
         fileName: INDEX_FILE_NAME,
         directoryName: `${resourceRoomName}/${newDirectoryName}`,
       })
+      expect(getResourceSpy).toHaveBeenCalledBefore(mockGitHubService.update)
     })
-    mockGitHubService.read.mockResolvedValueOnce({
-      content: mockMarkdownContent,
-      sha,
-    })
+
     it("Renaming a resource category slugifies the name correctly", async () => {
+      mockGitHubService.read.mockResolvedValueOnce({
+        content: mockMarkdownContent,
+        sha,
+      })
       const originalResourceCategory = "Test Resource"
       const slugifiedResourceCategory = "test-resource"
+      const getResourceSpy = jest.spyOn(service, "getResourceDirectoryPath")
+
       await expect(
         service.renameResourceDirectory(reqDetails, {
           resourceRoomName,
@@ -299,6 +306,7 @@ describe("Resource Directory Service", () => {
           newDirectoryName: originalResourceCategory,
         })
       ).resolves.not.toThrowError()
+
       expect(mockGitHubService.read).toHaveBeenCalledWith(reqDetails, {
         fileName: INDEX_FILE_NAME,
         directoryName,
@@ -322,6 +330,7 @@ describe("Resource Directory Service", () => {
         fileName: INDEX_FILE_NAME,
         directoryName: `${resourceRoomName}/${slugifiedResourceCategory}`,
       })
+      expect(getResourceSpy).toHaveBeenCalledBefore(mockGitHubService.update)
     })
   })
 

--- a/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
@@ -254,7 +254,7 @@ describe("Resource Directory Service", () => {
       sha,
     })
     it("Renaming a resource category works correctly", async () => {
-      const getResourceSpy = jest.spyOn(service, "getResourceDirectoryPath")
+      const renameResourceSpy = jest.spyOn(service, "renameResourceDirectory")
 
       await expect(
         service.renameResourceDirectory(reqDetails, {
@@ -287,7 +287,7 @@ describe("Resource Directory Service", () => {
         fileName: INDEX_FILE_NAME,
         directoryName: `${resourceRoomName}/${newDirectoryName}`,
       })
-      expect(getResourceSpy).toHaveBeenCalledBefore(mockGitHubService.update)
+      expect(renameResourceSpy).toHaveBeenCalledBefore(mockGitHubService.update)
     })
 
     it("Renaming a resource category slugifies the name correctly", async () => {
@@ -297,7 +297,7 @@ describe("Resource Directory Service", () => {
       })
       const originalResourceCategory = "Test Resource"
       const slugifiedResourceCategory = "test-resource"
-      const getResourceSpy = jest.spyOn(service, "getResourceDirectoryPath")
+      const renameResourceSpy = jest.spyOn(service, "renameResourceDirectory")
 
       await expect(
         service.renameResourceDirectory(reqDetails, {
@@ -330,7 +330,7 @@ describe("Resource Directory Service", () => {
         fileName: INDEX_FILE_NAME,
         directoryName: `${resourceRoomName}/${slugifiedResourceCategory}`,
       })
-      expect(getResourceSpy).toHaveBeenCalledBefore(mockGitHubService.update)
+      expect(renameResourceSpy).toHaveBeenCalledBefore(mockGitHubService.update)
     })
   })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,5 +39,6 @@
     "require": ["tsconfig-paths/register"],
     "transpileOnly": true
   },
+  "files": ["global.d.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,5 @@
     "require": ["tsconfig-paths/register"],
     "transpileOnly": true
   },
-  "files": ["global.d.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Problem
See #400 for a brief description of the issue.

Closes #400

## Solution
1. add `jest-extended`
2. check that directory level calls occur before file level reads

**New dev dependencies**:

- `jest-extended` : package to extend `jest` and add more matchers