### PR TITLE
Fix: update resource room

### DIFF
--- a/src/services/directoryServices/ResourceRoomDirectoryService.js
+++ b/src/services/directoryServices/ResourceRoomDirectoryService.js
@@ -95,17 +95,17 @@ class ResourceRoomDirectoryService {
     const { frontMatter, pageContent } = retrieveDataFromMarkdown(rawContent)
     frontMatter.title = newDirectoryName
     const newContent = convertDataToMarkdown(frontMatter, pageContent)
-    await this.gitHubService.update(reqDetails, {
-      fileContent: newContent,
-      sha,
-      fileName: INDEX_FILE_NAME,
-      directoryName: resourceRoomName,
-    })
 
     await this.baseDirectoryService.rename(reqDetails, {
       oldDirectoryName: resourceRoomName,
       newDirectoryName: slugifiedNewResourceRoomName,
       message: `Renaming resource room from ${resourceRoomName} to ${slugifiedNewResourceRoomName}`,
+    })
+    await this.gitHubService.update(reqDetails, {
+      fileContent: newContent,
+      sha,
+      fileName: INDEX_FILE_NAME,
+      directoryName: resourceRoomName,
     })
 
     const {


### PR DESCRIPTION
## Problem

This PR fixes an issue in our update resource room endpoint - as our index.html update was being done before our tree level operation, this was overridden by the tree level renaming operation (which uses a snapshot of the git tree retrieved at the start of the endpoint call), which caused the index.html title to not be updated. This PR rearranges the order to fix this issue. To be reviewed in conjunction with PR #[988](https://github.com/isomerpages/isomercms-frontend/pull/988) on the isomercms-frontend repo.