### PR TITLE
Chore/update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5240,15 +5240,26 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "dev": true
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true
+        }
+      }
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -5521,6 +5532,12 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "auto-bind": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
@@ -5758,6 +5775,35 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        }
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -5946,9 +5992,9 @@
       }
     },
     "cachedir": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.2.0.tgz",
-      "integrity": "sha512-VvxA0xhNqIIfg0V9AmJkDg91DaJwryutH5rVEZAhcNi4iJFj9f+QxmAjgK1LT9I8OgToX27fypX6/MeCXVbBjQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
+      "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
       "dev": true
     },
     "call-bind": {
@@ -6047,13 +6093,19 @@
       "dev": true
     },
     "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "^3.1.0"
       }
+    },
+    "cli-spinners": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
+      "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+      "dev": true
     },
     "cli-truncate": {
       "version": "2.1.0",
@@ -6067,8 +6119,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "ansi-styles": {
@@ -6135,9 +6186,9 @@
       }
     },
     "cli-width": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true
     },
     "cliui": {
@@ -6219,6 +6270,12 @@
           }
         }
       }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true
     },
     "co": {
       "version": "4.6.0",
@@ -6304,41 +6361,77 @@
       "dev": true
     },
     "commitizen": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.2.4.tgz",
-      "integrity": "sha512-LlZChbDzg3Ir3O2S7jSo/cgWp5/QwylQVr59K4xayVq8S4/RdKzSyJkghAiZZHfhh5t4pxunUoyeg0ml1q/7aw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.2.5.tgz",
+      "integrity": "sha512-9sXju8Qrz1B4Tw7kC5KhnvwYQN88qs2zbiB8oyMsnXZyJ24PPGiNM3nHr73d32dnE3i8VJEXddBFIbOgYSEXtQ==",
       "dev": true,
       "requires": {
-        "cachedir": "2.2.0",
-        "cz-conventional-changelog": "3.2.0",
+        "cachedir": "2.3.0",
+        "cz-conventional-changelog": "3.3.0",
         "dedent": "0.7.0",
-        "detect-indent": "6.0.0",
+        "detect-indent": "6.1.0",
         "find-node-modules": "^2.1.2",
         "find-root": "1.1.0",
-        "fs-extra": "8.1.0",
-        "glob": "7.1.4",
-        "inquirer": "6.5.2",
+        "fs-extra": "9.1.0",
+        "glob": "7.2.3",
+        "inquirer": "8.2.4",
         "is-utf8": "^0.2.1",
-        "lodash": "^4.17.20",
-        "minimist": "1.2.5",
+        "lodash": "4.17.21",
+        "minimist": "1.2.6",
         "strip-bom": "4.0.0",
-        "strip-json-comments": "3.0.1"
+        "strip-json-comments": "3.1.1"
       },
       "dependencies": {
-        "cz-conventional-changelog": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.0.tgz",
-          "integrity": "sha512-yAYxeGpVi27hqIilG1nh4A9Bnx4J3Ov+eXy4koL3drrR+IO9GaWPsKjik20ht608Asqi8TQPf0mczhEeyAtMzg==",
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
-            "@commitlint/load": ">6.1.1",
-            "chalk": "^2.4.1",
-            "commitizen": "^4.0.3",
-            "conventional-commit-types": "^3.0.0",
-            "lodash.map": "^4.5.1",
-            "longest": "^2.0.1",
-            "word-wrap": "^1.0.3"
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
           }
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
         }
       }
     },
@@ -6627,6 +6720,15 @@
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
+      }
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -6681,13 +6783,13 @@
     "detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
       "dev": true
     },
     "detect-indent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
-      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true
     },
     "detect-libc": {
@@ -7000,9 +7102,9 @@
           }
         },
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -7615,7 +7717,7 @@
     "expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
       "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
@@ -7830,9 +7932,9 @@
       "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
     },
     "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -7891,13 +7993,13 @@
       }
     },
     "find-node-modules": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.2.tgz",
