### PR TITLE
Fix/migrate script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Next, you will require the correct environment variables and credentials.
 - Search for the corresponding credentials `isomercms-<staging | production>-bastion.pem`
 - Put these credentials into the .ssh folder also.
 
-Finally, simply run the following command: `npm run db:migrate:<staging | production>`.
+Next, run the following command: `npm run jump:<staging | production>`. This sets up the port-forwarding service.
+Finally, run the following command in a separate terminal: `npm run db:migrate:<staging | production>` to run the migration.
 
 What happens under the hood is described below:
 You need to set up a local port-forwarding service that forwards traffic from a specific local port, e.g. 5433, to the database via the bastion host (remember: the bastion host resides in the public subnet of the VPC and thus can be contactable from your computer).

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "version": "auto-changelog -p && git add CHANGELOG.md",
     "db:migrate": "source .env && npx sequelize-cli db:migrate",
     "jump:staging": "source .ssh/.env.staging && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/isomercms-staging-bastion.pem",
-    "db:migrate:staging": "npm run jump:staging && npx sequelize-cli db:migrate",
+    "db:migrate:staging": "source .ssh/.env.staging && npx sequelize-cli db:migrate",
     "jump:prod": "source .ssh/.env.prod && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/isomercms-production-bastion.pem",
-    "db:migrate:prod": "npm run jump:prod && npx sequelize-cli db:migrate"
+    "db:migrate:prod": "source .ssh/.env.prod && npx sequelize-cli db:migrate"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.24.0",


### PR DESCRIPTION
## Problem

This PR fixes an issue with our previous migration script - we were attempting to run both `npm run jump:staging` and `npx sequelize-cli db:migrate` in the same command. However, due to the sequential order of execution, we would not be able to run `npx sequelize-cli db:migrate` until the jumphost was closed - this defeated the purpose of combining both commands. This PR separates out the commands and updates the README for the new flow.