### PR TITLE
feat(rr): db migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prepare": "husky install",
     "version": "auto-changelog -p && git add CHANGELOG.md",
     "db:migrate": "source .env && npx sequelize-cli db:migrate",
+    "db:migrate:undo": "source .env && npx sequelize-cli db:migrate:undo", 
     "jump:staging": "source .ssh/.env.staging && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/isomercms-staging-bastion.pem",
     "db:migrate:staging": "source .ssh/.env.staging && npx sequelize-cli db:migrate",
     "jump:prod": "source .ssh/.env.prod && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/isomercms-production-bastion.pem",

--- a/src/database/migrations/20221003052424-review-request-creation.js
+++ b/src/database/migrations/20221003052424-review-request-creation.js
@@ -1,0 +1,32 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("review_requests", {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.BIGINT,
+      },
+      requestor_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: "users",
+          key: "id",
+        },
+      },
+      site_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: "sites",
+          key: "id",
+        },
+      },
+    })
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable("review_requests")
+  },
+}

--- a/src/database/migrations/20221003052424-review-request-creation.js
+++ b/src/database/migrations/20221003052424-review-request-creation.js
@@ -6,6 +6,7 @@ module.exports = {
         allowNull: false,
         primaryKey: true,
         type: Sequelize.BIGINT,
+        autoIncrement: true,
       },
       requestor_id: {
         type: Sequelize.BIGINT,
@@ -22,6 +23,16 @@ module.exports = {
           model: "sites",
           key: "id",
         },
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("NOW"),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("NOW"),
       },
     })
   },

--- a/src/database/migrations/20221003123422-review-meta-creation.js
+++ b/src/database/migrations/20221003123422-review-meta-creation.js
@@ -5,6 +5,7 @@ module.exports = {
       id: {
         allowNull: false,
         primaryKey: true,
+        autoIncrement: true,
         type: Sequelize.BIGINT,
       },
       review_id: {
@@ -25,6 +26,16 @@ module.exports = {
         unique: true,
         type: Sequelize.STRING,
         allowNull: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("NOW"),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("NOW"),
       },
     })
   },

--- a/src/database/migrations/20221003123422-review-meta-creation.js
+++ b/src/database/migrations/20221003123422-review-meta-creation.js
@@ -1,0 +1,35 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("review_meta", {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.BIGINT,
+      },
+      review_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: "review_requests",
+          key: "id",
+        },
+      },
+      // The PR number stored by GitHub
+      pull_request_number: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+      },
+      // The link to view this RR
+      review_link: {
+        unique: true,
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+    })
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable("review_meta")
+  },
+}

--- a/src/database/migrations/20221003130006-reviewer-creation.js
+++ b/src/database/migrations/20221003130006-reviewer-creation.js
@@ -24,6 +24,16 @@ module.exports = {
         onUpdate: "CASCADE",
         onDelete: "CASCADE",
       },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("NOW"),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn("NOW"),
+      },
     })
   },
 

--- a/src/database/migrations/20221003130006-reviewer-creation.js
+++ b/src/database/migrations/20221003130006-reviewer-creation.js
@@ -1,0 +1,33 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable("reviewers", {
+      request_id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.BIGINT,
+        references: {
+          model: "review_requests",
+          key: "id",
+        },
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+      },
+      reviewer_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: "users",
+          key: "id",
+        },
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+      },
+    })
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.dropTable("reviewers")
+  },
+}

--- a/src/database/migrations/20221007124138-create-review-status.js
+++ b/src/database/migrations/20221007124138-create-review-status.js
@@ -1,0 +1,30 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) =>
+    queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn(
+        "review_requests", // name of Source model
+        "review_status", // name of column we're adding
+        {
+          type: Sequelize.ENUM,
+          values: ["OPEN", "MERGED", "CLOSED", "APPROVED"],
+          allowNull: false,
+          defaultValue: "OPEN",
+          transaction: t,
+        }
+      )
+    }),
+
+  down: async (queryInterface, _) =>
+    queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColumn(
+        "review_requests", // name of Source Model
+        "review_status", // name of column we want to remove
+        { transaction: t }
+      )
+      // drop created enum
+      await queryInterface.sequelize.query(
+        "drop type enum_review_requests_review_status;",
+        { transaction: t }
+      )
+    }),
+}

--- a/src/routes/v2/auth.js
+++ b/src/routes/v2/auth.js
@@ -7,8 +7,6 @@ const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
 const { FRONTEND_URL } = process.env
 const { isSecure } = require("@utils/auth-utils")
 
-const { AuthError } = require("@errors/AuthError")
-
 const AUTH_TOKEN_EXPIRY_MS = parseInt(
   process.env.AUTH_TOKEN_EXPIRY_DURATION_IN_MILLISECONDS,
   10

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -5,7 +5,6 @@ import logger from "@root/logger/logger"
 import DeploymentsService from "@services/identity/DeploymentsService"
 import ReposService from "@services/identity/ReposService"
 import SitesService from "@services/identity/SitesService"
-import UsersService from "@services/identity/UsersService"
 
 interface InfraServiceProps {
   sitesService: SitesService
@@ -30,12 +29,7 @@ export default class InfraService {
     this.deploymentsService = deploymentsService
   }
 
-  createSite = async (
-    submissionId: string,
-    creator: User,
-    siteName: string,
-    repoName: string
-  ) => {
+  createSite = async (creator: User, siteName: string, repoName: string) => {
     let site: Site | undefined // For error handling
     try {
       // 1. Create a new site record in the Sites table


### PR DESCRIPTION
## Problem
This PR adds the base db nigrations for review requests; it has some changes from the db schema listed [here](https://lucid.app/lucidchart/a1e55cbb-3938-4ba4-8a9a-2a2c9cdc7a64/edit?page=0_0#).

Related to 

## Solution
1. add migrations for `reviewers`, `reviewMeta` and `reviewRequest`
2. add a migration for undoing migrations (**locally only**) 