### PR TITLE
feat: add new siteUrl API endpoint to get the production URL of site

### DIFF
--- a/src/routes/v2/authenticated/__tests__/Sites.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/Sites.spec.ts
@@ -19,6 +19,7 @@ describe("Sites Router", () => {
     getSites: jest.fn(),
     getLastUpdated: jest.fn(),
     getStagingUrl: jest.fn(),
+    getSiteUrl: jest.fn(),
     getSiteInfo: jest.fn(),
   }
 
@@ -42,6 +43,10 @@ describe("Sites Router", () => {
   subrouter.get(
     "/:siteName/stagingUrl",
     attachReadRouteHandlerWrapper(router.getStagingUrl)
+  )
+  subrouter.get(
+    "/:siteName/siteUrl",
+    attachReadRouteHandlerWrapper(router.getSiteUrl)
   )
   subrouter.get(
     "/:siteName/info",
@@ -92,8 +97,24 @@ describe("Sites Router", () => {
         .get(`/${mockSiteName}/stagingUrl`)
         .expect(200)
 
-      expect(resp.body).toStrictEqual({ possibleStagingUrl: stagingUrl })
+      expect(resp.body).toStrictEqual({ stagingUrl })
       expect(mockSitesService.getStagingUrl).toHaveBeenCalledWith(
+        mockUserWithSiteSessionData
+      )
+    })
+  })
+
+  describe("getSiteUrl", () => {
+    it("returns the site's site URL", async () => {
+      const siteUrl = "prod-url"
+      mockSitesService.getSiteUrl.mockResolvedValueOnce(siteUrl)
+
+      const resp = await request(app)
+        .get(`/${mockSiteName}/siteUrl`)
+        .expect(200)
+
+      expect(resp.body).toStrictEqual({ siteUrl })
+      expect(mockSitesService.getSiteUrl).toHaveBeenCalledWith(
         mockUserWithSiteSessionData
       )
     })

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -71,7 +71,26 @@ export class SitesRouter {
     if (possibleStagingUrl instanceof BaseIsomerError) {
       return res.status(404).json({ message: possibleStagingUrl.message })
     }
-    return res.status(200).json({ possibleStagingUrl })
+    return res.status(200).json({ stagingUrl: possibleStagingUrl })
+  }
+
+  getSiteUrl: RequestHandler<
+    { siteName: string },
+    unknown,
+    never,
+    never,
+    { userWithSiteSessionData: UserWithSiteSessionData }
+  > = async (req, res) => {
+    const { userWithSiteSessionData } = res.locals
+    const possibleSiteUrl = await this.sitesService.getSiteUrl(
+      userWithSiteSessionData
+    )
+
+    // Check for error and throw
+    if (possibleSiteUrl instanceof BaseIsomerError) {
+      return res.status(404).json({ message: possibleSiteUrl.message })
+    }
+    return res.status(200).json({ siteUrl: possibleSiteUrl })
   }
 
   getSiteInfo: RequestHandler<
@@ -107,6 +126,11 @@ export class SitesRouter {
       "/:siteName/stagingUrl",
       attachSiteHandler,
       attachReadRouteHandlerWrapper(this.getStagingUrl)
+    )
+    router.get(
+      "/:siteName/siteUrl",
+      attachSiteHandler,
+      attachReadRouteHandlerWrapper(this.getSiteUrl)
     )
     router.get(
       "/:siteName/info",

--- a/src/services/identity/SitesService.ts
+++ b/src/services/identity/SitesService.ts
@@ -337,6 +337,21 @@ class SitesService {
     return staging
   }
 
+  async getSiteUrl(
+    sessionData: UserWithSiteSessionData
+  ): Promise<string | NotFoundError> {
+    const siteUrls = await this.getUrlsOfSite(sessionData)
+    if (siteUrls instanceof NotFoundError) {
+      return new NotFoundError(
+        `${sessionData.siteName} does not have a site url`
+      )
+    }
+
+    const { prod } = siteUrls
+
+    return prod
+  }
+
   async create(
     createParams: Partial<Site> & {
       name: Site["name"]

--- a/src/services/identity/__tests__/SitesService.spec.ts
+++ b/src/services/identity/__tests__/SitesService.spec.ts
@@ -508,6 +508,51 @@ describe("SitesService", () => {
     })
   })
 
+  describe("getSiteUrl", () => {
+    const stagingUrl = "https://repo-staging.netlify.app"
+    const productionUrl = "https://repo-prod.netlify.app"
+
+    it("should return the site URL if it is available", async () => {
+      // Arrange
+      const mockSiteWithDeployment = {
+        ...mockSite,
+        deployment: { stagingUrl, productionUrl },
+      }
+
+      MockRepository.findOne.mockResolvedValueOnce(mockSiteWithDeployment)
+
+      // Act
+      const actual = await SitesService.getSiteUrl(
+        mockSessionDataEmailUserWithSite
+      )
+
+      // Assert
+      expect(actual).toEqual(productionUrl)
+      expect(MockRepository.findOne).toHaveBeenCalled()
+    })
+
+    it("should return an error when the site url for a repo is not found", async () => {
+      // Arrange
+      MockRepository.findOne.mockResolvedValueOnce(null)
+      MockConfigYmlService.read.mockResolvedValueOnce({
+        content: {},
+      })
+      MockGithubService.getRepoInfo.mockResolvedValueOnce({
+        description: "",
+      })
+
+      // Act
+      await expect(
+        SitesService.getSiteUrl(mockUserWithSiteSessionData)
+      ).resolves.toBeInstanceOf(NotFoundError)
+
+      // Assert
+      expect(MockRepository.findOne).toHaveBeenCalled()
+      expect(MockConfigYmlService.read).toHaveBeenCalled()
+      expect(MockGithubService.getRepoInfo).toHaveBeenCalled()
+    })
+  })
+
   describe("getSiteInfo", () => {
     const stagingUrl = "https://repo-staging.netlify.app"
     const productionUrl = "https://repo-prod.netlify.app"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

There is currently no existing API endpoints for getting just the production URL of a particular site. There is an existing site info endpoint but it is too expensive (extra calls to get commits information), and the settings endpoint gets a user-defined value of the production URL, which may not exist or may be empty.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Introduce a new `/sites/:siteName/siteUrl` API endpoint to get the production URL of the given site.
- Also fixed a regression where the key for the `stagingUrl` has changed.

## Tests

<!-- What tests should be run to confirm functionality? -->

**Unit tests**: Run `npm run tests`

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*