### PR TITLE
fix: removed unnecessary (and failing) cors proxy from git push calls

### DIFF
--- a/services/identity/ReposService.ts
+++ b/services/identity/ReposService.ts
@@ -108,7 +108,6 @@ export default class ReposService {
       dir,
       remote,
       remoteRef: "staging",
-      corsProxy: "https://cors.isomorphic-git.org",
       onAuth: () => ({ username: "user", password: SYSTEM_GITHUB_TOKEN }),
     })
 
@@ -119,7 +118,6 @@ export default class ReposService {
       dir,
       remote,
       remoteRef: "master",
-      corsProxy: "https://cors.isomorphic-git.org",
       onAuth: () => ({ username: "user", password: SYSTEM_GITHUB_TOKEN }),
     })
   }
@@ -247,7 +245,6 @@ export default class ReposService {
       http,
       dir,
       remote,
-      corsProxy: "https://cors.isomorphic-git.org",
       onAuth: () => ({ username: "user", password: SYSTEM_GITHUB_TOKEN }),
     }
     await git.push({


### PR DESCRIPTION
If we merge #470, then we should abandon this PR (because #470 brings in this change as well).

This backend uses the `isomorphic-git` package to create repositories and push them to GitHub. The `isomorphic-git` [push](https://isomorphic-git.org/docs/en/push#docsNav) method has an optional `corsProxy` argument that allows the package to work in a browser, but is unnecessary in a backend such as this. For some reason, this argument was set to `https://cors.isomorphic-git.org/`, a proxy set up by the `isomorphic-git` project that is only guaranteed to work for requests sent from `https://isomorphic-git.github.io/`, though it [sometimes works](https://isomorphic-git.org/blog/2018/07/08/cors-proxy-origin-limited) from other origins. The configuration of this proxy must have changed on the evening of 11-July-2022, because all of our requests began to fail at that time. The fix is simple: stop using the proxy and everything works.