### PR TITLE
Feat/generic notification creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
       - run: npm run dev:services
-      - run: . .env.test && npx jest
+      - run: . .env.test && npx jest --runInBand
       - run: docker compose down
 
   gatekeep:

--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -1,0 +1,239 @@
+import express from "express"
+import request from "supertest"
+
+import { NotificationOnEditHandler } from "@middleware/notificationOnEditHandler"
+
+import UserSessionData from "@classes/UserSessionData"
+
+import {
+  Notification,
+  Repo,
+  Reviewer,
+  ReviewMeta,
+  ReviewRequest,
+  ReviewRequestView,
+  Site,
+  SiteMember,
+  User,
+  Whitelist,
+} from "@database/models"
+import { generateRouterForUserWithSite } from "@fixtures/app"
+import {
+  mockEmail,
+  mockIsomerUserId,
+  mockSiteName,
+} from "@fixtures/sessionData"
+import { GitHubService } from "@services/db/GitHubService"
+import * as ReviewApi from "@services/db/review"
+import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
+import { getUsersService, notificationsService } from "@services/identity"
+import CollaboratorsService from "@services/identity/CollaboratorsService"
+import IsomerAdminsService from "@services/identity/IsomerAdminsService"
+import SitesService from "@services/identity/SitesService"
+import ReviewRequestService from "@services/review/ReviewRequestService"
+import { sequelize } from "@tests/database"
+
+const mockSiteId = "1"
+const mockSiteMemberId = "1"
+
+const mockGithubService = {
+  getPullRequest: jest.fn(),
+  getComments: jest.fn(),
+}
+const usersService = getUsersService(sequelize)
+const reviewRequestService = new ReviewRequestService(
+  (mockGithubService as unknown) as typeof ReviewApi,
+  User,
+  ReviewRequest,
+  Reviewer,
+  ReviewMeta,
+  ReviewRequestView
+)
+const sitesService = new SitesService({
+  siteRepository: Site,
+  gitHubService: (mockGithubService as unknown) as GitHubService,
+  configYmlService: (jest.fn() as unknown) as ConfigYmlService,
+  usersService,
+  isomerAdminsService: (jest.fn() as unknown) as IsomerAdminsService,
+  reviewRequestService,
+})
+const collaboratorsService = new CollaboratorsService({
+  siteRepository: Site,
+  siteMemberRepository: SiteMember,
+  sitesService,
+  usersService,
+  whitelist: Whitelist,
+})
+
+const notificationsHandler = new NotificationOnEditHandler({
+  reviewRequestService,
+  collaboratorsService,
+  sitesService,
+  notificationsService,
+})
+
+// Set up express with defaults and use the router under test
+const router = express()
+const dummySubrouter = express()
+dummySubrouter.get("/:siteName/test", async (req, res, next) =>
+  // Dummy subrouter
+  next()
+)
+router.use(dummySubrouter)
+
+// We handle the test slightly differently - jest interprets the end of the test as when the response is sent,
+// but we normally create a notification after this response, due to the position of the middleware
+// the solution to get tests working is to send a response only after the notification middleware
+router.use(async (req, res, next) => {
+  // Inserts notification handler after all other subrouters
+  // Needs to be awaited so jest doesn't exit prematurely upon receiving response status
+  await notificationsHandler.createNotification(req as any, res as any, next)
+  res.status(200).send(200)
+})
+const userSessionData = new UserSessionData({
+  isomerUserId: mockIsomerUserId,
+  email: mockEmail,
+})
+const app = generateRouterForUserWithSite(router, userSessionData, mockSiteName)
+
+describe("Notifications Router", () => {
+  const mockAdditionalUserId = "2"
+  const mockAdditionalSiteId = "2"
+  const mockAdditionalSiteMemberId = "2"
+  const mockAnotherSiteMemberId = "3"
+
+  beforeAll(async () => {
+    // Mock github service return
+    mockGithubService.getPullRequest.mockResolvedValue({
+      title: "title",
+      body: "body",
+      changed_files: [],
+      created_at: new Date(),
+    })
+
+    // We need to force the relevant tables to start from a clean slate
+    // Otherwise, some tests may fail due to the auto-incrementing IDs
+    // not starting from 1
+    await User.sync({ force: true })
+    await Site.sync({ force: true })
+    await Repo.sync({ force: true })
+    await SiteMember.sync({ force: true })
+    await Notification.sync({ force: true })
+    await ReviewMeta.sync({ force: true })
+    await ReviewRequest.sync({ force: true })
+
+    // Set up User and Site table entries
+    await User.create({
+      id: mockIsomerUserId,
+    })
+    await User.create({
+      id: mockAdditionalUserId,
+    })
+    await Site.create({
+      id: mockSiteId,
+      name: mockSiteName,
+      apiTokenName: "token",
+      jobStatus: "READY",
+      siteStatus: "LAUNCHED",
+      creatorId: mockIsomerUserId,
+    })
+    await SiteMember.create({
+      userId: mockIsomerUserId,
+      siteId: mockSiteId,
+      role: "ADMIN",
+      id: mockSiteMemberId,
+    })
+    await Repo.create({
+      name: mockSiteName,
+      url: "url",
+      siteId: mockSiteId,
+    })
+    await SiteMember.create({
+      userId: mockAdditionalUserId,
+      siteId: mockSiteId,
+      role: "ADMIN",
+      id: mockAdditionalSiteMemberId,
+    })
+    await Site.create({
+      id: mockAdditionalSiteId,
+      name: "mockSite2",
+      apiTokenName: "token",
+      jobStatus: "READY",
+      siteStatus: "LAUNCHED",
+      creatorId: mockIsomerUserId,
+    })
+    await SiteMember.create({
+      userId: mockIsomerUserId,
+      siteId: mockAdditionalSiteId,
+      role: "ADMIN",
+      id: mockAnotherSiteMemberId,
+    })
+    await Repo.create({
+      name: `${mockSiteName}2`,
+      url: "url",
+      siteId: mockAdditionalSiteId,
+    })
+  })
+
+  afterAll(async () => {
+    await SiteMember.sync({ force: true })
+    await Site.sync({ force: true })
+    await User.sync({ force: true })
+    await Repo.sync({ force: true })
+  })
+
+  describe("createNotification handler", () => {
+    afterEach(async () => {
+      // Clean up so that different tests using
+      // the same notifications don't interfere with each other
+      await Notification.sync({ force: true })
+      await ReviewMeta.sync({ force: true })
+      await ReviewRequest.sync({ force: true })
+    })
+    it("should create a new notification when called", async () => {
+      // Arrange
+      await ReviewRequest.create({
+        id: 1,
+        requestorId: mockIsomerUserId,
+        siteId: mockSiteId,
+        reviewStatus: "OPEN",
+      })
+      await ReviewMeta.create({
+        reviewId: 1,
+        pullRequestNumber: 1,
+        reviewLink: "test",
+      })
+      mockGithubService.getComments.mockResolvedValueOnce([])
+
+      // Act
+      await request(app).get(`/${mockSiteName}/test`)
+
+      // Assert
+      // Notification should be sent to all site members other than the creator
+      expect(
+        (
+          await Notification.findAll({
+            where: {
+              userId: mockAdditionalUserId,
+              siteId: mockSiteId,
+              siteMemberId: mockAdditionalSiteMemberId,
+              firstReadTime: null,
+            },
+          })
+        ).length
+      ).toEqual(1)
+      expect(
+        (
+          await Notification.findAll({
+            where: {
+              userId: mockIsomerUserId,
+              siteId: mockSiteId,
+              siteMemberId: mockSiteMemberId,
+              firstReadTime: null,
+            },
+          })
+        ).length
+      ).toEqual(0)
+    })
+  })
+})

