### PR TITLE
feat: add review request views API endpoint and functions

### DIFF
--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -252,6 +252,49 @@ export class ReviewsRouter {
     })
   }
 
+  markAllReviewRequestsAsViewed: RequestHandler<
+    { siteName: string },
+    string | ResponseErrorBody,
+    never,
+    unknown,
+    { userWithSiteSessionData: UserWithSiteSessionData }
+  > = async (req, res) => {
+    // Step 1: Check that the site exists
+    const { siteName } = req.params
+    const site = await this.sitesService.getBySiteName(siteName)
+
+    if (!site) {
+      return res.status(404).send({
+        message: "Please ensure that the site exists!",
+      })
+    }
+
+    // Step 2: Check that user exists.
+    // Having session data is proof that this user exists
+    // as otherwise, they would be rejected by our middleware
+    const { userWithSiteSessionData } = res.locals
+
+    // Check if they are a collaborator
+    const role = await this.collaboratorsService.getRole(
+      siteName,
+      userWithSiteSessionData.isomerUserId
+    )
+
+    if (!role) {
+      return res.status(400).send({
+        message: "User is not a collaborator of this site!",
+      })
+    }
+
+    // Step 3: Update all review requests for the site as viewed
+    await this.reviewRequestService.markAllReviewRequestsAsViewed(
+      userWithSiteSessionData,
+      site
+    )
+
+    return res.status(200).json()
+  }
+
   getReviewRequest: RequestHandler<
     { siteName: string; requestId: number },
     { reviewRequest: ReviewRequestDto } | ResponseErrorBody,
@@ -504,6 +547,11 @@ export class ReviewsRouter {
     // as the underlying Github API returns 404 if
     // the requested review could not be found.
     await this.reviewRequestService.mergeReviewRequest(possibleReviewRequest)
+
+    // Step 5: Clean up the review request view records
+    // The error is discarded as we are guaranteed to have a review request
+    await this.reviewRequestService.deleteAllReviewRequestViews(site, requestId)
+
     return res.status(200).send()
   }
 
@@ -659,6 +707,11 @@ export class ReviewsRouter {
     // as the underlying Github API returns 404 if
     // the requested review could not be found.
     await this.reviewRequestService.closeReviewRequest(possibleReviewRequest)
+
+    // Step 6: Clean up the review request view records
+    // The error is discarded as we are guaranteed to have a review request
+    await this.reviewRequestService.deleteAllReviewRequestViews(site, requestId)
+
     return res.status(200).send()
   }
 
@@ -671,6 +724,10 @@ export class ReviewsRouter {
       attachWriteRouteHandlerWrapper(this.createReviewRequest)
     )
     router.get("/summary", attachReadRouteHandlerWrapper(this.listReviews))
