### PR TITLE
chore: Upgraded dotenv to enable running tests in WebStorm.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4671,9 +4671,9 @@
       "integrity": "sha512-xGWt+NHAQS+4tpgbOAI08yxW0Pr256Gu/FNE2frZVTbgrBUn8M7tz7/ktS/LZ2MHeGqz6topj0/xY+y8R5FBFw=="
     },
     "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
     },
     "dottie": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "crypto-js": "^4.1.1",
     "debug": "~2.6.9",
     "dompurify": "^2.3.1",
-    "dotenv": "^10.0.0",
+    "dotenv": "^16.0.1",
     "exponential-backoff": "^3.1.0",
     "express": "~4.16.1",
     "file-type": "^16.5.3",


### PR DESCRIPTION
The newest version allows me to import env vars from .env.test on the command line by setting one env var `DOTENV_CONFIG_PATH=.env.test` and passing jest the command line argument `--require dotenv/config`