### PR TITLE
chore(mergify): change dependabot rule to lowercase

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,7 +4,7 @@ pull_request_rules:
       - author~=^dependabot\[bot\]$
       - check-success~=lint
       - check-success~=test
-      - title~=Bump [^\s]+ from ([\d]+)\..+ to \1\.
+      - title~=bump [^\s]+ from ([\d]+)\..+ to \1\.
     actions:
       review:
         type: APPROVE


### PR DESCRIPTION
## Problem
somehow dependabot PRs on FE differ from BE. This prevented mergify from working well; this fixes the rule to account for the differences

## Solution
1. lowercase b for dependabot rule ._.
