### PR TITLE
Feat/move whitelist into database

### DIFF
--- a/database/migrations/20220407074127-create-whitelist.js
+++ b/database/migrations/20220407074127-create-whitelist.js
@@ -1,6 +1,6 @@
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.createTable("whitelists", {
+    await queryInterface.createTable("whitelist", {
       id: {
         allowNull: false,
         autoIncrement: true,
@@ -31,6 +31,6 @@ module.exports = {
   },
 
   down: async (queryInterface) => {
-    await queryInterface.dropTable("whitelists")
+    await queryInterface.dropTable("whitelist")
   },
 }

--- a/database/migrations/20220407074127-create-whitelist.js
+++ b/database/migrations/20220407074127-create-whitelist.js
@@ -11,14 +11,11 @@ module.exports = {
         allowNull: false,
         unique: true,
         type: Sequelize.TEXT,
-        validate: {
-          isEmail: true,
-        },
       },
       expiry: {
         type: Sequelize.DATE,
         allowNull: true,
-        defaultValue: null,
+        defaultValue: Sequelize.literal("NOW() + INTERVAL '6 months'"),
       },
       created_at: {
         type: Sequelize.DATE,

--- a/database/migrations/20220407074127-create-whitelist.js
+++ b/database/migrations/20220407074127-create-whitelist.js
@@ -1,0 +1,39 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable("whitelists", {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.BIGINT,
+      },
+      email: {
+        allowNull: false,
+        unique: true,
+        type: Sequelize.TEXT,
+        validate: {
+          isEmail: true,
+        },
+      },
+      expiry: {
+        type: Sequelize.DATE,
+        allowNull: true,
+        defaultValue: null,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("NOW"),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("NOW"),
+      },
+    })
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.dropTable("whitelists")
+  },
+}

--- a/database/models/User.ts
+++ b/database/models/User.ts
@@ -26,7 +26,7 @@ export class User extends Model {
     unique: true,
     type: DataType.TEXT,
   })
-  email!: string
+  email?: string | null
 
   @Column({
     allowNull: false,
@@ -42,7 +42,7 @@ export class User extends Model {
     allowNull: true,
     type: DataType.STRING(255),
   })
-  contactNumber!: string
+  contactNumber?: string | null
 
   @Column({
     type: DataType.DATE,

--- a/database/models/Whitelist.ts
+++ b/database/models/Whitelist.ts
@@ -8,7 +8,7 @@ import {
   UpdatedAt,
 } from "sequelize-typescript"
 
-@Table({ tableName: "whitelists" })
+@Table({ tableName: "whitelist" })
 export class Whitelist extends Model {
   @Column({
     autoIncrement: true,

--- a/database/models/Whitelist.ts
+++ b/database/models/Whitelist.ts
@@ -32,7 +32,7 @@ export class Whitelist extends Model {
     type: DataType.DATE,
     defaultValue: null,
   })
-  expiry!: Date
+  expiry: Date
 
   @CreatedAt
   createdAt!: Date

--- a/database/models/Whitelist.ts
+++ b/database/models/Whitelist.ts
@@ -1,0 +1,42 @@
+import {
+  DataType,
+  Column,
+  Model,
+  Table,
+  CreatedAt,
+  UpdatedAt,
+} from "sequelize-typescript"
+
+@Table({ tableName: "whitelists" })
+export class Whitelist extends Model {
+  @Column({
+    autoIncrement: true,
+    primaryKey: true,
+    allowNull: false,
+    type: DataType.BIGINT,
+  })
+  id!: number
+
+  @Column({
+    allowNull: false,
+    unique: true,
+    type: DataType.TEXT,
+    validate: {
+      notEmpty: true,
+    },
+  })
+  email!: string
+
+  @Column({
+    allowNull: true,
+    type: DataType.DATE,
+    defaultValue: null,
+  })
+  expiry!: Date
+
+  @CreatedAt
+  createdAt!: Date
+
+  @UpdatedAt
+  updatedAt!: Date
+}

--- a/database/models/Whitelist.ts
+++ b/database/models/Whitelist.ts
@@ -33,7 +33,7 @@ export class Whitelist extends Model {
     type: DataType.DATE,
     defaultValue: moment().add(6, "months"),
   })
-  expiry!: Date
+  expiry!: Date | null
 
   @CreatedAt
   createdAt!: Date

--- a/database/models/Whitelist.ts
+++ b/database/models/Whitelist.ts
@@ -1,3 +1,4 @@
+import moment from "moment-timezone"
 import {
   DataType,
   Column,
@@ -30,9 +31,9 @@ export class Whitelist extends Model {
   @Column({
     allowNull: true,
     type: DataType.DATE,
-    defaultValue: null,
+    defaultValue: moment().add(6, "months"),
   })
-  expiry: Date
+  expiry!: Date
 
   @CreatedAt
   createdAt!: Date

--- a/database/models/index.ts
+++ b/database/models/index.ts
@@ -1,3 +1,4 @@
 export * from "./Site"
 export * from "./SiteMember"
 export * from "./User"
+export * from "./Whitelist"

--- a/newroutes/authenticated/users.ts
+++ b/newroutes/authenticated/users.ts
@@ -34,7 +34,8 @@ export class UsersRouter {
     }
 
     try {
-      if (!this.usersService.canSendEmailOtp(email)) {
+      const isValidEmail = await this.usersService.canSendEmailOtp(email)
+      if (!isValidEmail) {
         throw new Error(
           `The email you have entered is not a government-issued email. Please contact your website owner for assistance.`
         )

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format-fix": "npx prettier --write .",
     "prepare": "husky install",
     "version": "auto-changelog -p && git add CHANGELOG.md",
-    "npm run db:migrate": "source .env && npx sequelize-cli db:migrate",
+    "db:migrate": "source .env && npx sequelize-cli db:migrate",
     "jump:staging": "source .ssh/.env.staging && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/isomercms-staging-bastion.pem",
     "db:migrate:staging": "npm run jump:staging && npx sequelize-cli db:migrate",
     "jump:prod": "source .ssh/.env.prod && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/isomercms-production-bastion.pem",

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ import "module-alias/register"
 import logger from "@logger/logger"
 
 import initSequelize from "@database/index"
-import { Site, SiteMember, User } from "@database/models"
+import { Site, SiteMember, User, Whitelist } from "@database/models"
 import bootstrap from "@root/bootstrap"
 import { getIdentityAuthService, getUsersService } from "@services/identity"
 
@@ -15,7 +15,7 @@ import getAuthenticatedSitesSubrouterV1 from "./routes/authenticatedSites"
 
 const path = require("path")
 
-const sequelize = initSequelize([Site, SiteMember, User])
+const sequelize = initSequelize([Site, SiteMember, User, Whitelist])
 const usersService = getUsersService(sequelize)
 
 const axios = require("axios")

--- a/services/identity/index.ts
+++ b/services/identity/index.ts
@@ -2,7 +2,7 @@ import { Sequelize } from "sequelize-typescript"
 
 import logger from "@logger/logger"
 
-import { User, Site } from "@database/models"
+import { User, Site, Whitelist } from "@database/models"
 import { GitHubService } from "@services/db/GitHubService"
 
 import AuthService from "./AuthService"
@@ -68,6 +68,7 @@ export const getUsersService = (sequelize: Sequelize) =>
     mailer,
     smsClient,
     sequelize,
+    whitelist: Whitelist,
   })
 
 // NOTE: This is because the identity auth service has an

--- a/tests/database.ts
+++ b/tests/database.ts
@@ -1,7 +1,7 @@
 import { Sequelize, SequelizeOptions } from "sequelize-typescript"
 
 import sequelizeConfig from "../database/config"
-import { Site, SiteMember, User } from "../database/models"
+import { Site, SiteMember, User, Whitelist } from "../database/models"
 
 /**
  * NOTE: This is required because globalSetup/Teardown live separately from
@@ -14,7 +14,7 @@ const sequelize = new Sequelize({
   ...sequelizeConfig,
 } as SequelizeOptions)
 
-sequelize.addModels([Site, SiteMember, User])
+sequelize.addModels([Site, SiteMember, User, Whitelist])
 
 // eslint-disable-next-line import/prefer-default-export
 export { sequelize }


### PR DESCRIPTION
## Problem

This PR modifies our existing method for verifying the domains were whitelisted - we were previously relying on env vars for the list of whitelisted domains, but as the number of sites may increase with the CWP migration, we have opted to move this into a database, which removes the character restriction we previously had on the list of names.

Closes https://github.com/isomerpages/isomercms-backend/issues/381

## Solution

Adds a new table to our database for whitelisted domains.

**Breaking Changes**

- Yes - this PR contains breaking changes
  - Run migrations on staging/prod db before merging

## Fixes
This PR also fixes the User table types - we were previously not correctly specifying that the `email` and `contact_number` could be a null value.

**New scripts**:

- `db:migrate` : modifies this script to use `db:migrate` instead of `npm run db:migrate`