### PR TITLE
fix: compute the number of new comments to show

### DIFF
--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -243,14 +243,16 @@ export default class ReviewRequestService {
         // 3. The review request views table contains a record in the
         //    lastViewedAt entry, and the comment has a timestamp greater
         //    than the one stored in the database.
-        const newComments = await this.getComments(
+        const allComments = await this.getComments(
           sessionData,
           site,
           pullRequestNumber
         )
         const countNewComments = await Promise.all(
-          newComments.map(async (value) => value.isRead)
-        ).then((arr) => arr.filter((value) => value).length)
+          allComments.map(async (value) => value.isRead)
+        ).then(
+          (arr) => arr.filter((isCommentRead) => isCommentRead === true).length
+        )
 
         return {
           id: pullRequestNumber,

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -250,9 +250,10 @@ export default class ReviewRequestService {
         )
         const countNewComments = await Promise.all(
           allComments.map(async (value) => value.isRead)
-        ).then(
-          (arr) => arr.filter((isCommentRead) => isCommentRead === true).length
-        )
+        ).then((arr) => {
+          const readComments = arr.filter((isRead) => !!isRead)
+          return readComments.length
+        })
 
         return {
           id: pullRequestNumber,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The current dashboard summary does not display a count of the number of new comments that the user has not seen.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- The existing site dashboard summary endpoint has been enhanced to use the new list comments feature, which provides a boolean for each comment on whether it is the first time the user is seeing the comment. A count is taken and returned to the user.

## Tests

<!-- What tests should be run to confirm functionality? -->

There are no tests 😭 

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*