### PR TITLE
fix: remove resources_name and add support for url

### DIFF
--- a/src/fixtures/config.js
+++ b/src/fixtures/config.js
@@ -118,7 +118,7 @@ const configContent = {
 const configSha = "configsha"
 
 const configResponse = {
-  url: configContent.url,
+  url: configContent.url.replace("https://", ""),
   title: configContent.title,
   description: configContent.description,
   favicon: configContent.favicon,

--- a/src/fixtures/config.js
+++ b/src/fixtures/config.js
@@ -127,7 +127,6 @@ const configResponse = {
   facebook_pixel: configContent["facebook-pixel"],
   google_analytics: configContent.google_analytics,
   linkedin_insights: configContent["linkedin-insights"],
-  resources_name: configContent.resources_name,
   colors: configContent.colors,
 }
 

--- a/src/services/configServices/SettingsService.js
+++ b/src/services/configServices/SettingsService.js
@@ -58,6 +58,11 @@ class SettingsService {
         config.content,
         updatedConfigContent
       )
+      // Prepend "https://" to url parameter if parameter is defined
+      if (mergedConfigContent.url !== "") {
+        mergedConfigContent.url = "https://" + mergedConfigContent.url
+      }
+
       await this.configYmlService.update(reqDetails, {
         fileContent: mergedConfigContent,
         sha: config.sha,
@@ -152,7 +157,7 @@ class SettingsService {
 
   static extractConfigFields(config) {
     return {
-      url: config.content.url,
+      url: config.content.url.replace("https://", ""),
       description: config.content.description,
       title: config.content.title,
       favicon: config.content.favicon,

--- a/src/services/configServices/SettingsService.js
+++ b/src/services/configServices/SettingsService.js
@@ -59,7 +59,10 @@ class SettingsService {
         updatedConfigContent
       )
       // Prepend "https://" to url parameter if parameter is defined
-      if (mergedConfigContent.url !== "") {
+      if (
+        mergedConfigContent.url !== "" &&
+        !mergedConfigContent.url.startsWith("https://")
+      ) {
         mergedConfigContent.url = "https://" + mergedConfigContent.url
       }
 

--- a/src/services/configServices/SettingsService.js
+++ b/src/services/configServices/SettingsService.js
@@ -161,7 +161,6 @@ class SettingsService {
       facebook_pixel: config.content["facebook-pixel"],
       google_analytics: config.content.google_analytics,
       linkedin_insights: config.content["linkedin-insights"],
-      resources_name: config.content.resources_name,
       colors: config.content.colors,
     }
   }
@@ -187,7 +186,6 @@ class SettingsService {
       "facebook-pixel",
       "google_analytics",
       "linkedin-insights",
-      "resources_name",
       "colors",
     ]
     const footerParams = [

--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -236,12 +236,7 @@ const UpdateNavigationRequestSchema = Joi.object().keys({
 })
 
 const UpdateSettingsRequestSchema = Joi.object().keys({
-  url: Joi.string()
-    .uri({
-      scheme: ["http", "https"],
-      domain: {},
-    })
-    .allow(""),
+  url: Joi.string().domain().allow(""),
   colors: Joi.object().keys({
     "primary-color": Joi.string().required(),
     "secondary-color": Joi.string().required(),

--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -236,6 +236,12 @@ const UpdateNavigationRequestSchema = Joi.object().keys({
 })
 
 const UpdateSettingsRequestSchema = Joi.object().keys({
+  url: Joi.string()
+    .uri({
+      scheme: ["http", "https"],
+      domain: {},
+    })
+    .allow(""),
   colors: Joi.object().keys({
     "primary-color": Joi.string().required(),
     "secondary-color": Joi.string().required(),


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes #454.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The `resources_name` parameter has been removed from the response when calling GET `/v2/sites/:siteName/settings`, as it is an extra parameter and can cause issues on the frontend.
- The `url` parameter has been enhanced to support POST `/v2/sites/:siteName/settings`.
  - The parameter only takes in a valid domain name.
  - All invalid inputs will throw a 400 BadRequestError.

## Tests

<!-- What tests should be run to confirm functionality? -->

**Unit tests**:
- Run `npm run tests`

**Smoke tests**:
- Check out the `fix/settings-parameters` branch on the CMS frontend.
- Run `npm run dev`.
- Log in and navigate to any site dashboard, then access the "Site settings" page.
- Modify the value in the "Site URL" input field.
- Verify that the new settings can be saved and correctly displayed upon page refresh.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*