### PR TITLE
fix: remove unnecessary update step

### DIFF
--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -77,11 +77,6 @@ export default class ReposService {
     productionUrl: string,
     stagingUrl: string
   ) => {
-    await octokit.repos.update({
-      owner: ISOMER_GITHUB_ORGANIZATION_NAME,
-      repo: repoName,
-    })
-
     const dir = this.getLocalRepoPath(repoName)
 
     // 1. Set URLs in local _config.yml


### PR DESCRIPTION
## Problem

This PR fixes an issue introduced by https://github.com/isomerpages/isomercms-backend/pull/482 - we had previously removed the description in the repo update step as we believed it was not necessary - however, this caused issues with the site creation form, as we were attempting to call update on the repo with nothing to update. This PR removes the extra step to prevent this bug from occurring.