### PR TITLE
feat: add endpoint to mark a review request as viewed

### DIFF
--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -285,18 +285,12 @@ export default class ReviewRequestService {
     const { isomerUserId: userId } = sessionData
     const { id: reviewRequestId } = reviewRequest
 
-    await this.reviewRequestView.update(
-      {
-        lastViewedAt: new Date(),
-      },
-      {
-        where: {
-          reviewRequestId,
-          siteId: site.id,
-          userId,
-        },
-      }
-    )
+    await this.reviewRequestView.upsert({
+      reviewRequestId,
+      siteId: site.id,
+      userId,
+      lastViewedAt: new Date(),
+    })
   }
 
   markReviewRequestAsViewed = async (

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -299,6 +299,35 @@ export default class ReviewRequestService {
     )
   }
 
+  markReviewRequestAsViewed = async (
+    sessionData: UserWithSiteSessionData,
+    site: Site,
+    requestId: number
+  ): Promise<void> => {
+    const { isomerUserId: userId } = sessionData
+
+    const reviewRequestView = await this.reviewRequestView.findOne({
+      where: {
+        siteId: site.id,
+        userId,
+        reviewRequestId: requestId,
+      },
+    })
+
+    // We only want to create the entry if it does not exist
+    // (i.e. the review request has never been viewed before)
+    if (!reviewRequestView) {
+      await this.reviewRequestView.create({
+        reviewRequestId: requestId,
+        siteId: site.id,
+        userId,
+        // This field represents the user opening the review request
+        // itself, which the user has not done so yet at this stage.
+        lastViewedAt: null,
+      })
+    }
+  }
+
   deleteAllReviewRequestViews = async (
     site: Site,
     pullRequestNumber: number


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Currently, there is no specific endpoint for marking a review request as viewed. This would mean that a user that accesses a review request directly using the URL and goes into the site dashboard will incorrectly see the review request as new.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- A new API POST endpoint has been added to allow marking a particular review request as viewed.

## Tests

<!-- What tests should be run to confirm functionality? -->

There are no tests 😭 

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*