### PR TITLE
Refactor/generalised mail client

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -10,6 +10,7 @@ export FRONTEND_URL="http://localhost:3000"
 export GITHUB_ORG_NAME="isomerpages"
 export GITHUB_BUILD_ORG_NAME="opengovsg"
 export GITHUB_BUILD_REPO_NAME="isomer-build"
+export ISOMERPAGES_REPO_PAGE_COUNT=3
 
 # Database
 export DB_URI="postgres://isomer:password@localhost:54321/isomercms_test"

--- a/fixtures/identity.ts
+++ b/fixtures/identity.ts
@@ -1,4 +1,5 @@
 export const mockRecipient = "hello@world.com"
+export const mockSubject = "mock subject"
 export const mockBody = "somebody"
 
 export const mockAccessToken = "some token"

--- a/services/identity/MailClient.ts
+++ b/services/identity/MailClient.ts
@@ -11,10 +11,14 @@ class MailClient {
     this.POSTMAN_API_KEY = apiKey
   }
 
-  async sendMail(recipient: string, body: string): Promise<void> {
+  async sendMail(
+    recipient: string,
+    subject: string,
+    body: string
+  ): Promise<void> {
     const endpoint = `${POSTMAN_API_URL}/transactional/email/send`
     const email = {
-      subject: "One-Time Password (OTP) for IsomerCMS",
+      subject,
       from: "IsomerCMS <donotreply@mail.postman.gov.sg>",
       body,
       recipient,

--- a/services/identity/UsersService.ts
+++ b/services/identity/UsersService.ts
@@ -102,10 +102,11 @@ class UsersService {
     const otp = this.otp.generate(email)
     const expiry = this.otp.getExpiryMinutes()
 
+    const subject = "One-Time Password (OTP) for IsomerCMS"
     const html = `<p>Your OTP is <b>${otp}</b>. It will expire in ${expiry} minutes. Please use this to verify your email address.</p>
     <p>If your OTP does not work, please request for a new OTP.</p>
     <p>IsomerCMS Support Team</p>`
-    await this.mailer.sendMail(email, html)
+    await this.mailer.sendMail(email, subject, html)
   }
 
   async sendSmsOtp(mobileNumber: string) {

--- a/services/identity/__tests__/MailClient.spec.ts
+++ b/services/identity/__tests__/MailClient.spec.ts
@@ -2,6 +2,7 @@ import mockAxios from "jest-mock-axios"
 
 import {
   mockRecipient,
+  mockSubject,
   mockBody,
   mockBearerTokenHeaders,
 } from "@fixtures/identity"
@@ -12,8 +13,8 @@ const mockEndpoint = "https://api.postman.gov.sg/v1/transactional/email/send"
 
 const MailClient = new _MailClient(process.env.POSTMAN_API_KEY!)
 
-const generateEmail = (recipient: string, body: string) => ({
-  subject: "One-Time Password (OTP) for IsomerCMS",
+const generateEmail = (recipient: string, subject: string, body: string) => ({
+  subject,
   from: "IsomerCMS <donotreply@mail.postman.gov.sg>",
   body,
   recipient,
@@ -24,27 +25,32 @@ describe("Mail Client", () => {
   afterEach(() => mockAxios.reset())
   it("should return the result successfully when all parameters are valid", async () => {
     // Arrange
+    const generatedEmail = generateEmail(mockRecipient, mockSubject, mockBody)
     mockAxios.post.mockResolvedValueOnce(200)
 
     // Act
-    const actual = await MailClient.sendMail(mockRecipient, mockBody)
+    const actual = await MailClient.sendMail(
+      mockRecipient,
+      mockSubject,
+      mockBody
+    )
 
     // Assert
     expect(actual).toBeUndefined()
     expect(mockAxios.post).toHaveBeenCalledWith(
       mockEndpoint,
-      generateEmail(mockRecipient, mockBody),
+      generatedEmail,
       mockBearerTokenHeaders
     )
   })
 
   it("should return an error when a network error occurs", async () => {
     // Arrange
-    const generatedEmail = generateEmail(mockRecipient, mockBody)
+    const generatedEmail = generateEmail(mockRecipient, mockSubject, mockBody)
     mockAxios.post.mockRejectedValueOnce("some error")
 
     // Act
-    const actual = MailClient.sendMail(mockRecipient, mockBody)
+    const actual = MailClient.sendMail(mockRecipient, mockSubject, mockBody)
 
     // Assert
     expect(actual).rejects.toThrowError("Failed to send email")

--- a/services/identity/index.ts
+++ b/services/identity/index.ts
@@ -47,7 +47,8 @@ if (!POSTMAN_API_KEY && !IS_LOCAL_DEV) {
 }
 
 const mockMailer = {
-  sendMail: (_email: string, html: string) => logger.info(html),
+  sendMail: (_email: string, _subject: string, html: string) =>
+    logger.info(html),
 } as MailClient
 const mailer = IS_LOCAL_DEV ? mockMailer : new MailClient(POSTMAN_API_KEY!)
 

--- a/services/utilServices/SitesService.js
+++ b/services/utilServices/SitesService.js
@@ -7,7 +7,8 @@ const {
 } = require("@root/services/api/AxiosInstance")
 
 const GH_MAX_REPO_COUNT = 100
-const ISOMERPAGES_REPO_PAGE_COUNT = process.env.ISOMERPAGES_REPO_PAGE_COUNT || 3
+const ISOMERPAGES_REPO_PAGE_COUNT =
+  parseInt(process.env.ISOMERPAGES_REPO_PAGE_COUNT) || 3
 const ISOMER_GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME
 const ISOMER_ADMIN_REPOS = [
   "isomercms-backend",

--- a/services/utilServices/__tests__/SitesService.spec.js
+++ b/services/utilServices/__tests__/SitesService.spec.js
@@ -38,6 +38,10 @@ describe("Resource Page Service", () => {
 
   describe("getSites", () => {
     it("Filters accessible sites correctly", async () => {
+      // Store the API key and set it later so that other tests are not affected
+      const currRepoCount = process.env.ISOMERPAGES_REPO_PAGE_COUNT
+      process.env.ISOMERPAGES_REPO_PAGE_COUNT = 3
+
       const expectedResp = [
         {
           lastUpdated: repoInfo.pushed_at,
@@ -67,6 +71,8 @@ describe("Resource Page Service", () => {
       )
 
       expect(genericGitHubAxiosInstance.get).toHaveBeenCalledTimes(3)
+      process.env.ISOMERPAGES_REPO_PAGE_COUNT = currRepoCount
+      expect(process.env.ISOMERPAGES_REPO_PAGE_COUNT).toBe(currRepoCount)
     })
   })
 


### PR DESCRIPTION
## Problem
This PR is part of https://github.com/isomerpages/isomercms-backend/issues/453. It refactors our existing `sendMail` method to allow the subject to be specified as well, for a more general email endpoint.

It also removes a dependency of one of our tests on the existing value of our `ISOMERPAGES_REPO_PAGE_COUNT` env var.