+    router.post(
+      "/viewed",
+      attachWriteRouteHandlerWrapper(this.markAllReviewRequestsAsViewed)
+    )
     router.get(
       "/:requestId",
       attachReadRouteHandlerWrapper(this.getReviewRequest)

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -283,13 +283,16 @@ export default class ReviewRequestService {
     pullRequestNumber: number
   ): Promise<void | RequestNotFoundError> => {
     const { isomerUserId: userId } = sessionData
-    const reviewRequest = await this.getReviewRequest(site, pullRequestNumber)
+    const possibleReviewRequest = await this.getReviewRequest(
+      site,
+      pullRequestNumber
+    )
 
-    if (isIsomerError(reviewRequest)) {
-      return reviewRequest
+    if (isIsomerError(possibleReviewRequest)) {
+      return possibleReviewRequest
     }
 
-    const { id: reviewRequestId } = reviewRequest
+    const { id: reviewRequestId } = possibleReviewRequest
 
     await this.reviewRequestView.update(
       {
@@ -309,13 +312,16 @@ export default class ReviewRequestService {
     site: Site,
     pullRequestNumber: number
   ): Promise<void | RequestNotFoundError> => {
-    const reviewRequest = await this.getReviewRequest(site, pullRequestNumber)
+    const possibleReviewRequest = await this.getReviewRequest(
+      site,
+      pullRequestNumber
+    )
 
-    if (isIsomerError(reviewRequest)) {
-      return reviewRequest
+    if (isIsomerError(possibleReviewRequest)) {
+      return possibleReviewRequest
     }
 
-    const { id: reviewRequestId } = reviewRequest
+    const { id: reviewRequestId } = possibleReviewRequest
 
     await this.reviewRequestView.destroy({
       where: {

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -280,19 +280,10 @@ export default class ReviewRequestService {
   updateReviewRequestLastViewedAt = async (
     sessionData: UserWithSiteSessionData,
     site: Site,
-    pullRequestNumber: number
+    reviewRequest: ReviewRequest
   ): Promise<void | RequestNotFoundError> => {
     const { isomerUserId: userId } = sessionData
-    const possibleReviewRequest = await this.getReviewRequest(
-      site,
-      pullRequestNumber
-    )
-
-    if (isIsomerError(possibleReviewRequest)) {
-      return possibleReviewRequest
-    }
-
-    const { id: reviewRequestId } = possibleReviewRequest
+    const { id: reviewRequestId } = reviewRequest
 
     await this.reviewRequestView.update(
       {

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -1,3 +1,4 @@
+import _ from "lodash"
 import { ModelStatic } from "sequelize"
 
 import UserWithSiteSessionData from "@classes/UserWithSiteSessionData"
@@ -6,6 +7,7 @@ import { Reviewer } from "@database/models/Reviewers"
 import { ReviewMeta } from "@database/models/ReviewMeta"
 import { ReviewRequest } from "@database/models/ReviewRequest"
 import { ReviewRequestStatus } from "@root/constants"
+import { ReviewRequestView } from "@root/database/models"
 import { Site } from "@root/database/models/Site"
 import { User } from "@root/database/models/User"
 import RequestNotFoundError from "@root/errors/RequestNotFoundError"
@@ -15,6 +17,7 @@ import {
   FileType,
   ReviewRequestDto,
 } from "@root/types/dto/review"
+import { isIsomerError } from "@root/types/error"
 import { Commit, fromGithubCommitMessage } from "@root/types/github"
 import { RequestChangeInfo } from "@root/types/review"
 import * as ReviewApi from "@services/db/review"
@@ -40,18 +43,22 @@ export default class ReviewRequestService {
 
   private readonly reviewMeta: ModelStatic<ReviewMeta>
 
+  private readonly reviewRequestView: ModelStatic<ReviewRequestView>
+
   constructor(
     apiService: typeof ReviewApi,
     users: ModelStatic<User>,
     repository: ModelStatic<ReviewRequest>,
     reviewers: ModelStatic<Reviewer>,
-    reviewMeta: ModelStatic<ReviewMeta>
+    reviewMeta: ModelStatic<ReviewMeta>,
+    reviewRequestView: ModelStatic<ReviewRequestView>
   ) {
     this.apiService = apiService
     this.users = users
     this.repository = repository
     this.reviewers = reviewers
     this.reviewMeta = reviewMeta
+    this.reviewRequestView = reviewRequestView
   }
 
   compareDiff = async (
@@ -159,9 +166,11 @@ export default class ReviewRequestService {
   }
 
   listReviewRequest = async (
-    { siteName }: UserWithSiteSessionData,
+    sessionData: UserWithSiteSessionData,
     site: Site
   ): Promise<DashboardReviewRequestDto[]> => {
+    const { siteName, isomerUserId: userId } = sessionData
+
     // Find all review requests associated with the site
     const requests = await this.repository.findAll({
       where: {
@@ -194,6 +203,16 @@ export default class ReviewRequestService {
           created_at,
         } = await this.apiService.getPullRequest(siteName, pullRequestNumber)
 
+        // It is the user's first view if the review request views table
+        // does not contain a record for the user and the review request
+        const isFirstView = !(await this.reviewRequestView.count({
+          where: {
+            reviewId: req.id,
+            siteId: site.id,
+            userId,
+          },
+        }))
+
         return {
           id: pullRequestNumber,
           author: req.requestor.email || "Unknown user",
@@ -204,11 +223,101 @@ export default class ReviewRequestService {
           createdAt: new Date(created_at).getTime(),
           // TODO!
           newComments: 0,
-          // TODO!
-          firstView: false,
+          firstView: isFirstView,
         }
       })
     )
+  }
+
+  markAllReviewRequestsAsViewed = async (
+    sessionData: UserWithSiteSessionData,
+    site: Site
+  ): Promise<void> => {
+    const { isomerUserId: userId } = sessionData
+
+    const requestsViewed = await this.reviewRequestView.findAll({
+      where: {
+        siteId: site.id,
+        userId,
+      },
+    })
+
+    const allActiveRequests = await this.repository.findAll({
+      where: {
+        siteId: site.id,
+        // NOTE: Closed and merged review requests would not have an
+        // entry in the review request views table
+        reviewStatus: ["OPEN", "APPROVED"],
+      },
+    })
+
+    const requestIdsViewed = requestsViewed.map(
+      (request) => request.reviewRequestId
+    )
+    const allActiveRequestIds = allActiveRequests.map((request) => request.id)
+    const requestIdsToMarkAsViewed = _.difference(
+      allActiveRequestIds,
+      requestIdsViewed
+    )
+
+    requestIdsToMarkAsViewed.forEach(async (requestId) => {
+      await this.reviewRequestView.create({
+        reviewRequestId: requestId,
+        siteId: site.id,
+        userId,
+        // This field represents the user opening the review request
+        // itself, which the user has not done so yet at this stage.
+        lastViewedAt: null,
+      })
+    })
+  }
+
+  updateReviewRequestLastViewedAt = async (
+    sessionData: UserWithSiteSessionData,
+    site: Site,
+    pullRequestNumber: number
+  ): Promise<void | RequestNotFoundError> => {
+    const { isomerUserId: userId } = sessionData
+    const reviewRequest = await this.getReviewRequest(site, pullRequestNumber)
+
+    if (isIsomerError(reviewRequest)) {
+      return reviewRequest
+    }
+
+    const { id: reviewRequestId } = reviewRequest
+
+    await this.reviewRequestView.update(
+      {
+        lastViewedAt: new Date(),
+      },
+      {
+        where: {
+          reviewRequestId,
+          siteId: site.id,
+          userId,
+        },
+      }
+    )
+  }
+
+  deleteAllReviewRequestViews = async (
+    site: Site,
+    pullRequestNumber: number
+  ): Promise<void | RequestNotFoundError> => {
+    const reviewRequest = await this.getReviewRequest(site, pullRequestNumber)
+
+    if (isIsomerError(reviewRequest)) {
+      return reviewRequest
+    }
+
+    const { id: reviewRequestId } = reviewRequest
+
+    await this.reviewRequestView.destroy({
+      where: {
+        reviewRequestId,
+        siteId: site.id,
+      },
+    })
   }
 
   getReviewRequest = async (site: Site, pullRequestNumber: number) => {

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -260,16 +260,21 @@ export default class ReviewRequestService {
       requestIdsViewed
     )
 
-    requestIdsToMarkAsViewed.forEach(async (requestId) => {
-      await this.reviewRequestView.create({
-        reviewRequestId: requestId,
-        siteId: site.id,
-        userId,
-        // This field represents the user opening the review request
-        // itself, which the user has not done so yet at this stage.
-        lastViewedAt: null,
-      })
-    })
+    await Promise.all(
+      // Using map here to allow creations to be done concurrently
+      // But we do not actually need the result of the view creation
+      requestIdsToMarkAsViewed.map(
+        async (requestId) =>
+          await this.reviewRequestView.create({
+            reviewRequestId: requestId,
+            siteId: site.id,
+            userId,
+            // This field represents the user opening the review request
+            // itself, which the user has not done so yet at this stage.
+            lastViewedAt: null,
+          })
+      )
+    )
   }
 
   updateReviewRequestLastViewedAt = async (


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The current backend does not support recording a user's viewing status of a particular review request, which makes it impossible for the site dashboard to differentiate between a new/existing review request that the user has/has not seen before.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- A new API endpoint `POST /v2/sites/:siteName/review/viewed` has been added, which does not take in any input and will automatically record all open/approved review requests for that particular site as viewed.
- New functions have been added to ReviewRequestService to mark all review requests as viewed, to update the lastViewedAt attribute for a particular review request, and to delete any existing review request views.

## Tests

<!-- What tests should be run to confirm functionality? -->

No tests currently. 😭 

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*