### PR TITLE
Feat/comments

### DIFF
--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -637,7 +637,7 @@ export class ReviewsRouter {
 
   getComments: RequestHandler<
     { siteName: string; requestId: number },
-    CommentItem[] | ResponseErrorBody,
+    CommentItem[],
     never,
     unknown,
     { userWithSiteSessionData: UserWithSiteSessionData }

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -647,6 +647,15 @@ export class ReviewsRouter {
     // Step 1: Check that the site exists
     const site = await this.sitesService.getBySiteName(siteName)
     if (!site) {
+      logger.error({
+        message: "Invalid site requested",
+        method: "getComments",
+        meta: {
+          userId: userWithSiteSessionData.isomerUserId,
+          email: userWithSiteSessionData.email,
+          siteName,
+        },
+      })
       return res.status(404).send({
         message: "Please ensure that the site exists!",
       })

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -637,7 +637,7 @@ export class ReviewsRouter {
 
   getComments: RequestHandler<
     { siteName: string; requestId: number },
-    CommentItem[],
+    CommentItem[] | ResponseErrorBody,
     never,
     unknown,
     { userWithSiteSessionData: UserWithSiteSessionData }
@@ -673,7 +673,7 @@ export class ReviewsRouter {
 
   createComment: RequestHandler<
     { siteName: string; requestId: number },
-    string | ResponseErrorBody,
+    string,
     { message: string },
     unknown,
     { userWithSiteSessionData: UserWithSiteSessionData }

--- a/src/services/db/GitHubService.js
+++ b/src/services/db/GitHubService.js
@@ -51,6 +51,14 @@ class GitHubService {
     return ReviewApi.approvePullRequest(siteName, pullRequestNumber)
   }
 
+  async getComments(siteName, pullRequestNumber) {
+    return ReviewApi.getComments(siteName, pullRequestNumber)
+  }
+
+  async createComment(siteName, pullRequestNumber, user, message) {
+    return ReviewApi.createComment(siteName, pullRequestNumber, user, message)
+  }
+
   getFilePath({ siteName, fileName, directoryName }) {
     if (!directoryName)
       return `${siteName}/contents/${encodeURIComponent(fileName)}`

--- a/src/services/db/review.ts
+++ b/src/services/db/review.ts
@@ -128,7 +128,6 @@ export const createComment = async (
   })
   return axiosInstance.post<void>(
     `${siteName}/issues/${pullRequestNumber}/comments`,
-    // NOTE: only create body if a valid description is given
     { body: stringifiedMessage }
   )
 }

--- a/src/services/db/review.ts
+++ b/src/services/db/review.ts
@@ -1,3 +1,5 @@
+import _ from "lodash"
+
 import {
   RawFileChangeInfo,
   Commit,
@@ -96,15 +98,22 @@ export const getComments = async (
   const rawComments = await axiosInstance
     .get<RawComment[]>(`${siteName}/issues/${pullRequestNumber}/comments`)
     .then(({ data }) => data)
-  return rawComments.map((rawComment) => {
-    const commentData = JSON.parse(rawComment.body)
-    const { user, message } = commentData
-    return {
-      user,
-      message,
-      createdAt: rawComment.created_at,
-    }
-  })
+  return _.compact(
+    rawComments.map((rawComment) => {
+      try {
+        const commentData = JSON.parse(rawComment.body)
+        const { user, message } = commentData
+        return {
+          user,
+          message,
+          createdAt: rawComment.created_at,
+        }
+      } catch (e) {
+        // Not properly formatted comment, ignore
+        return null
+      }
+    })
+  )
 }
 
 export const createComment = async (

--- a/src/services/db/review.ts
+++ b/src/services/db/review.ts
@@ -1,4 +1,9 @@
-import { RawFileChangeInfo, Commit, RawPullRequest } from "@root/types/github"
+import {
+  RawFileChangeInfo,
+  Commit,
+  RawPullRequest,
+  RawComment,
+} from "@root/types/github"
 
 import { isomerRepoAxiosInstance as axiosInstance } from "../api/AxiosInstance"
 
@@ -83,3 +88,38 @@ export const approvePullRequest = (
       },
     }
   )
+
+export const getComments = async (
+  siteName: string,
+  pullRequestNumber: number
+) => {
+  const rawComments = await axiosInstance
+    .get<RawComment[]>(`${siteName}/issues/${pullRequestNumber}/comments`)
+    .then(({ data }) => data)
+  return rawComments.map((rawComment) => {
+    const commentData = JSON.parse(rawComment.body)
+    const { user, message } = commentData
+    return {
+      user,
+      message,
+      createdAt: rawComment.created_at,
+    }
+  })
+}
+
+export const createComment = async (
+  siteName: string,
+  pullRequestNumber: number,
+  user: string,
+  message: string
+) => {
+  const stringifiedMessage = JSON.stringify({
+    user,
+    message,
+  })
+  return axiosInstance.post<void>(
+    `${siteName}/issues/${pullRequestNumber}/comments`,
+    // NOTE: only create body if a valid description is given
+    { body: stringifiedMessage }
+  )
+}

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -479,7 +479,6 @@ export default class ReviewRequestService {
   ): Promise<CommentItem[]> => {
     const { siteName, isomerUserId: userId } = sessionData
 
-    // Find all review requests associated with the site
     const comments = await this.apiService.getComments(
       siteName,
       pullRequestNumber

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -234,6 +234,27 @@ export default class ReviewRequestService {
           },
         }))
 
+        // It is a new comment to the user if any of the following
+        // conditions satisfy:
+        // 1. The review request views table does not contain a record
+        //    for the user and the review request.
+        // 2. The review request views table contains a record for that
+        //    user and review request, but the lastViewedAt entry is NULL.
+        // 3. The review request views table contains a record in the
+        //    lastViewedAt entry, and the comment has a timestamp greater
+        //    than the one stored in the database.
+        const allComments = await this.getComments(
+          sessionData,
+          site,
+          pullRequestNumber
+        )
+        const countNewComments = await Promise.all(
+          allComments.map(async (value) => value.isRead)
+        ).then((arr) => {
+          const readComments = arr.filter((isRead) => !!isRead)
+          return readComments.length
+        })
+
         return {
           id: pullRequestNumber,
           author: req.requestor.email || "Unknown user",
@@ -242,8 +263,7 @@ export default class ReviewRequestService {
           description: body || "",
           changedFiles: changed_files,
           createdAt: new Date(created_at).getTime(),
-          // TODO!
-          newComments: 0,
+          newComments: countNewComments,
           firstView: isFirstView,
         }
       })

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -16,6 +16,7 @@ import {
   DashboardReviewRequestDto,
   EditedItemDto,
   FileType,
+  GithubCommentData,
   ReviewRequestDto,
 } from "@root/types/dto/review"
 import { isIsomerError } from "@root/types/error"
@@ -126,12 +127,8 @@ export default class ReviewRequestService {
     return mappings
   }
 
-  computeCommentDataMappings = async (
-    comments: {
-      userId: string
-      message: string
-      createdAt: string
-    }[],
+  computeCommentData = async (
+    comments: GithubCommentData[],
     viewedTime: Date | null
   ) => {
     const mappings = await Promise.all(
@@ -531,6 +528,6 @@ export default class ReviewRequestService {
 
     const viewedTime = requestsView ? new Date(requestsView.lastViewedAt) : null
 
-    return this.computeCommentDataMappings(comments, viewedTime)
+    return this.computeCommentData(comments, viewedTime)
   }
 }

--- a/src/types/dto/review.ts
+++ b/src/types/dto/review.ts
@@ -44,3 +44,10 @@ export interface ReviewRequestDto {
 export interface UpdateReviewRequestDto {
   reviewers: string[]
 }
+
+export interface CommentItem {
+  user: string
+  createdAt: number
+  message: string
+  isRead: boolean
+}

--- a/src/types/dto/review.ts
+++ b/src/types/dto/review.ts
@@ -51,3 +51,9 @@ export interface CommentItem {
   message: string
   isRead: boolean
 }
+
+export interface GithubCommentData {
+  userId: string
+  message: string
+  createdAt: string
+}

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -81,3 +81,8 @@ export interface RawPullRequest {
   changed_files: number
   created_at: string
 }
+
+export interface RawComment {
+  body: string
+  created_at: string
+}


### PR DESCRIPTION
## Problem

This PR adds comments endpoints. It introduces the ability to retrieve and create comments, and also renames an existing endpoint to be used to mark the time at which users read comments. More information on the endpoints can be found in the [design doc](https://www.notion.so/opengov/Comments-Notifications-4332401f397c487e9a6e3bf641b23814).

## Testing
For testing of notification endpoints, the appropriate review request entries in `ReviewRequests`, `ReviewRequestMeta`, and `ReviewRequestView` should be populated, including an active pull request on the desired repo. The creation of a notification will populate the appropriate comment as a github comment on the actual pull request.