### PR TITLE
Fix: check for JsonWebTokenError

### DIFF
--- a/services/middlewareServices/AuthMiddlewareService.js
+++ b/services/middlewareServices/AuthMiddlewareService.js
@@ -81,7 +81,9 @@ class AuthMiddlewareService {
         logger.error(`Authentication error: JWT token expired. Url: ${url}`)
         throw new AuthError(`JWT token has expired`)
       } else {
-        logger.error(`Authentication error. Message:${err.message} Url: ${url}`)
+        logger.error(
+          `Authentication error. Message: ${err.message} Url: ${url}`
+        )
       }
       throw err
     }

--- a/services/middlewareServices/AuthMiddlewareService.js
+++ b/services/middlewareServices/AuthMiddlewareService.js
@@ -73,7 +73,10 @@ class AuthMiddlewareService {
         throw new AuthError(
           `Authentication error: user not logged in with email`
         )
-      } else if (err.name === "TokenExpiredError") {
+      } else if (
+        err.name === "TokenExpiredError" ||
+        err.name === "JsonWebTokenError"
+      ) {
         logger.error(`Authentication error: JWT token expired. Url: ${url}`)
         throw new AuthError(`JWT token has expired`)
       } else {

--- a/services/middlewareServices/AuthMiddlewareService.js
+++ b/services/middlewareServices/AuthMiddlewareService.js
@@ -49,6 +49,10 @@ class AuthMiddlewareService {
       const userId = E2E_TEST_USER
       return { accessToken, userId }
     }
+    if (!isomercms) {
+      logger.error(`Authentication error: JWT token expired. Url: ${url}`)
+      throw new AuthError(`JWT token has expired`)
+    }
     try {
       const {
         access_token: retrievedToken,
@@ -73,14 +77,11 @@ class AuthMiddlewareService {
         throw new AuthError(
           `Authentication error: user not logged in with email`
         )
-      } else if (
-        err.name === "TokenExpiredError" ||
-        err.name === "JsonWebTokenError"
-      ) {
+      } else if (err.name === "TokenExpiredError") {
         logger.error(`Authentication error: JWT token expired. Url: ${url}`)
         throw new AuthError(`JWT token has expired`)
       } else {
-        logger.error(`Authentication error. Url: ${url}`)
+        logger.error(`Authentication error. Message:${err.message} Url: ${url}`)
       }
       throw err
     }


### PR DESCRIPTION
## Problem

This PR addresses an issue with our identification of expired tokens - previously, we were expecting a `TokenExpiredError` for expired tokens, however, we were receiving an abnormal number of unhandled server errors. The reason for this is that we also set an expiry for the cookie the token is attached to - this means that after the token/cookie expires, the token we attempt to decrypt is empty, which results in a `JsonWebTokenError` instead. As users getting logged out due to expiring tokens is an expected error, this PR handles this error in the same way, in order to reduce the number of alerts we receive on our monitoring channels.