-      "integrity": "sha512-x+3P4mbtRPlSiVE1Qco0Z4YLU8WFiFcuWTf3m75OV9Uzcfs2Bg+O9N+r/K0AnmINBW06KpfqKwYJbFlFq4qNug==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.3.tgz",
+      "integrity": "sha512-UC2I2+nx1ZuOBclWVNdcnbDR5dlrOdVb7xNjmT/lHE+LsgztWks3dG7boJ37yTS/venXw84B/mAW9uHVoC5QRg==",
       "dev": true,
       "requires": {
         "findup-sync": "^4.0.0",
-        "merge": "^2.1.0"
+        "merge": "^2.1.1"
       }
     },
     "find-root": {
@@ -7931,57 +8033,6 @@
         "is-glob": "^4.0.0",
         "micromatch": "^4.0.2",
         "resolve-dir": "^1.0.1"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.2.3"
-          }
-        },
-        "picomatch": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-          "dev": true
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
       }
     },
     "flat-cache": {
@@ -8006,9 +8057,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
-      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw=="
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "form-data": {
       "version": "3.0.1",
@@ -8303,7 +8354,7 @@
     "global-prefix": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
       "dev": true,
       "requires": {
         "expand-tilde": "^2.0.2",
@@ -8634,24 +8685,103 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
+      "integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.12",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^5.1.0",
-        "through": "^2.3.6"
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "rxjs": {
+          "version": "7.5.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+          "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
       }
     },
     "internal-slot": {
@@ -8733,9 +8863,9 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
     "is-generator-fn": {
@@ -8752,6 +8882,12 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
     },
     "is-lambda": {
       "version": "1.0.1",
@@ -8859,7 +8995,7 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
       "dev": true
     },
     "is-weakref": {
@@ -10868,8 +11004,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "ansi-styles": {
@@ -11393,9 +11528,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
     "mimic-response": {
@@ -11412,9 +11547,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minimisted": {
       "version": "2.0.1",
@@ -11565,9 +11700,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
     "nan": {
@@ -11991,12 +12126,12 @@
       }
     },
     "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "opentracing": {
@@ -12017,10 +12152,78 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true
     },
     "otplib": {
@@ -12147,7 +12350,7 @@
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
       "dev": true
     },
     "parse5": {
@@ -12640,7 +12843,7 @@
     "resolve-dir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
       "dev": true,
       "requires": {
         "expand-tilde": "^2.0.0",
@@ -12670,12 +12873,12 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
+        "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
     },
@@ -13227,24 +13430,14 @@
       }
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "dependencies": {
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       }
     },
     "string.prototype.trimend": {
@@ -13294,20 +13487,12 @@
       }
     },
     "strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^4.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        }
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-bom": {
@@ -13323,9 +13508,9 @@
       "dev": true
     },
     "strip-json-comments": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
     "strtok3": {
@@ -13497,9 +13682,9 @@
           }
         },
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -14186,6 +14371,15 @@
         "makeerror": "1.0.12"
       }
     },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
+      }
+    },
     "webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -14385,9 +14579,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -729,6 +729,707 @@
         }
       }
     },
