### PR TITLE
Chore: remove site links from description

### DIFF
--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -80,7 +80,6 @@ export default class ReposService {
     await octokit.repos.update({
       owner: ISOMER_GITHUB_ORGANIZATION_NAME,
       repo: repoName,
-      description: `Staging: ${stagingUrl} | Production: ${productionUrl}`,
     })
 
     const dir = this.getLocalRepoPath(repoName)


### PR DESCRIPTION
## Problem

This PR removes the site staging and prod links from the description on site creation - we were receiving feedback from schools that the github repo description was being indexed by google, which they were not comfortable with. The links are still accessible via the `_config.yml`, so we can still access them if necessary.