### PR TITLE
Fix: add trailing slash to permalink

### DIFF
--- a/src/utils/markdown-utils.js
+++ b/src/utils/markdown-utils.js
@@ -1,4 +1,8 @@
+const _ = require("lodash")
 const yaml = require("yaml")
+
+const getTrailingSlashWithPermalink = (permalink) =>
+  permalink.endsWith("/") ? permalink : `${permalink}/`
 
 const retrieveDataFromMarkdown = (fileContent) => {
   // eslint-disable-next-line no-unused-vars
@@ -7,7 +11,12 @@ const retrieveDataFromMarkdown = (fileContent) => {
   return { frontMatter, pageContent: pageContent.join("---") }
 }
 
-const convertDataToMarkdown = (frontMatter, pageContent) => {
+const convertDataToMarkdown = (originalFrontMatter, pageContent) => {
+  const frontMatter = _.clone(originalFrontMatter)
+  const { permalink } = frontMatter
+  if (permalink) {
+    frontMatter.permalink = getTrailingSlashWithPermalink(permalink)
+  }
   const newFrontMatter = yaml.stringify(frontMatter)
   const newContent = ["---\n", newFrontMatter, "---\n", pageContent].join("")
   return newContent


### PR DESCRIPTION
## Problem

This PR adds a check for trailing slash for all page permalinks, as missing it does not play well with our amplify builds. Resolves https://github.com/isomerpages/isomercms-frontend/issues/1024.