+    "@aws-sdk/client-cloudwatch-logs": {
+      "version": "3.179.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.179.0.tgz",
+      "integrity": "sha512-6b+oQZM18Zs/I1EwHShh1oPXhSYA6iSdwXAK6IEfp/ilPWGDliN+Qp8zYks9bgp9Lndzgz091BvaalwMjgieMw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.179.0",
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/credential-provider-node": "3.178.0",
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/hash-node": "3.178.0",
+        "@aws-sdk/invalid-dependency": "3.178.0",
+        "@aws-sdk/middleware-content-length": "3.178.0",
+        "@aws-sdk/middleware-host-header": "3.178.0",
+        "@aws-sdk/middleware-logger": "3.178.0",
+        "@aws-sdk/middleware-recursion-detection": "3.178.0",
+        "@aws-sdk/middleware-retry": "3.178.0",
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/middleware-signing": "3.179.0",
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/middleware-user-agent": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/smithy-client": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-base64-node": "3.170.0",
+        "@aws-sdk/util-body-length-browser": "3.170.0",
+        "@aws-sdk/util-body-length-node": "3.170.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.178.0",
+        "@aws-sdk/util-defaults-mode-node": "3.178.0",
+        "@aws-sdk/util-user-agent-browser": "3.178.0",
+        "@aws-sdk/util-user-agent-node": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-crypto/ie11-detection": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+          "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+          "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^2.0.0",
+            "@aws-crypto/sha256-js": "^2.0.0",
+            "@aws-crypto/supports-web-crypto": "^2.0.0",
+            "@aws-crypto/util": "^2.0.0",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+          "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+          "requires": {
+            "@aws-crypto/util": "^2.0.0",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+          "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.178.0.tgz",
+          "integrity": "sha512-ptDkCB06BJrYdhKzamM9yI15LxcGkPczY80hzKAY/aecm09alnW27uCt5HJJx2nCd18IUH28ZO1sc7DTLOWb3A==",
+          "requires": {
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.178.0.tgz",
+          "integrity": "sha512-3y7+/eD7VgByUu6IXIT0ICBNVJiDdkCKsck18OUzankICQsCsEg7RGeOlhdHkKBmDqGDJEJMuTWnGJQo1IVsgw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.178.0",
+            "@aws-sdk/fetch-http-handler": "3.178.0",
+            "@aws-sdk/hash-node": "3.178.0",
+            "@aws-sdk/invalid-dependency": "3.178.0",
+            "@aws-sdk/middleware-content-length": "3.178.0",
+            "@aws-sdk/middleware-host-header": "3.178.0",
+            "@aws-sdk/middleware-logger": "3.178.0",
+            "@aws-sdk/middleware-recursion-detection": "3.178.0",
+            "@aws-sdk/middleware-retry": "3.178.0",
+            "@aws-sdk/middleware-serde": "3.178.0",
+            "@aws-sdk/middleware-stack": "3.178.0",
+            "@aws-sdk/middleware-user-agent": "3.178.0",
+            "@aws-sdk/node-config-provider": "3.178.0",
+            "@aws-sdk/node-http-handler": "3.178.0",
+            "@aws-sdk/protocol-http": "3.178.0",
+            "@aws-sdk/smithy-client": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "@aws-sdk/url-parser": "3.178.0",
+            "@aws-sdk/util-base64-browser": "3.170.0",
+            "@aws-sdk/util-base64-node": "3.170.0",
+            "@aws-sdk/util-body-length-browser": "3.170.0",
+            "@aws-sdk/util-body-length-node": "3.170.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.178.0",
+            "@aws-sdk/util-defaults-mode-node": "3.178.0",
+            "@aws-sdk/util-user-agent-browser": "3.178.0",
+            "@aws-sdk/util-user-agent-node": "3.178.0",
+            "@aws-sdk/util-utf8-browser": "3.170.0",
+            "@aws-sdk/util-utf8-node": "3.170.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.179.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.179.0.tgz",
+          "integrity": "sha512-yZEi81eRWAJBaEY6tYjJ/WNI2XcRIM/pUvjyHrkfPcwVhXUH68vPJVgcEe947+gewj5hA1Ri6wA4EpKv45jS8g==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.178.0",
+            "@aws-sdk/credential-provider-node": "3.178.0",
+            "@aws-sdk/fetch-http-handler": "3.178.0",
+            "@aws-sdk/hash-node": "3.178.0",
+            "@aws-sdk/invalid-dependency": "3.178.0",
+            "@aws-sdk/middleware-content-length": "3.178.0",
+            "@aws-sdk/middleware-host-header": "3.178.0",
+            "@aws-sdk/middleware-logger": "3.178.0",
+            "@aws-sdk/middleware-recursion-detection": "3.178.0",
+            "@aws-sdk/middleware-retry": "3.178.0",
+            "@aws-sdk/middleware-sdk-sts": "3.179.0",
+            "@aws-sdk/middleware-serde": "3.178.0",
+            "@aws-sdk/middleware-signing": "3.179.0",
+            "@aws-sdk/middleware-stack": "3.178.0",
+            "@aws-sdk/middleware-user-agent": "3.178.0",
+            "@aws-sdk/node-config-provider": "3.178.0",
+            "@aws-sdk/node-http-handler": "3.178.0",
+            "@aws-sdk/protocol-http": "3.178.0",
+            "@aws-sdk/smithy-client": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "@aws-sdk/url-parser": "3.178.0",
+            "@aws-sdk/util-base64-browser": "3.170.0",
+            "@aws-sdk/util-base64-node": "3.170.0",
+            "@aws-sdk/util-body-length-browser": "3.170.0",
+            "@aws-sdk/util-body-length-node": "3.170.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.178.0",
+            "@aws-sdk/util-defaults-mode-node": "3.178.0",
+            "@aws-sdk/util-user-agent-browser": "3.178.0",
+            "@aws-sdk/util-user-agent-node": "3.178.0",
+            "@aws-sdk/util-utf8-browser": "3.170.0",
+            "@aws-sdk/util-utf8-node": "3.170.0",
+            "entities": "2.2.0",
+            "fast-xml-parser": "3.19.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.178.0.tgz",
+          "integrity": "sha512-8xL98TGMaVULIN7HRWV2q1o0Y2p38QuweehzM8yXCZrrLOyHgWo3waP2RNVeddOB7MrSwwU/gw9rXSv7YHLZ6w==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "@aws-sdk/util-config-provider": "3.170.0",
+            "@aws-sdk/util-middleware": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.178.0.tgz",
+          "integrity": "sha512-5CMswTJ188RuK9TmI5yAosIsyu4Mm9Cdq1068tRls5EqqwGK1PI7Q007b6rD7zqCb5IgeFBV0t2DxHkBmHRd3w==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.178.0.tgz",
+          "integrity": "sha512-ZvqQTi3+S13LACVgaWNCOKBv5jROIz7rqyZh56QunAkaAUqPbpM4VFODgAGZYPCOSggZbEUUqXOVB9xSnshLnA==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.178.0",
+            "@aws-sdk/property-provider": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "@aws-sdk/url-parser": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.178.0.tgz",
+          "integrity": "sha512-PhaJMzgg0I0WMD6i+t53Y7x0vCZQ5p6fTOQMOrbfJkAaCLZvUuDd2XfoCGpS53PPQKOg7hHQxMLJ5lfJ4qSIzg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.178.0",
+            "@aws-sdk/credential-provider-imds": "3.178.0",
+            "@aws-sdk/credential-provider-sso": "3.178.0",
+            "@aws-sdk/credential-provider-web-identity": "3.178.0",
+            "@aws-sdk/property-provider": "3.178.0",
+            "@aws-sdk/shared-ini-file-loader": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.178.0.tgz",
+          "integrity": "sha512-4yTP1ny0+D3fM7U4IdIp99EgveXxMSsxBr1jpCcZqTfP5MtfG9DK3i6QzkXGK4T6CQRU3o+DpD3yfcBChdjrww==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.178.0",
+            "@aws-sdk/credential-provider-imds": "3.178.0",
+            "@aws-sdk/credential-provider-ini": "3.178.0",
+            "@aws-sdk/credential-provider-process": "3.178.0",
+            "@aws-sdk/credential-provider-sso": "3.178.0",
+            "@aws-sdk/credential-provider-web-identity": "3.178.0",
+            "@aws-sdk/property-provider": "3.178.0",
+            "@aws-sdk/shared-ini-file-loader": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.178.0.tgz",
+          "integrity": "sha512-J4TldKrAnfayvRfxNEnLJUnTgkpTcct6rc7PwZlVSGSUgjglbcqfemUOP/pisLKbVNNL742lsUXmkUVH4km0Fw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.178.0",
+            "@aws-sdk/shared-ini-file-loader": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.178.0.tgz",
+          "integrity": "sha512-fHgKYAve+nHKyr/j7njwfogLMZhlEWumTuZCmJjl19r0kM1X9c0MYStd1MvCDP3c+XG8vI17bQWNsD9eTJ86OQ==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.178.0",
+            "@aws-sdk/property-provider": "3.178.0",
+            "@aws-sdk/shared-ini-file-loader": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.178.0.tgz",
+          "integrity": "sha512-aei8o9ALtzwgYsZCAWdr+ItJyYTkYRmCoKstM4mkGtWNK9BjdISaVUAnndl6Pc/l/5eiK+2rlA+6Ujs4H8m+XQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.178.0.tgz",
+          "integrity": "sha512-T/LCNwCihdVNzGn39Dw7tk2U1fMlupFlCsAvDBbO+FOM3h+y9WLHzxmlAVsjPrFXlzdONKf9zd5cuQ+ZW93yAQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.178.0",
+            "@aws-sdk/querystring-builder": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "@aws-sdk/util-base64-browser": "3.170.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.178.0.tgz",
+          "integrity": "sha512-mqYraRQlvPO5egUKTNZ1kP52sfwBlsz7woOewQTHOGomZBDXrh8bl1J+sgaDi1NAwXdZUgxuD3QKxxAKRs9a2Q==",
+          "requires": {
+            "@aws-sdk/types": "3.178.0",
+            "@aws-sdk/util-buffer-from": "3.170.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.178.0.tgz",
+          "integrity": "sha512-JJNaiLr3nbRYym6oUAAaoFFYtDnIZ9Scco2p4sG/thT2eyAfXcEdNl1cSD3E/R1J+Ml/YplqTiIY4u1KPAriRw==",
+          "requires": {
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.170.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.170.0.tgz",
+          "integrity": "sha512-yYXqgp8rilBckIvNRs22yAXHKcXb86/g+F+hsTZl38OJintTsLQB//O5v6EQTYhSW7T3wMe1NHDrjZ+hFjAy4Q==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.178.0.tgz",
+          "integrity": "sha512-p3n3IzU03eRzZivEoQn1HA83LbAKukZwRevsJpya1UfCUtWkXQO3v0jU8rhZE4deGa9k7zuCAEmJ8nCw3QxclQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.178.0.tgz",
+          "integrity": "sha512-EFc9S63iwCmudVpVSiVPiTnp6WCfsRYUmTrZJJouZzthEhJwcrunwu7Fa9lHYb0zcWLgVFLhzs1Z34J/Er4JoQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.178.0.tgz",
+          "integrity": "sha512-k4jnB+ryGiAhv6vyNFz2YoaVodldjkbz4mqDlVzhwEn77LT/TcwdBoown3cJD/45LEtiuPqeONoTcNCsuCkRFQ==",
+          "requires": {
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.178.0.tgz",
+          "integrity": "sha512-dVgSoP2Mer8A0JGaWgpC/f4vPyvHh7laES/u5sTy6RfwrR87oTx+uhKrc6eh+9NkMR2xdRyaNJAMIXwL5bsVzg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.178.0.tgz",
+          "integrity": "sha512-glBXpAqt+4KQ7q8y2/kwDX2ujCvCSQok5rlAmUjaQjVPc3cX77QwATIRQTS2nBC4v9tfMc7yL64ZeRbx6n0RAQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.178.0",
+            "@aws-sdk/service-error-classification": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "@aws-sdk/util-middleware": "3.178.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.179.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.179.0.tgz",
+          "integrity": "sha512-uU9UdG9ornvblXdLLNsZNpgMOA9vgFMB93zo3DL/Q6MPmYprZYyK7dUiA06i1pe4HP2gR3N3hxXwzmKU6Bjt6A==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.179.0",
+            "@aws-sdk/property-provider": "3.178.0",
+            "@aws-sdk/protocol-http": "3.178.0",
+            "@aws-sdk/signature-v4": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.178.0.tgz",
+          "integrity": "sha512-TERiu/B4hYi5Jd4iQN9ECTWbt2IZweAgFB010MboM4CAPm6EcszEc/uCB4faLZNdJaksk1BhAR7koURcda8Sew==",
+          "requires": {
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.179.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.179.0.tgz",
+          "integrity": "sha512-rtB6t3w1Km3ngO1yoiEUqsobujcBk36oPs2fTUKTbmuTr+54YH3NF0zAwVJv08lpfAs56holtp+bYyAxZJIxSQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.178.0",
+            "@aws-sdk/protocol-http": "3.178.0",
+            "@aws-sdk/signature-v4": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "@aws-sdk/util-middleware": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.178.0.tgz",
+          "integrity": "sha512-ELYM5Imhlcz2zT1Z4OjVZwO564KvI4L9dMBxuUgO0fwommzjWqxR03yaRGhpGwpCP64d0Op5Koc/RKq5V92Wbw==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.178.0.tgz",
+          "integrity": "sha512-xkKBxrFbs+UwUPpfIGEPuHeBWS2Jgmcd+ipEJUQRR3lY4h1fJ6mPGeyyaVDvwaJp9KgESSI6QTp6V15l8GXXgQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.178.0.tgz",
+          "integrity": "sha512-yb5XJcC7SxkZ5oxu3zQ/foBdMkLBKryzx/CVg5BNSsKDjfbouf/ZYPcJDHhc2gzCtZcx18GjFBOnv8cpo/tyXQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.178.0",
+            "@aws-sdk/shared-ini-file-loader": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.178.0.tgz",
+          "integrity": "sha512-EtH6YiX1IX0QraQ/+kKBWAEtsFYBnFyxOimTBtlpDYwFpgDzIZ1GFn2wORYomEWALg10kphs8n3E5/7b5t5OWQ==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.178.0",
+            "@aws-sdk/protocol-http": "3.178.0",
+            "@aws-sdk/querystring-builder": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.178.0.tgz",
+          "integrity": "sha512-+Fh1aUANa+Gt/rh4SUHO0yHwKsibyZGk2LLDUcM1+9r0pUZT0qy3h0UCl5Kkj9HUcDJMD73wHTx4UB440xRobw==",
+          "requires": {
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.178.0.tgz",
+          "integrity": "sha512-GsnANW60mVYMlE16UGNSOwYZ6TbkoODvmDQi95SEPjM7asf4vihEyDvhxiGS/JvC18UyxRVWT89l/V3hR/SF7w==",
+          "requires": {
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.178.0.tgz",
+          "integrity": "sha512-vJXlExSshlHtGVvan/U6JihWvzf8t9QwH5I4F6HUY+exxMy5vFDYCnNqGAzbJwq7w/HME1gQWLoXq2k0uODz7g==",
+          "requires": {
+            "@aws-sdk/types": "3.178.0",
+            "@aws-sdk/util-uri-escape": "3.170.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.178.0.tgz",
+          "integrity": "sha512-dp3pLnsOvAcIF7Yn2PY5CIVWX7GvC33nSlWDYeLeCMapccwTbe6zBqreWbScmIGJra4QJTdjccpwo2Yxwhr5QQ==",
+          "requires": {
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.178.0.tgz",
+          "integrity": "sha512-tDKTBXxck2N4bhAnQaeokx9ps38V3G70lcDdHS/N9hmqcQQmH5x+1/AMwYWLjUZmOQPBW9sFoG4B3psnl+sefw=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.178.0.tgz",
+          "integrity": "sha512-nZGmuhGLDFbXsb7QYDg7PiPMAmsdlSshKJ+AhKSZF/J0SK94kdZgGnGXGUZe52S3G41E3CZIgnLnnsMXq0uErA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.178.0.tgz",
+          "integrity": "sha512-8oOx6o0uOqlCDPM0dszfR1WHqd0E1VuFqez8iNItp0DhmhaCuanEwKYYA6HOkVu/MA6CsG6zDIJaFr5ODU2NvQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.170.0",
+            "@aws-sdk/types": "3.178.0",
+            "@aws-sdk/util-hex-encoding": "3.170.0",
+            "@aws-sdk/util-middleware": "3.178.0",
+            "@aws-sdk/util-uri-escape": "3.170.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.178.0.tgz",
+          "integrity": "sha512-y2uAL3VMKIMZ/6kRAeL/vlIN4qrnmsfYhihm0yYhetdHtaXAN3WRsOpxOEjO3T92KmtQxMvtmRoAN05aVwtgoQ==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.178.0.tgz",
+          "integrity": "sha512-CrHxHzXSEr/Z3NLFvJgSGHGcD9tYUZ0Rhp8tFCSpD3TpBo3/Y7RIvqaEPvECsL52UEloeBhQf65AO8590YkVmQ=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.178.0.tgz",
+          "integrity": "sha512-+Ch29d+IZG6zD1gNDVgFC00huY8ytrPdijAuNJ4DtPBTGP4zbrImw3js0GfvfBjLrQYBnclcAvSx4J1Q/8tqBQ==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.170.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.170.0.tgz",
+          "integrity": "sha512-uLP9Kp74+jc+UWI392LSWIaUj9eXZBhkAiSm8dXAyrr+5GFOKvmEdidFoZKKcFcZ2v3RMonDgFVcDBiZ33w7BQ==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.170.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.170.0.tgz",
+          "integrity": "sha512-sjpOmfyW0RWCLXU8Du0ZtwgFoxIuKQIyVygXJ4qxByoa3jIUJXf4U33uSRMy47V3JoogdZuKSpND9hiNk2wU4w==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.170.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.170.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.170.0.tgz",
+          "integrity": "sha512-SqSWA++gsZgHw6tlcEXx9K6R6cVKNYzOq6bca+NR7jXvy1hfqiv9Gx5TZrG4oL4JziP8QA0fTklmI1uQJ4HBRA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.170.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.170.0.tgz",
+          "integrity": "sha512-sFb85ngsgfpamwDn22LC/+FkbDTNiddbMHptkajw+CAD2Rb4SJDp2PfXZ6k883BueJWhmxZ9+lApHZqYtgPdzw==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.170.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.170.0.tgz",
+          "integrity": "sha512-3ClE3wgN/Zw0ahfVAY5KQ/y3K2c+SYHwVUQaGSuVQlPOCDInGYjE/XEFwCeGJzncRPHIKDRPEsHCpm1uwgwEqQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.170.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.170.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.170.0.tgz",
+          "integrity": "sha512-VV6lfss6Go00TF2hRVJnN8Uf2FOwC++1e8glaeU7fMWluYCBjwl+116mPOPFaxvkJCg0dui2tFroXioslM/rvQ==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.178.0.tgz",
+          "integrity": "sha512-XssMIemfTOA3Pat+xRtCPUF6Irh05HJ3H9VEI3CJSMEduM0DCDKf7hbc9rp8Y/s/WTSJpa2Ag3JJ50dy2YGCqA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.178.0.tgz",
+          "integrity": "sha512-GChdZiWC1gLC2BY4pkyFLw6/3fgtCv1uUaCuA6fWLo8doDBKi1D4Rhgkg3sYgtC3M2C042zMNmyGdiSywT0SXg==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.178.0",
+            "@aws-sdk/credential-provider-imds": "3.178.0",
+            "@aws-sdk/node-config-provider": "3.178.0",
+            "@aws-sdk/property-provider": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.170.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.170.0.tgz",
+          "integrity": "sha512-BDYyMqaxX4/N7rYOIYlqgpZaBuHw3kNXKgOkWtJdzndIZbQX8HnyJ+rF0Pr1aVsOpVDM+fY1prERleFh/ZRTCg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.178.0.tgz",
+          "integrity": "sha512-93WgrJKuwtv3f2r1Q04emzjMiwpYR5hysOHKMkrGOvAVZdDqe1UTjmtuxQadVi3DBr1KOT/d5uP9MjV8LqaUUA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.170.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.170.0.tgz",
+          "integrity": "sha512-Fof0urZ3Lx6z6LNKSEO6T4DNaNh6sLJaSWFaC6gtVDPux/C3R7wy2RQRDp0baHxE8m1KMB0XnKzHizJNrbDI1w==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.178.0.tgz",
+          "integrity": "sha512-LxOrn7Ai88n0i5J5rTb5Bt0TAycPvDYzjdCwmd2mahsPHZGSDLeCeh6KOIxZsEfnzYRl4HGWvIEXdHIYZ3RTug==",
+          "requires": {
+            "@aws-sdk/types": "3.178.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.178.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.178.0.tgz",
+          "integrity": "sha512-TrP6v+V4Qnv3E9CNgwR/G+1xiy8fa9j5LAm43qwp9PfJHchNyWOJ0FURD3Ne2sm/388Ybzjb1DRYRZ7B+xbnOw==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.178.0",
+            "@aws-sdk/types": "3.178.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.170.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.170.0.tgz",
+          "integrity": "sha512-tJby9krepSwDsBK+KQF5ACacZQ4LH1Aheh5Dy0pghxsN/9IRw7kMWTumuRCnSntLFFphDD7GM494/Dvnl1UCLA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.170.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.170.0.tgz",
+          "integrity": "sha512-52QWGNoNQoyT2CuoQz6LjBKxHQtN/ceMFLW+9J1E0I1ni8XTuTYP52BlMe5484KkmZKsHOm+EWe4xuwwVetTxg==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.170.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
     "@aws-sdk/client-secrets-manager": {
       "version": "3.24.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.24.0.tgz",
@@ -4793,9 +5494,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -5936,14 +6637,14 @@
       }
     },
     "degenerator": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-3.0.1.tgz",
-      "integrity": "sha512-LFsIFEeLPlKvAKXu7j3ssIG6RT0TbI7/GhsqrI0DnHASEQjXQ0LUSYcjJteGgRGmZbl1TnMSxpNQIAiJ7Du5TQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-3.0.2.tgz",
+      "integrity": "sha512-c0mef3SNQo56t6urUU6tdQAs+ThoD0o9B9MJ8HEt7NQcGEILCRFqQb7ZbP9JAv+QF1Ky5plydhMR/IrqWDm+TQ==",
       "requires": {
         "ast-types": "^0.13.2",
         "escodegen": "^1.8.1",
         "esprima": "^4.0.0",
-        "vm2": "^3.9.3"
+        "vm2": "^3.9.8"
       }
     },
     "delay": {
@@ -7387,7 +8088,7 @@
     "ftp": {
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
-      "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+      "integrity": "sha512-faFVML1aBx2UoDStmLwv2Wptt4vw5x03xxX172nhA5Y5HBshW5JweqQ2W4xL4dezQTG8inJsuYcpPHHU3X5OTQ==",
       "requires": {
         "readable-stream": "1.1.x",
         "xregexp": "2.0.0"
@@ -7396,12 +8097,12 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
         },
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -7412,7 +8113,7 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
         }
       }
     },
@@ -7542,9 +8243,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -10251,7 +10952,7 @@
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -10262,7 +10963,7 @@
     "lodash.find": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
+      "integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg=="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -10277,12 +10978,12 @@
     "lodash.isempty": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg=="
     },
     "lodash.iserror": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.iserror/-/lodash.iserror-3.1.1.tgz",
-      "integrity": "sha1-KXuaBfq2cUvCRE18wZ0dfES17Ow="
+      "integrity": "sha512-eT/VeNns9hS7vAj1NKW/rRX6b+C3UX3/IAAqEE7aC4Oo2C0iD82NaP5IS4bSlQsammTii4qBJ8G1zd1LTL8hCw=="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
@@ -11382,9 +12083,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -11397,13 +12098,13 @@
       }
     },
     "pac-resolver": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-5.0.0.tgz",
-      "integrity": "sha512-H+/A6KitiHNNW+bxBKREk2MCGSxljfqRX76NjummWEYIat7ldVXRU3dhRIE3iXZ0nvGBk6smv3nntxKkzRL8NA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-5.0.1.tgz",
+      "integrity": "sha512-cy7u00ko2KVgBAjuhevqpPeHIkCIqPe1v24cydhWjmeuzaBfmUWFCZJ1iAh5TuVzVZoUzXIW7K8sMYOZ84uZ9Q==",
       "requires": {
-        "degenerator": "^3.0.1",
+        "degenerator": "^3.0.2",
         "ip": "^1.1.5",
-        "netmask": "^2.0.1"
+        "netmask": "^2.0.2"
       }
     },
     "packet-reader": {
@@ -11759,9 +12460,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -12358,12 +13059,19 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
     "socks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
+      "integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
       "requires": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.1.0"
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      },
+      "dependencies": {
+        "ip": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+          "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+        }
       }
     },
     "socks-proxy-agent": {
@@ -12377,9 +13085,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -13433,18 +14141,18 @@
       }
     },
     "vm2": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.7.tgz",
-      "integrity": "sha512-g/GZ7V0Mlmch3eDVOATvAXr1GsJNg6kQ5PjvYy3HbJMCRn5slNbo/u73Uy7r5yUej1cRa3ZjtoVwcWSQuQ/fow==",
+      "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.11.tgz",
+      "integrity": "sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==",
       "requires": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
         },
         "acorn-walk": {
           "version": "8.2.0",
@@ -13554,9 +14262,9 @@
       }
     },
     "winston-cloudwatch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/winston-cloudwatch/-/winston-cloudwatch-3.1.0.tgz",
