### PR TITLE
Fix/unexpected footer fields

### DIFF
--- a/src/services/configServices/SettingsService.js
+++ b/src/services/configServices/SettingsService.js
@@ -137,16 +137,17 @@ class SettingsService {
 
   mergeUpdatedFooterData(currentData, updatedData) {
     // Special configuration to remove empty footer settings entirely so they don't show up in the actual site
+    // Any updated data with empty strings are to be deleted from the footer object
     const clonedCurrentData = _.cloneDeep(currentData)
     Object.keys(updatedData).forEach((field) => {
       if (field === "social_media") {
+        // social_media is an object with each social link in a separate property
         // Set social_media field if it doesn't exist
         if (!clonedCurrentData[field]) clonedCurrentData[field] = {}
         const socials = updatedData[field]
         Object.keys(socials).forEach((social) => {
           if (!socials[social]) {
-            if (clonedCurrentData[field][social])
-              delete clonedCurrentData[field][social]
+            delete clonedCurrentData[field][social]
           } else {
             clonedCurrentData[field][social] = updatedData[field][social]
           }

--- a/src/services/configServices/SettingsService.js
+++ b/src/services/configServices/SettingsService.js
@@ -135,33 +135,28 @@ class SettingsService {
     return clonedCurrentData
   }
 
+  cloneDeepNonEmpty(originalObj, updatedObj) {
+    const clonedOriginalObj = originalObj ? { ...originalObj } : {}
+    Object.keys(updatedObj).forEach((field) => {
+      if (typeof updatedObj[field] === "object" && updatedObj[field] !== null) {
+        clonedOriginalObj[field] = this.cloneDeepNonEmpty(
+          originalObj[field],
+          updatedObj[field]
+        )
+      } else if (updatedObj[field] === "") {
+        // Check for empty string because false value exists
+        delete clonedOriginalObj[field]
+      } else {
+        clonedOriginalObj[field] = updatedObj[field]
+      }
+    })
+    return clonedOriginalObj
+  }
+
   mergeUpdatedFooterData(currentData, updatedData) {
     // Special configuration to remove empty footer settings entirely so they don't show up in the actual site
     // Any updated data with empty strings are to be deleted from the footer object
-    const clonedCurrentData = _.cloneDeep(currentData)
-    Object.keys(updatedData).forEach((field) => {
-      if (field === "social_media") {
-        // social_media is an object with each social link in a separate property
-        // Set social_media field if it doesn't exist
-        if (!clonedCurrentData[field]) {
-          clonedCurrentData[field] = {}
-        }
-        const socials = updatedData[field]
-        Object.keys(socials).forEach((social) => {
-          if (!socials[social]) {
-            delete clonedCurrentData[field][social]
-          } else {
-            clonedCurrentData[field][social] = updatedData[field][social]
-          }
-        })
-      } else if (updatedData[field] === "") {
-        // Check for empty string because false value exists
-        delete clonedCurrentData[field]
-      } else {
-        clonedCurrentData[field] = updatedData[field]
-      }
-    })
-    return clonedCurrentData
+    return this.cloneDeepNonEmpty(currentData, updatedData)
   }
 
   static extractConfigFields(config) {

--- a/src/services/configServices/SettingsService.js
+++ b/src/services/configServices/SettingsService.js
@@ -177,7 +177,13 @@ class SettingsService {
   }
 
   static extractFooterFields(footer) {
-    return footer.content
+    return {
+      show_reach: footer.content.show_reach,
+      social_media: footer.content.social_media,
+      faq: footer.content.faq,
+      contact_us: footer.content.contact_us,
+      feedback: footer.content.feedback,
+    }
   }
 
   static extractNavFields(navigation) {

--- a/src/services/configServices/SettingsService.js
+++ b/src/services/configServices/SettingsService.js
@@ -63,7 +63,7 @@ class SettingsService {
         mergedConfigContent.url !== "" &&
         !mergedConfigContent.url.startsWith("https://")
       ) {
-        mergedConfigContent.url = "https://" + mergedConfigContent.url
+        mergedConfigContent.url = `https://${mergedConfigContent.url}`
       }
 
       await this.configYmlService.update(reqDetails, {
@@ -140,12 +140,15 @@ class SettingsService {
     const clonedCurrentData = _.cloneDeep(currentData)
     Object.keys(updatedData).forEach((field) => {
       if (field === "social_media") {
+        // Set social_media field if it doesn't exist
+        if (!clonedCurrentData[field]) clonedCurrentData[field] = {}
         const socials = updatedData[field]
         Object.keys(socials).forEach((social) => {
           if (!socials[social]) {
-            delete clonedCurrentData[field][social]
+            if (clonedCurrentData[field][social])
+              delete clonedCurrentData[field][social]
           } else {
-            clonedCurrentData[field] = updatedData[field]
+            clonedCurrentData[field][social] = updatedData[field][social]
           }
         })
       } else if (updatedData[field] === "") {

--- a/src/services/configServices/SettingsService.js
+++ b/src/services/configServices/SettingsService.js
@@ -143,7 +143,9 @@ class SettingsService {
       if (field === "social_media") {
         // social_media is an object with each social link in a separate property
         // Set social_media field if it doesn't exist
-        if (!clonedCurrentData[field]) clonedCurrentData[field] = {}
+        if (!clonedCurrentData[field]) {
+          clonedCurrentData[field] = {}
+        }
         const socials = updatedData[field]
         Object.keys(socials).forEach((social) => {
           if (!socials[social]) {


### PR DESCRIPTION
## Problem

This PR fixes an issue with existing legacy site formats. Previously, if a site has extra footer fields, we would run into an error when saving settings on the frontend, as we specify the exact data structure that we are supposed to receive. This PR constrains the fields provided to only those that we expect. It also fixes an issue with handling empty social media fields.