### PR TITLE
Fix: remove unnecessary resource category check

### DIFF
--- a/services/directoryServices/ResourceDirectoryService.js
+++ b/services/directoryServices/ResourceDirectoryService.js
@@ -79,12 +79,6 @@ class ResourceDirectoryService {
     reqDetails,
     { resourceRoomName, resourceCategoryName }
   ) {
-    if (/[^a-zA-Z0-9- ]/g.test(resourceCategoryName)) {
-      // Contains non-allowed characters
-      throw new BadRequestError(
-        "Special characters not allowed in resource category name"
-      )
-    }
     const slugifiedResourceCategoryName = slugifyCollectionName(
       resourceCategoryName
     )
@@ -110,12 +104,6 @@ class ResourceDirectoryService {
     reqDetails,
     { resourceRoomName, resourceCategoryName, newDirectoryName }
   ) {
-    if (/[^a-zA-Z0-9- ]/g.test(newDirectoryName)) {
-      // Contains non-allowed characters
-      throw new BadRequestError(
-        "Special characters not allowed in resource category name"
-      )
-    }
     const oldDirectoryName = this.getResourceDirectoryPath({
       resourceRoomName,
       resourceCategoryName,

--- a/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
+++ b/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
@@ -183,15 +183,6 @@ describe("Resource Directory Service", () => {
   })
 
   describe("CreateResourceDirectory", () => {
-    it("rejects resource categories with special characters", async () => {
-      await expect(
-        service.createResourceDirectory(reqDetails, {
-          resourceRoomName,
-          resourceCategoryName: "dir/dir",
-        })
-      ).rejects.toThrowError(BadRequestError)
-    })
-
     it("Creating a resource category works correctly", async () => {
       await expect(
         service.createResourceDirectory(reqDetails, {
@@ -240,15 +231,6 @@ describe("Resource Directory Service", () => {
 
   describe("RenameResourceDirectory", () => {
     const newDirectoryName = "new-dir"
-    it("rejects resource categories with special characters", async () => {
-      await expect(
-        service.renameResourceDirectory(reqDetails, {
-          resourceRoomName,
-          resourceCategoryName,
-          newDirectoryName: "dir/dir",
-        })
-      ).rejects.toThrowError(BadRequestError)
-    })
     mockGitHubService.read.mockResolvedValueOnce({
       content: mockMarkdownContent,
       sha,


### PR DESCRIPTION
## Problem

This PR fixes an issue where resource categories with special characters were being rejected - this was because we had an extra unnecessary check for the original resource category title, when we were already slugifying the title. We remove the check in this title to stop titles with special characters from failing.