--- a/src/integration/Notifications.spec.ts
+++ b/src/integration/Notifications.spec.ts
@@ -4,6 +4,10 @@ import request from "supertest"
 import {
   Notification,
   Repo,
+  Reviewer,
+  ReviewMeta,
+  ReviewRequest,
+  ReviewRequestView,
   Site,
   SiteMember,
   User,
@@ -30,13 +34,15 @@ import { NotificationsRouter as _NotificationsRouter } from "@root/routes/v2/aut
 import { SitesRouter as _SitesRouter } from "@root/routes/v2/authenticated/sites"
 import { genericGitHubAxiosInstance } from "@root/services/api/AxiosInstance"
 import { GitHubService } from "@root/services/db/GitHubService"
+import { ConfigYmlService } from "@root/services/fileServices/YmlFileServices/ConfigYmlService"
 import CollaboratorsService from "@root/services/identity/CollaboratorsService"
+import SitesService from "@root/services/identity/SitesService"
+import ReviewRequestService from "@root/services/review/ReviewRequestService"
 import {
   getIdentityAuthService,
   getUsersService,
   isomerAdminsService,
   notificationsService,
-  sitesService,
 } from "@services/identity"
 import { sequelize } from "@tests/database"
 
@@ -44,11 +50,28 @@ const MOCK_SITE = "mockSite"
 const MOCK_SITE_ID = "1"
 const MOCK_SITE_MEMBER_ID = "1"
 
-const githubService = new GitHubService({
+const gitHubService = new GitHubService({
   axiosInstance: genericGitHubAxiosInstance,
 })
-const identityAuthService = getIdentityAuthService(githubService)
+const identityAuthService = getIdentityAuthService(gitHubService)
 const usersService = getUsersService(sequelize)
+const configYmlService = new ConfigYmlService({ gitHubService })
+const reviewRequestService = new ReviewRequestService(
+  gitHubService,
+  User,
+  ReviewRequest,
+  Reviewer,
+  ReviewMeta,
+  ReviewRequestView
+)
+const sitesService = new SitesService({
+  siteRepository: Site,
+  gitHubService,
+  configYmlService,
+  usersService,
+  isomerAdminsService,
+  reviewRequestService,
+})
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,
   siteMemberRepository: SiteMember,

--- a/src/integration/Notifications.spec.ts
+++ b/src/integration/Notifications.spec.ts
@@ -39,6 +39,7 @@ import { ConfigYmlService } from "@root/services/fileServices/YmlFileServices/Co
 import CollaboratorsService from "@root/services/identity/CollaboratorsService"
 import SitesService from "@root/services/identity/SitesService"
 import ReviewRequestService from "@root/services/review/ReviewRequestService"
+import * as ReviewApi from "@services/db/review"
 import {
   getIdentityAuthService,
   getUsersService,
@@ -58,7 +59,7 @@ const identityAuthService = getIdentityAuthService(gitHubService)
 const usersService = getUsersService(sequelize)
 const configYmlService = new ConfigYmlService({ gitHubService })
 const reviewRequestService = new ReviewRequestService(
-  gitHubService,
+  (gitHubService as unknown) as typeof ReviewApi,
   User,
   ReviewRequest,
   Reviewer,
@@ -109,6 +110,15 @@ describe("Notifications Router", () => {
   const MOCK_ANOTHER_SITE_MEMBER_ID = "3"
 
   beforeAll(async () => {
+    // We need to force the relevant tables to start from a clean slate
+    // Otherwise, some tests may fail due to the auto-incrementing IDs
+    // not starting from 1
+    await User.sync({ force: true })
+    await Site.sync({ force: true })
+    await Repo.sync({ force: true })
+    await SiteMember.sync({ force: true })
+    await Notification.sync({ force: true })
+
     // Set up User and Site table entries
     await User.create({
       id: mockIsomerUserId,

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -7,6 +7,7 @@ import { SitesRouter as _SitesRouter } from "@routes/v2/authenticated/sites"
 
 import {
   IsomerAdmin,
+  Notification,
   Repo,
   Reviewer,
   ReviewMeta,
@@ -70,8 +71,9 @@ import {
 import { ReviewRequestStatus } from "@root/constants"
 import { ReviewRequestDto } from "@root/types/dto/review"
 import { GitHubService } from "@services/db/GitHubService"
+import * as ReviewApi from "@services/db/review"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
-import { getUsersService } from "@services/identity"
+import { getUsersService, notificationsService } from "@services/identity"
 import CollaboratorsService from "@services/identity/CollaboratorsService"
 import IsomerAdminsService from "@services/identity/IsomerAdminsService"
 import SitesService from "@services/identity/SitesService"
@@ -83,7 +85,7 @@ const configYmlService = new ConfigYmlService({ gitHubService })
 const usersService = getUsersService(sequelize)
 const isomerAdminsService = new IsomerAdminsService({ repository: IsomerAdmin })
 const reviewRequestService = new ReviewRequestService(
-  gitHubService,
+  (gitHubService as unknown) as typeof ReviewApi,
   User,
   ReviewRequest,
   Reviewer,
@@ -110,7 +112,8 @@ const ReviewsRouter = new _ReviewsRouter(
   reviewRequestService,
   usersService,
   sitesService,
-  collaboratorsService
+  collaboratorsService,
+  notificationsService
 )
 const reviewsSubrouter = ReviewsRouter.getRouter()
 const subrouter = express()
@@ -136,6 +139,8 @@ describe("Review Requests Integration Tests", () => {
     await Site.sync({ force: true })
     await Repo.sync({ force: true })
     await SiteMember.sync({ force: true })
+    await Notification.sync({ force: true })
+    await ReviewMeta.sync({ force: true })
 
     await User.create(MOCK_USER_DBENTRY_ONE)
     await User.create(MOCK_USER_DBENTRY_TWO)

--- a/src/middleware/notificationOnEditHandler.ts
+++ b/src/middleware/notificationOnEditHandler.ts
@@ -55,15 +55,18 @@ export class NotificationOnEditHandler {
     if (reviewRequests.length === 0) return
     // For now, we only have 1 active review request
     const reviewRequest = reviewRequests[0]
-    users.forEach(async (user: User & { SiteMember: SiteMember }) => {
-      if (user.id.toString() === userId) return // Don't create notification for the source user
-      const { SiteMember: siteMember } = user
-      await this.notificationsService.create({
-        siteMember,
-        link: "TODO",
-        notificationType: "updated_request",
-        notificationSourceUsername: email,
+
+    await Promise.all(
+      users.map(async (user: User & { SiteMember: SiteMember }) => {
+        if (user.id.toString() === userId) return // Don't create notification for the source user
+        const { SiteMember: siteMember } = user
+        await this.notificationsService.create({
+          siteMember,
+          link: "TODO",
+          notificationType: "updated_request",
+          notificationSourceUsername: email,
+        })
       })
-    })
+    )
   }
 }

--- a/src/middleware/notificationOnEditHandler.ts
+++ b/src/middleware/notificationOnEditHandler.ts
@@ -1,0 +1,69 @@
+import autoBind from "auto-bind"
+
+import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
+import { SiteMember, User } from "@root/database/models"
+import CollaboratorsService from "@root/services/identity/CollaboratorsService"
+import NotificationsService from "@root/services/identity/NotificationsService"
+import SitesService from "@root/services/identity/SitesService"
+import ReviewRequestService from "@root/services/review/ReviewRequestService"
+import { RequestHandler } from "@root/types"
+
+export class NotificationOnEditHandler {
+  private readonly reviewRequestService: ReviewRequestService
+
+  private readonly sitesService: SitesService
+
+  private readonly collaboratorsService: CollaboratorsService
+
+  private readonly notificationsService: NotificationsService
+
+  constructor({
+    reviewRequestService,
+    sitesService,
+    collaboratorsService,
+    notificationsService,
+  }: {
+    reviewRequestService: ReviewRequestService
+    sitesService: SitesService
+    collaboratorsService: CollaboratorsService
+    notificationsService: NotificationsService
+  }) {
+    this.reviewRequestService = reviewRequestService
+    this.sitesService = sitesService
+    this.collaboratorsService = collaboratorsService
+    this.notificationsService = notificationsService
+    // We need to bind all methods because we don't invoke them from the class directly
+    autoBind(this)
+  }
+
+  createNotification: RequestHandler<
+    never,
+    unknown,
+    unknown,
+    never,
+    { userWithSiteSessionData: UserWithSiteSessionData }
+  > = async (req, res, next) => {
+    const { userWithSiteSessionData } = res.locals
+    const { siteName, isomerUserId: userId, email } = userWithSiteSessionData
+    const site = await this.sitesService.getBySiteName(siteName)
+    const users = await this.collaboratorsService.list(siteName, userId)
+    if (!site) throw new Error("Site should always exist")
+    const reviewRequests = await this.reviewRequestService.listReviewRequest(
+      userWithSiteSessionData,
+      site
+    )
+    if (reviewRequests.length === 0) return
+    // For now, we only have 1 active review request
+    const reviewRequest = reviewRequests[0]
+    users.forEach(async (user: User & { SiteMember: SiteMember }) => {
+      if (user.id.toString() === userId) return // Don't create notification for the source user
+      const { SiteMember: siteMember } = user
+      await this.notificationsService.create({
+        siteMember,
+        link: "TODO",
+        notificationType: "updated_request",
+        notificationSourceUsername: email,
+      })
+    })
+  }
+}

--- a/src/middleware/notificationOnEditHandler.ts
+++ b/src/middleware/notificationOnEditHandler.ts
@@ -56,6 +56,8 @@ export class NotificationOnEditHandler {
       site
     )
     if (reviewRequests.length === 0) return
+    // For now, we only have 1 active review request
+    const reviewRequest = reviewRequests[0]
 
     await Promise.all(
       users.map(async (user: User & { SiteMember: SiteMember }) => {
@@ -63,7 +65,7 @@ export class NotificationOnEditHandler {
         const { SiteMember: siteMember } = user
         await this.notificationsService.create({
           siteMember,
-          link: "TODO",
+          link: `/sites/${siteName}/review/${reviewRequest.id}`,
           notificationType: "updated_request",
           notificationSourceUsername: email,
         })

--- a/src/middleware/notificationOnEditHandler.ts
+++ b/src/middleware/notificationOnEditHandler.ts
@@ -36,6 +36,9 @@ export class NotificationOnEditHandler {
     autoBind(this)
   }
 
+  /**
+   * Creates a notification. Requires attachSiteHandler as a precondition
+   */
   createNotification: RequestHandler<
     never,
     unknown,
@@ -53,8 +56,6 @@ export class NotificationOnEditHandler {
       site
     )
     if (reviewRequests.length === 0) return
-    // For now, we only have 1 active review request
-    const reviewRequest = reviewRequests[0]
 
     await Promise.all(
       users.map(async (user: User & { SiteMember: SiteMember }) => {

--- a/src/middleware/routeHandler.js
+++ b/src/middleware/routeHandler.js
@@ -24,7 +24,7 @@ const attachWriteRouteHandlerWrapper = (routeHandler) => async (
 ) => {
   const { siteName } = req.params
   await lock(siteName)
-  routeHandler(req, res).catch(async (err) => {
+  routeHandler(req, res, next).catch(async (err) => {
     await unlock(siteName)
     next(err)
   })
@@ -61,7 +61,7 @@ const attachRollbackRouteHandlerWrapper = (routeHandler) => async (
     await unlock(siteName)
     next(err)
   }
-  routeHandler(req, res).catch(async (err) => {
+  routeHandler(req, res, next).catch(async (err) => {
     try {
       await backOff(() =>
         revertCommit(originalCommitSha, siteName, accessToken)

--- a/src/routes/v2/authenticated/__tests__/Notifications.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/Notifications.spec.ts
@@ -3,10 +3,9 @@ import request from "supertest"
 
 import { attachReadRouteHandlerWrapper } from "@middleware/routeHandler"
 
-import { NotificationsRouter as _NotificationsRouter } from "@routes/v2/authenticatedSites/notifications"
-
 import { generateRouter } from "@fixtures/app"
 import { mockSiteName, mockIsomerUserId } from "@fixtures/sessionData"
+import { NotificationsRouter as _NotificationsRouter } from "@root/routes/v2/authenticated/notifications"
 import NotificationsService from "@services/identity/NotificationsService"
 
 describe("Notifications Router", () => {

--- a/src/routes/v2/authenticated/__tests__/Notifications.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/Notifications.spec.ts
@@ -5,6 +5,7 @@ import { attachReadRouteHandlerWrapper } from "@middleware/routeHandler"
 
 import { generateRouter } from "@fixtures/app"
 import { mockSiteName, mockIsomerUserId } from "@fixtures/sessionData"
+import { AuthorizationMiddleware } from "@root/middleware/authorization"
 import { NotificationsRouter as _NotificationsRouter } from "@root/routes/v2/authenticated/notifications"
 import NotificationsService from "@services/identity/NotificationsService"
 
@@ -14,9 +15,13 @@ describe("Notifications Router", () => {
     listAll: jest.fn(),
     markNotificationsAsRead: jest.fn(),
   }
+  const mockAuthorizationMiddleware = {
+    verifySiteMember: jest.fn(),
+  }
 
   const NotificationsRouter = new _NotificationsRouter({
     notificationsService: (mockNotificationsService as unknown) as NotificationsService,
+    authorizationMiddleware: (mockAuthorizationMiddleware as unknown) as AuthorizationMiddleware,
   })
 
   const subrouter = express()

--- a/src/routes/v2/authenticated/index.js
+++ b/src/routes/v2/authenticated/index.js
@@ -1,5 +1,7 @@
 import { attachSiteHandler } from "@root/middleware"
 
+import { NotificationsRouter } from "./notifications"
+
 const express = require("express")
 
 const {
@@ -18,6 +20,7 @@ const getAuthenticatedSubrouter = ({
   collaboratorsService,
   authorizationMiddleware,
   reviewRouter,
+  notificationsService,
 }) => {
   const netlifyTomlService = new NetlifyTomlService()
 
@@ -31,6 +34,10 @@ const getAuthenticatedSubrouter = ({
   })
   const usersRouter = new UsersRouter({ usersService })
   const netlifyTomlV2Router = new NetlifyTomlRouter({ netlifyTomlService })
+  const notificationsRouter = new NotificationsRouter({
+    authorizationMiddleware,
+    notificationsService,
+  })
 
   const authenticatedSubrouter = express.Router({ mergeParams: true })
 
@@ -47,6 +54,10 @@ const getAuthenticatedSubrouter = ({
     reviewRouter.getRouter()
   )
   authenticatedSubrouter.use("/sites", sitesRouterWithReviewRequest)
+  authenticatedSubrouter.use(
+    "/sites/:siteName/notifications",
+    notificationsRouter.getRouter()
+  )
   authenticatedSubrouter.use("/user", usersRouter.getRouter())
   authenticatedSubrouter.use("/netlify-toml", netlifyTomlV2Router.getRouter())
 

--- a/src/routes/v2/authenticated/notifications.ts
+++ b/src/routes/v2/authenticated/notifications.ts
@@ -7,6 +7,8 @@ import {
 } from "@middleware/routeHandler"
 
 import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
+import { attachSiteHandler } from "@root/middleware"
+import { AuthorizationMiddleware } from "@root/middleware/authorization"
 import { RequestHandler } from "@root/types"
 import NotificationsService, {
   NotificationResponse,
@@ -14,14 +16,21 @@ import NotificationsService, {
 
 interface NotificationsRouterProps {
   notificationsService: NotificationsService
+  authorizationMiddleware: AuthorizationMiddleware
 }
 
 // eslint-disable-next-line import/prefer-default-export
 export class NotificationsRouter {
   private readonly notificationsService
 
-  constructor({ notificationsService }: NotificationsRouterProps) {
+  private readonly authorizationMiddleware
+
+  constructor({
+    notificationsService,
+    authorizationMiddleware,
+  }: NotificationsRouterProps) {
     this.notificationsService = notificationsService
+    this.authorizationMiddleware = authorizationMiddleware
     autoBind(this)
   }
 
@@ -78,6 +87,8 @@ export class NotificationsRouter {
 
   getRouter() {
     const router = express.Router({ mergeParams: true })
+    router.use(attachSiteHandler)
+    router.use(this.authorizationMiddleware.verifySiteMember)
 
     router.get("/", attachReadRouteHandlerWrapper(this.getRecentNotifications))
     router.get(

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -943,7 +943,6 @@ export class ReviewsRouter {
     }
 
     // Step 4: Check if the user is a reviewer of the RR
-    const { userWithSiteSessionData } = res.locals
     const { reviewers } = possibleReviewRequest
     const isReviewer = _.some(
       reviewers,

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -720,6 +720,22 @@ export class ReviewsRouter {
     // as the underlying Github API returns 404 if
     // the requested review could not be found.
     await this.reviewRequestService.approveReviewRequest(possibleReviewRequest)
+
+    // Step 6: Create notifications
+    const collaborators = await this.collaboratorsService.list(siteName)
+    await Promise.all(
+      collaborators.map(async (user: User & { SiteMember: SiteMember }) => {
+        // Don't send notification to self
+        if (user.id.toString() === userWithSiteSessionData.isomerUserId) return
+        await this.notificationsService.create({
+          siteMember: user.SiteMember,
+          link: `/sites/${siteName}/review/${requestId}`,
+          notificationType: "request_approved",
+          notificationSourceUsername: userWithSiteSessionData.email,
+        })
+      })
+    )
+
     return res.status(200).send()
   }
 
@@ -938,44 +954,6 @@ export class ReviewsRouter {
       userWithSiteSessionData,
       site,
       possibleReviewRequest
-    )
-
-    if (isIsomerError(possibleReviewRequest)) {
-      return res.status(404).json({ message: possibleReviewRequest.message })
-    }
-
-    // Step 4: Check if the user is a reviewer of the RR
-    const { reviewers } = possibleReviewRequest
-    const isReviewer = _.some(
-      reviewers,
-      (user) => user.email === userWithSiteSessionData.email
-    )
-
-    if (!isReviewer) {
-      return res.status(401).json({
-        message: "Only reviewers can approve Review Requests!",
-      })
-    }
-
-    // Step 5: Approve review request
-    // NOTE: We are not checking for existence of PR
-    // as the underlying Github API returns 404 if
-    // the requested review could not be found.
-    await this.reviewRequestService.approveReviewRequest(possibleReviewRequest)
-
-    // Step 6: Create notifications
-    const collaborators = await this.collaboratorsService.list(siteName)
-    await Promise.all(
-      collaborators.map(async (user: User & { SiteMember: SiteMember }) => {
-        // Don't send notification to self
-        if (user.id.toString() === userWithSiteSessionData.isomerUserId) return
-        await this.notificationsService.create({
-          siteMember: user.SiteMember,
-          link: `/sites/${siteName}/review/${requestId}`,
-          notificationType: "request_approved",
-          notificationSourceUsername: userWithSiteSessionData.email,
-        })
-      })
     )
 
     return res.status(200).send()

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -194,19 +194,21 @@ export class ReviewsRouter {
     )
 
     // Step 5: Create notifications
-    collaborators.forEach(async (user: User & { SiteMember: SiteMember }) => {
-      // Don't send notification to self
-      if (user.id.toString() === userWithSiteSessionData.isomerUserId) return
-      const notificationType = reviewersMap[user.email || ""]
-        ? "sent_request"
-        : "request_created"
-      await this.notificationsService.create({
-        siteMember: user.SiteMember,
-        link: "TODO",
-        notificationType,
-        notificationSourceUsername: userWithSiteSessionData.email,
+    await Promise.all(
+      collaborators.map(async (user: User & { SiteMember: SiteMember }) => {
+        // Don't send notification to self
+        if (user.id.toString() === userWithSiteSessionData.isomerUserId) return
+        const notificationType = reviewersMap[user.email || ""]
+          ? "sent_request"
+          : "request_created"
+        await this.notificationsService.create({
+          siteMember: user.SiteMember,
+          link: `/sites/${siteName}/review/${pullRequestNumber}`,
+          notificationType,
+          notificationSourceUsername: userWithSiteSessionData.email,
+        })
       })
-    })
+    )
 
     return res.status(200).send({
       pullRequestNumber,
@@ -963,16 +965,18 @@ export class ReviewsRouter {
 
     // Step 6: Create notifications
     const collaborators = await this.collaboratorsService.list(siteName)
-    collaborators.forEach(async (user: User & { SiteMember: SiteMember }) => {
-      // Don't send notification to self
-      if (user.id.toString() === userWithSiteSessionData.isomerUserId) return
-      await this.notificationsService.create({
-        siteMember: user.SiteMember,
-        link: "TODO",
-        notificationType: "request_approved",
-        notificationSourceUsername: userWithSiteSessionData.email,
+    await Promise.all(
+      collaborators.map(async (user: User & { SiteMember: SiteMember }) => {
+        // Don't send notification to self
+        if (user.id.toString() === userWithSiteSessionData.isomerUserId) return
+        await this.notificationsService.create({
+          siteMember: user.SiteMember,
+          link: `/sites/${siteName}/review/${requestId}`,
+          notificationType: "request_approved",
+          notificationSourceUsername: userWithSiteSessionData.email,
+        })
       })
-    })
+    )
 
     return res.status(200).send()
   }
@@ -1057,16 +1061,18 @@ export class ReviewsRouter {
 
     // Step 7: Create notifications
     const collaborators = await this.collaboratorsService.list(siteName)
-    collaborators.forEach(async (user: User & { SiteMember: SiteMember }) => {
-      // Don't send notification to self
-      if (user.id.toString() === userWithSiteSessionData.isomerUserId) return
-      await this.notificationsService.create({
-        siteMember: user.SiteMember,
-        link: "TODO",
-        notificationType: "request_cancelled",
-        notificationSourceUsername: userWithSiteSessionData.email,
+    await Promise.all(
+      collaborators.map(async (user: User & { SiteMember: SiteMember }) => {
+        // Don't send notification to self
+        if (user.id.toString() === userWithSiteSessionData.isomerUserId) return
+        await this.notificationsService.create({
+          siteMember: user.SiteMember,
+          link: `/sites/${siteName}/review/${requestId}`,
+          notificationType: "request_cancelled",
+          notificationSourceUsername: userWithSiteSessionData.email,
+        })
       })
-    })
+    )
     return res.status(200).send()
   }
 

--- a/src/routes/v2/authenticatedSites/collectionPages.js
+++ b/src/routes/v2/authenticatedSites/collectionPages.js
@@ -24,7 +24,7 @@ class CollectionPagesRouter {
   }
 
   // Create new page in collection
-  async createCollectionPage(req, res) {
+  async createCollectionPage(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { collectionName, subcollectionName } = req.params
@@ -58,7 +58,8 @@ class CollectionPagesRouter {
       )
     }
 
-    return res.status(200).json(createResp)
+    res.status(200).json(createResp)
+    return next()
   }
 
   // Read page in collection
@@ -90,7 +91,7 @@ class CollectionPagesRouter {
   }
 
   // Update page in collection
-  async updateCollectionPage(req, res) {
+  async updateCollectionPage(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { pageName, collectionName, subcollectionName } = req.params
@@ -156,12 +157,12 @@ class CollectionPagesRouter {
         )
       }
     }
-    /* eslint-enable no-lonely-if */
-    return res.status(200).json(updateResp)
+    res.status(200).json(updateResp)
+    return next()
   }
 
   // Delete page in collection
-  async deleteCollectionPage(req, res) {
+  async deleteCollectionPage(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { pageName, collectionName, subcollectionName } = req.params
@@ -183,7 +184,8 @@ class CollectionPagesRouter {
       })
     }
 
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   getRouter() {

--- a/src/routes/v2/authenticatedSites/collections.js
+++ b/src/routes/v2/authenticatedSites/collections.js
@@ -58,7 +58,7 @@ class CollectionsRouter {
   }
 
   // Create new collection/subcollection
-  async createCollectionDirectory(req, res) {
+  async createCollectionDirectory(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { collectionName } = req.params
@@ -87,11 +87,12 @@ class CollectionsRouter {
       )
     }
 
-    return res.status(200).json(createResp)
+    res.status(200).json(createResp)
+    return next()
   }
 
   // Rename collection/subcollection
-  async renameCollectionDirectory(req, res) {
+  async renameCollectionDirectory(req, res, next) {
     const { userWithSiteSessionData, githubSessionData } = res.locals
 
     const { collectionName, subcollectionName } = req.params
@@ -119,11 +120,12 @@ class CollectionsRouter {
       )
     }
 
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   // Delete collection/subcollection
-  async deleteCollectionDirectory(req, res) {
+  async deleteCollectionDirectory(req, res, next) {
     const { userWithSiteSessionData, githubSessionData } = res.locals
 
     const { collectionName, subcollectionName } = req.params
@@ -145,11 +147,12 @@ class CollectionsRouter {
         }
       )
     }
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   // Reorder collection/subcollection
-  async reorderCollectionDirectory(req, res) {
+  async reorderCollectionDirectory(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { collectionName, subcollectionName } = req.params
@@ -175,11 +178,12 @@ class CollectionsRouter {
         }
       )
     }
-    return res.status(200).json(reorderResp)
+    res.status(200).json(reorderResp)
+    return next()
   }
 
   // Move collection/subcollection pages
-  async moveCollectionDirectoryPages(req, res) {
+  async moveCollectionDirectoryPages(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { collectionName, subcollectionName } = req.params
@@ -211,7 +215,8 @@ class CollectionsRouter {
         objArray: items,
       })
     }
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   getRouter() {

--- a/src/routes/v2/authenticatedSites/contactUs.js
+++ b/src/routes/v2/authenticatedSites/contactUs.js
@@ -30,7 +30,7 @@ class ContactUsRouter {
   }
 
   // Update contactUs index file
-  async updateContactUs(req, res) {
+  async updateContactUs(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { error } = UpdateContactUsSchema.validate(req.body)
@@ -45,7 +45,8 @@ class ContactUsRouter {
       { content: pageBody, frontMatter, sha }
     )
 
-    return res.status(200).json(updatedContactUsPage)
+    res.status(200).json(updatedContactUsPage)
+    return next()
   }
 
   getRouter() {

--- a/src/routes/v2/authenticatedSites/homepage.js
+++ b/src/routes/v2/authenticatedSites/homepage.js
@@ -30,7 +30,7 @@ class HomepageRouter {
   }
 
   // Update homepage index file
-  async updateHomepage(req, res) {
+  async updateHomepage(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { error } = UpdateHomepageSchema.validate(req.body, {
@@ -51,7 +51,8 @@ class HomepageRouter {
       }
     )
 
-    return res.status(200).json(updatedHomepage)
+    res.status(200).json(updatedHomepage)
+    return next()
   }
 
   getRouter() {

--- a/src/routes/v2/authenticatedSites/index.js
+++ b/src/routes/v2/authenticatedSites/index.js
@@ -1,7 +1,5 @@
 import { attachSiteHandler } from "@root/middleware"
 
-import { NotificationsRouter } from "./notifications"
-
 const express = require("express")
 
 const {
@@ -90,7 +88,6 @@ const getAuthenticatedSitesSubrouter = ({
   authorizationMiddleware,
   gitHubService,
   configYmlService,
-  notificationsService,
 }) => {
   const collectionYmlService = new CollectionYmlService({ gitHubService })
   const homepagePageService = new HomepagePageService({ gitHubService })
@@ -187,7 +184,6 @@ const getAuthenticatedSitesSubrouter = ({
   const navigationV2Router = new NavigationRouter({
     navigationYmlService: navYmlService,
   })
-  const notificationsRouter = new NotificationsRouter({ notificationsService })
 
   const authenticatedSitesSubrouter = express.Router({ mergeParams: true })
 
@@ -225,10 +221,6 @@ const getAuthenticatedSitesSubrouter = ({
   authenticatedSitesSubrouter.use("/contactUs", contactUsV2Router.getRouter())
   authenticatedSitesSubrouter.use("/homepage", homepageV2Router.getRouter())
   authenticatedSitesSubrouter.use("/settings", settingsV2Router.getRouter())
-  authenticatedSitesSubrouter.use(
-    "/notifications",
-    notificationsRouter.getRouter()
-  )
 
   return authenticatedSitesSubrouter
 }

--- a/src/routes/v2/authenticatedSites/index.js
+++ b/src/routes/v2/authenticatedSites/index.js
@@ -88,6 +88,7 @@ const getAuthenticatedSitesSubrouter = ({
   authorizationMiddleware,
   gitHubService,
   configYmlService,
+  notificationOnEditHandler,
 }) => {
   const collectionYmlService = new CollectionYmlService({ gitHubService })
   const homepagePageService = new HomepagePageService({ gitHubService })
@@ -221,6 +222,7 @@ const getAuthenticatedSitesSubrouter = ({
   authenticatedSitesSubrouter.use("/contactUs", contactUsV2Router.getRouter())
   authenticatedSitesSubrouter.use("/homepage", homepageV2Router.getRouter())
   authenticatedSitesSubrouter.use("/settings", settingsV2Router.getRouter())
+  authenticatedSitesSubrouter.use(notificationOnEditHandler.createNotification)
 
   return authenticatedSitesSubrouter
 }

--- a/src/routes/v2/authenticatedSites/mediaCategories.js
+++ b/src/routes/v2/authenticatedSites/mediaCategories.js
@@ -37,7 +37,7 @@ class MediaCategoriesRouter {
   }
 
   // Create new media directory
-  async createMediaDirectory(req, res) {
+  async createMediaDirectory(req, res, next) {
     const { userWithSiteSessionData, githubSessionData } = res.locals
 
     const { error } = CreateMediaDirectoryRequestSchema.validate(req.body)
@@ -52,11 +52,12 @@ class MediaCategoriesRouter {
       }
     )
 
-    return res.status(200).json(createResp)
+    res.status(200).json(createResp)
+    return next()
   }
 
   // Rename resource category
-  async renameMediaDirectory(req, res) {
+  async renameMediaDirectory(req, res, next) {
     const { userWithSiteSessionData, githubSessionData } = res.locals
 
     const { directoryName } = req.params
@@ -72,11 +73,12 @@ class MediaCategoriesRouter {
       }
     )
 
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   // Delete resource category
-  async deleteMediaDirectory(req, res) {
+  async deleteMediaDirectory(req, res, next) {
     const { userWithSiteSessionData, githubSessionData } = res.locals
 
     const { directoryName } = req.params
@@ -87,11 +89,12 @@ class MediaCategoriesRouter {
         directoryName,
       }
     )
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   // Move resource category
-  async moveMediaFiles(req, res) {
+  async moveMediaFiles(req, res, next) {
     const { userWithSiteSessionData, githubSessionData } = res.locals
 
     const { directoryName } = req.params
@@ -110,7 +113,8 @@ class MediaCategoriesRouter {
         objArray: items,
       }
     )
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   getRouter() {

--- a/src/routes/v2/authenticatedSites/mediaFiles.js
+++ b/src/routes/v2/authenticatedSites/mediaFiles.js
@@ -23,7 +23,7 @@ class MediaFilesRouter {
   }
 
   // Create new page in collection
-  async createMediaFile(req, res) {
+  async createMediaFile(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { directoryName } = req.params
@@ -39,7 +39,8 @@ class MediaFilesRouter {
       }
     )
 
-    return res.status(200).json(createResp)
+    res.status(200).json(createResp)
+    return next()
   }
 
   // Read page in collection
@@ -56,7 +57,7 @@ class MediaFilesRouter {
   }
 
   // Update page in collection
-  async updateMediaFile(req, res) {
+  async updateMediaFile(req, res, next) {
     const { userWithSiteSessionData, githubSessionData } = res.locals
 
     const { fileName, directoryName } = req.params
@@ -84,11 +85,12 @@ class MediaFilesRouter {
         sha,
       })
     }
-    return res.status(200).json(updateResp)
+    res.status(200).json(updateResp)
+    return next()
   }
 
   // Delete page in collection
-  async deleteMediaFile(req, res) {
+  async deleteMediaFile(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { fileName, directoryName } = req.params
@@ -101,7 +103,8 @@ class MediaFilesRouter {
       sha,
     })
 
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   getRouter() {

--- a/src/routes/v2/authenticatedSites/navigation.js
+++ b/src/routes/v2/authenticatedSites/navigation.js
@@ -30,7 +30,7 @@ class NavigationRouter {
   }
 
   // Update navigation index file
-  async updateNavigation(req, res) {
+  async updateNavigation(req, res, next) {
     const { error } = UpdateNavigationRequestSchema.validate(req.body)
     if (error) throw new BadRequestError(error.message)
 
@@ -44,7 +44,8 @@ class NavigationRouter {
       { fileContent, sha }
     )
 
-    return res.status(200).json(updatedNavigationPage)
+    res.status(200).json(updatedNavigationPage)
+    return next()
   }
 
   getRouter() {

--- a/src/routes/v2/authenticatedSites/resourceCategories.js
+++ b/src/routes/v2/authenticatedSites/resourceCategories.js
@@ -35,7 +35,7 @@ class ResourceCategoriesRouter {
   }
 
   // Create new resource category
-  async createResourceDirectory(req, res) {
+  async createResourceDirectory(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { resourceRoomName } = req.params
@@ -50,11 +50,12 @@ class ResourceCategoriesRouter {
       }
     )
 
-    return res.status(200).json(createResp)
+    res.status(200).json(createResp)
+    return next()
   }
 
   // Rename resource category
-  async renameResourceDirectory(req, res) {
+  async renameResourceDirectory(req, res, next) {
     const { userWithSiteSessionData, githubSessionData } = res.locals
 
     const { resourceRoomName, resourceCategoryName } = req.params
@@ -71,11 +72,12 @@ class ResourceCategoriesRouter {
       }
     )
 
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   // Delete resource category
-  async deleteResourceDirectory(req, res) {
+  async deleteResourceDirectory(req, res, next) {
     const { userWithSiteSessionData, githubSessionData } = res.locals
 
     const { resourceRoomName, resourceCategoryName } = req.params
@@ -87,11 +89,12 @@ class ResourceCategoriesRouter {
         resourceCategoryName,
       }
     )
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   // Move resource category
-  async moveResourceDirectoryPages(req, res) {
+  async moveResourceDirectoryPages(req, res, next) {
     const { userWithSiteSessionData, githubSessionData } = res.locals
 
     const { resourceRoomName, resourceCategoryName } = req.params
@@ -111,7 +114,8 @@ class ResourceCategoriesRouter {
         objArray: items,
       }
     )
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   getRouter() {

--- a/src/routes/v2/authenticatedSites/resourcePages.js
+++ b/src/routes/v2/authenticatedSites/resourcePages.js
@@ -23,7 +23,7 @@ class ResourcePagesRouter {
   }
 
   // Create new page in resource category
-  async createResourcePage(req, res) {
+  async createResourcePage(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { resourceRoomName, resourceCategoryName } = req.params
@@ -44,7 +44,8 @@ class ResourcePagesRouter {
       }
     )
 
-    return res.status(200).json(createResp)
+    res.status(200).json(createResp)
+    return next()
   }
 
   // Read page in resource category
@@ -66,7 +67,7 @@ class ResourcePagesRouter {
   }
 
   // Update page in resource category
-  async updateResourcePage(req, res) {
+  async updateResourcePage(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { resourceRoomName, resourceCategoryName, pageName } = req.params
@@ -104,11 +105,12 @@ class ResourcePagesRouter {
         }
       )
     }
-    return res.status(200).json(updateResp)
+    res.status(200).json(updateResp)
+    return next()
   }
 
   // Delete page in resource category
-  async deleteResourcePage(req, res) {
+  async deleteResourcePage(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { resourceRoomName, resourceCategoryName, pageName } = req.params
@@ -122,7 +124,8 @@ class ResourcePagesRouter {
       sha,
     })
 
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   getRouter() {

--- a/src/routes/v2/authenticatedSites/resourceRoom.js
+++ b/src/routes/v2/authenticatedSites/resourceRoom.js
@@ -48,7 +48,7 @@ class ResourceRoomRouter {
   }
 
   // Create new resource room
-  async createResourceRoomDirectory(req, res) {
+  async createResourceRoomDirectory(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { error } = CreateResourceDirectoryRequestSchema.validate(req.body)
@@ -61,11 +61,12 @@ class ResourceRoomRouter {
       }
     )
 
-    return res.status(200).json(createResp)
+    res.status(200).json(createResp)
+    return next()
   }
 
   // Rename resource room
-  async renameResourceRoomDirectory(req, res) {
+  async renameResourceRoomDirectory(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { resourceRoomName } = req.params
@@ -80,7 +81,8 @@ class ResourceRoomRouter {
       }
     )
 
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   // Delete resource room

--- a/src/routes/v2/authenticatedSites/settings.js
+++ b/src/routes/v2/authenticatedSites/settings.js
@@ -39,7 +39,7 @@ class SettingsRouter {
     })
   }
 
-  async updateSettingsPage(req, res) {
+  async updateSettingsPage(req, res, next) {
     const { body } = req
     const { userWithSiteSessionData } = res.locals
 
@@ -73,7 +73,8 @@ class SettingsRouter {
       updatedFooterContent,
       updatedNavigationContent,
     })
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   getRouter() {

--- a/src/routes/v2/authenticatedSites/unlinkedPages.js
+++ b/src/routes/v2/authenticatedSites/unlinkedPages.js
@@ -34,7 +34,7 @@ class UnlinkedPagesRouter {
     return res.status(200).json(listResp)
   }
 
-  async createUnlinkedPage(req, res) {
+  async createUnlinkedPage(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { error } = CreatePageRequestSchema.validate(req.body)
@@ -52,7 +52,8 @@ class UnlinkedPagesRouter {
       }
     )
 
-    return res.status(200).json(createResp)
+    res.status(200).json(createResp)
+    return next()
   }
 
   async readUnlinkedPage(req, res) {
@@ -69,7 +70,7 @@ class UnlinkedPagesRouter {
     return res.status(200).json({ pageName, sha, content })
   }
 
-  async updateUnlinkedPage(req, res) {
+  async updateUnlinkedPage(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { pageName } = req.params
@@ -105,10 +106,11 @@ class UnlinkedPagesRouter {
       )
     }
 
-    return res.status(200).json(updateResp)
+    res.status(200).json(updateResp)
+    return next()
   }
 
-  async deleteUnlinkedPage(req, res) {
+  async deleteUnlinkedPage(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { pageName } = req.params
@@ -120,10 +122,11 @@ class UnlinkedPagesRouter {
       sha,
     })
 
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
-  async moveUnlinkedPages(req, res) {
+  async moveUnlinkedPages(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
     const { error } = MoveDirectoryPagesRequestSchema.validate(req.body)
@@ -143,7 +146,8 @@ class UnlinkedPagesRouter {
         objArray: items,
       }
     )
-    return res.status(200).send("OK")
+    res.status(200).send("OK")
+    return next()
   }
 
   getRouter() {

--- a/src/server.js
+++ b/src/server.js
@@ -37,6 +37,7 @@ import SitesService from "@services/identity/SitesService"
 import InfraService from "@services/infra/InfraService"
 import ReviewRequestService from "@services/review/ReviewRequestService"
 
+import { NotificationOnEditHandler } from "./middleware/notificationOnEditHandler"
 import getAuthenticatedSubrouterV1 from "./routes/v1/authenticated"
 import getAuthenticatedSitesSubrouterV1 from "./routes/v1/authenticatedSites"
 import getAuthenticatedSubrouter from "./routes/v2/authenticated"
@@ -130,6 +131,12 @@ const authorizationMiddleware = getAuthorizationMiddleware({
   isomerAdminsService,
   collaboratorsService,
 })
+const notificationOnEditHandler = new NotificationOnEditHandler({
+  reviewRequestService,
+  sitesService,
+  collaboratorsService,
+  notificationsService,
+})
 
 const reviewRouter = new ReviewsRouter(
   reviewRequestService,
@@ -153,6 +160,7 @@ const authenticatedSubrouterV2 = getAuthenticatedSubrouter({
   collaboratorsService,
   authorizationMiddleware,
   reviewRouter,
+  notificationsService,
 })
 
 const authenticatedSitesSubrouterV2 = getAuthenticatedSitesSubrouter({
@@ -160,7 +168,7 @@ const authenticatedSitesSubrouterV2 = getAuthenticatedSitesSubrouter({
   authenticationMiddleware,
   gitHubService,
   configYmlService,
-  notificationsService,
+  notificationOnEditHandler,
 })
 const authV2Router = new AuthRouter({ authenticationMiddleware, authService })
 const formsgRouter = new FormsgRouter({ usersService, infraService })

--- a/src/server.js
+++ b/src/server.js
@@ -142,7 +142,8 @@ const reviewRouter = new ReviewsRouter(
   reviewRequestService,
   usersService,
   sitesService,
-  collaboratorsService
+  collaboratorsService,
+  notificationsService
 )
 const authenticatedSubrouterV1 = getAuthenticatedSubrouterV1({
   authenticationMiddleware,

--- a/src/server.js
+++ b/src/server.js
@@ -204,7 +204,7 @@ app.use("/v1", authenticatedSubrouterV1)
 app.use("/v2/auth", authV2Router.getRouter())
 // Endpoints which have require login, but not site access token
 app.use("/v2", authenticatedSubrouterV2)
-// Endpoints which have siteName, used to inject site access token
+// Endpoints which modify the github repo, used to inject site access token
 app.use("/v2/sites/:siteName", authenticatedSitesSubrouterV2)
 
 // FormSG Backend handler routes

--- a/src/services/identity/NotificationsService.ts
+++ b/src/services/identity/NotificationsService.ts
@@ -205,10 +205,15 @@ class NotificationsService {
 
     if (recentTargetNotification) {
       // Update existing notification
-      await recentTargetNotification.update({
-        firstReadTime: null,
-        createdAt: new Date(),
-      })
+      // createdAt is a special column which must be flagged as changed
+      recentTargetNotification.changed("createdAt", true)
+      await recentTargetNotification.update(
+        {
+          firstReadTime: null,
+          createdAt: new Date(),
+        },
+        { raw: true }
+      )
     } else {
       // Create new notification
       await this.repository.create({

--- a/src/services/identity/NotificationsService.ts
+++ b/src/services/identity/NotificationsService.ts
@@ -171,41 +171,19 @@ class NotificationsService {
   }
 
   async create({
-    siteName,
-    userId,
+    siteMember,
     link,
     notificationType,
     notificationSourceUsername,
   }: {
-    siteName: string
-    userId: string
+    siteMember: SiteMember
     link: string
     notificationType: NotificationType
     notificationSourceUsername: string
   }) {
-    const siteMember = await this.siteMember.findOne({
-      where: { user_id: userId },
-      include: [
-        {
-          model: Site,
-          required: true,
-          include: [
-            {
-              model: Repo,
-              required: true,
-              where: {
-                name: siteName,
-              },
-            },
-          ],
-        },
-      ],
-    })
-
-    // Look for a recent notification to decide whether to create a new notification or update the old one
     const recentTargetNotification = await this.repository.findOne({
       where: {
-        user_id: userId,
+        user_id: siteMember.userId,
         type: notificationType,
         created_at: {
           [Op.gte]: getNotificationExpiryDate(notificationType),
@@ -218,15 +196,9 @@ class NotificationsService {
           model: Site,
           as: "site",
           required: true,
-          include: [
-            {
-              model: Repo,
-              required: true,
-              where: {
-                name: siteName,
-              },
-            },
-          ],
+          where: {
+            id: siteMember.siteId,
+          },
         },
       ],
     })
@@ -242,7 +214,7 @@ class NotificationsService {
       await this.repository.create({
         siteMemberId: siteMember?.id,
         siteId: siteMember?.siteId,
-        userId,
+        userId: siteMember.userId,
         message: getNotificationMessage(
           notificationType,
           notificationSourceUsername

--- a/src/services/identity/NotificationsService.ts
+++ b/src/services/identity/NotificationsService.ts
@@ -211,6 +211,10 @@ class NotificationsService {
         {
           firstReadTime: null,
           createdAt: new Date(),
+          message: getNotificationMessage(
+            notificationType,
+            notificationSourceUsername
+          ),
         },
         { raw: true }
       )

--- a/src/services/identity/__tests__/NotificationsService.spec.ts
+++ b/src/services/identity/__tests__/NotificationsService.spec.ts
@@ -162,6 +162,10 @@ describe("Notification Service", () => {
   })
 
   describe("create", () => {
+    const mockSiteMember = ({
+      userId: mockUserId,
+      siteId: 1,
+    } as unknown) as SiteMember
     it("should create a new notification if no similar one exists", async () => {
       // Arrange
       MockSiteMember.findOne.mockResolvedValueOnce({ id: mockUserId })
@@ -169,8 +173,7 @@ describe("Notification Service", () => {
 
       // Act
       const actual = NotificationsService.create({
-        userId: mockUserId,
-        siteName: mockSiteName,
+        siteMember: mockSiteMember,
         link: "link",
         notificationType: "sent_request",
         notificationSourceUsername: "user",
@@ -178,7 +181,6 @@ describe("Notification Service", () => {
 
       // Assert
       await expect(actual).resolves.not.toThrow()
-      expect(MockSiteMember.findOne).toHaveBeenCalledTimes(1)
       expect(MockRepository.findOne).toHaveBeenCalledTimes(1)
       expect(MockRepository.create).toHaveBeenCalledTimes(1)
     })
@@ -189,12 +191,12 @@ describe("Notification Service", () => {
       MockSiteMember.findOne.mockResolvedValueOnce({ id: mockUserId })
       MockRepository.findOne.mockResolvedValueOnce({
         update: notificationUpdate,
+        changed: jest.fn(),
       })
 
       // Act
       const actual = NotificationsService.create({
-        userId: mockUserId,
-        siteName: mockSiteName,
+        siteMember: mockSiteMember,
         link: "link",
         notificationType: "sent_request",
         notificationSourceUsername: "user",
@@ -202,7 +204,6 @@ describe("Notification Service", () => {
 
       // Assert
       await expect(actual).resolves.not.toThrow()
-      expect(MockSiteMember.findOne).toHaveBeenCalledTimes(1)
       expect(MockRepository.findOne).toHaveBeenCalledTimes(1)
       expect(notificationUpdate).toHaveBeenCalledTimes(1)
     })

--- a/src/utils/notification-utils.ts
+++ b/src/utils/notification-utils.ts
@@ -17,7 +17,7 @@ export const getNotificationExpiryDate = (
       // Always notify for review request information
       return moment()
     default:
-      return moment().subtract(3, "months")
+      return moment().subtract(3, "hours")
   }
 }
 

--- a/src/utils/notification-utils.ts
+++ b/src/utils/notification-utils.ts
@@ -1,11 +1,21 @@
 import moment from "moment"
 
-export type NotificationType = "sent_request" | "updated_request"
+export type NotificationType =
+  | "sent_request"
+  | "updated_request"
+  | "request_created"
+  | "request_approved"
+  | "request_cancelled"
 
 export const getNotificationExpiryDate = (
   notificationType: NotificationType
 ) => {
   switch (notificationType) {
+    case "request_created":
+    case "request_approved":
+    case "request_cancelled":
+      // Always notify for review request information
+      return moment()
     default:
       return moment().subtract(3, "months")
   }
@@ -17,7 +27,13 @@ export const getNotificationMessage = (
 ) => {
   switch (notificationType) {
     case "sent_request":
+      return `${sourceUsername} has sent you a review request.`
+    case "request_created":
       return `${sourceUsername} created a review request.`
+    case "request_approved":
+      return `${sourceUsername} has approved a review request.`
+    case "request_cancelled":
+      return `${sourceUsername} has cancelled a review request.`
     case "updated_request":
       return `${sourceUsername} made changes to a review request.`
     default:


### PR DESCRIPTION
This PR builds on https://github.com/isomerpages/isomercms-backend/pull/508 - it introduces notification creation for the following actions:

- Creating a review request
- Cancelling a review request
- Approving a review request
- Editing a repo while a review request is open

This PR should be reviewed from commit [750fdfc](https://github.com/isomerpages/isomercms-backend/pull/523/commits/750fdfc3c571adf03efc8db3886420f4161a2d5f) - the remainder are due to merge issues which will be resolved once we merge the relevant PRs.

Key Features
This PR adds a dependency of the reviews router to NotificationsService. It also adds a new middleware which is used for all endpoints which modify repo info - this is introduced in the `authenticatedSites` router, and the notifications router has been moved out of this router to facilitate this.

Other Misc changes

- Modify routeHandlers to allow for `next` to be passed to wrapped routes
- Notifications router moved to `authenticated` subrouter instead