-      "integrity": "sha512-zwkuZTFk5nybf42JAp1RGtfCnyGhPDFR3oMbl3BMFgt/a/TD30GAtzZqjvqZOlhB23gtNhC4+YIZySsozVCWCg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/winston-cloudwatch/-/winston-cloudwatch-6.1.1.tgz",
+      "integrity": "sha512-5wOJhAYRU3s6I1t/XO1/3tHJLhzvUUNNxcdbAjhDbyaKnghgKHrRtoQPXO2qTlWOTdhoXS0nJqV/L3RaBBuv3A==",
       "requires": {
         "async": "^3.1.0",
         "chalk": "^4.0.0",
@@ -13783,7 +14491,7 @@
     "xregexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
+      "integrity": "sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11528,9 +11528,9 @@
       "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moment-timezone": {
       "version": "0.5.35",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-amplify": "^3.112.0",
+    "@aws-sdk/client-cloudwatch-logs": "^3.179.0",
     "@aws-sdk/client-secrets-manager": "^3.24.0",
     "@octokit/rest": "^18.12.0",
     "@opengovsg/formsg-sdk": "^0.9.0",
@@ -72,7 +73,7 @@
     "uuid": "^3.3.3",
     "validator": "^13.6.0",
     "winston": "^3.3.3",
-    "winston-cloudwatch": "^3.1.0",
+    "winston-cloudwatch": "^6.1.1",
     "yaml": "^1.10.2"
   },
   "devDependencies": {

--- a/src/logger/logger.js
+++ b/src/logger/logger.js
@@ -5,7 +5,7 @@ const Bluebird = require("bluebird")
 const moment = require("moment-timezone")
 // Logging tools
 const winston = require("winston")
-const WinstonCloudWatch = require("winston-cloudwatch")
+const WinstonCloudwatch = require("winston-cloudwatch")
 
 // Env vars
 const { NODE_ENV } = process.env
@@ -66,7 +66,7 @@ class CloudWatchLogger {
           handleExceptions: true,
         }
 
-        this._logger.add(new WinstonCloudWatch(cloudwatchConfig))
+        this._logger.add(new WinstonCloudwatch(cloudwatchConfig))
       } catch (err) {
         console.error(`${timestampGenerator()} ${err.message}`)
         console.error(


### PR DESCRIPTION
This PR runs `npm audit fix` and additionally upgrades some outdated packages to resolve vulnerabilities (`winston-cloudwatch` to upgrade `vm2`, and `moment`)