### PR TITLE
fix: use review request requestor email for production commit email

### DIFF
--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -5,6 +5,10 @@ import request from "supertest"
 import {
   IsomerAdmin,
   Repo,
+  Reviewer,
+  ReviewMeta,
+  ReviewRequest,
+  ReviewRequestView,
   Site,
   SiteMember,
   User,
@@ -19,6 +23,7 @@ import { GitHubService } from "@root/services/db/GitHubService"
 import { ConfigYmlService } from "@root/services/fileServices/YmlFileServices/ConfigYmlService"
 import IsomerAdminsService from "@root/services/identity/IsomerAdminsService"
 import SitesService from "@root/services/identity/SitesService"
+import ReviewRequestService from "@root/services/review/ReviewRequestService"
 import { getIdentityAuthService, getUsersService } from "@services/identity"
 import CollaboratorsService from "@services/identity/CollaboratorsService"
 import { sequelize } from "@tests/database"
@@ -35,12 +40,21 @@ const configYmlService = new ConfigYmlService({ gitHubService })
 const usersService = getUsersService(sequelize)
 const isomerAdminsService = new IsomerAdminsService({ repository: IsomerAdmin })
 const identityAuthService = getIdentityAuthService(gitHubService)
+const reviewRequestService = new ReviewRequestService(
+  gitHubService,
+  User,
+  ReviewRequest,
+  Reviewer,
+  ReviewMeta,
+  ReviewRequestView
+)
 const sitesService = new SitesService({
   siteRepository: Site,
   gitHubService,
   configYmlService,
   usersService,
   isomerAdminsService,
+  reviewRequestService,
 })
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,

--- a/src/server.js
+++ b/src/server.js
@@ -94,12 +94,21 @@ const gitHubService = new GitHubService({
 })
 const identityAuthService = getIdentityAuthService(gitHubService)
 const configYmlService = new ConfigYmlService({ gitHubService })
+const reviewRequestService = new ReviewRequestService(
+  gitHubService,
+  User,
+  ReviewRequest,
+  Reviewer,
+  ReviewMeta,
+  ReviewRequestView
+)
 const sitesService = new SitesService({
   siteRepository: Site,
   gitHubService,
   configYmlService,
   usersService,
   isomerAdminsService,
+  reviewRequestService,
 })
 const infraService = new InfraService({
   sitesService,
@@ -113,14 +122,6 @@ const collaboratorsService = new CollaboratorsService({
   usersService,
   whitelist: Whitelist,
 })
-const reviewRequestService = new ReviewRequestService(
-  gitHubService,
-  User,
-  ReviewRequest,
-  Reviewer,
-  ReviewMeta,
-  ReviewRequestView
-)
 
 const authenticationMiddleware = getAuthenticationMiddleware()
 const authorizationMiddleware = getAuthorizationMiddleware({

--- a/src/services/identity/__tests__/SitesService.spec.ts
+++ b/src/services/identity/__tests__/SitesService.spec.ts
@@ -29,6 +29,7 @@ import {
 import mockAxios from "@mocks/axios"
 import { NotFoundError } from "@root/errors/NotFoundError"
 import { UnprocessableError } from "@root/errors/UnprocessableError"
+import ReviewRequestService from "@root/services/review/ReviewRequestService"
 import { GitHubCommitData } from "@root/types/commitData"
 import { ConfigYmlData } from "@root/types/configYml"
 import type { RepositoryData } from "@root/types/repoInfo"
@@ -62,12 +63,17 @@ const MockIsomerAdminsService = {
   getByUserId: jest.fn(),
 }
 
+const MockReviewRequestService = {
+  getLatestMergedReviewRequest: jest.fn(),
+}
+
 const SitesService = new _SitesService({
   siteRepository: (MockRepository as unknown) as ModelStatic<Site>,
   gitHubService: (MockGithubService as unknown) as GitHubService,
   configYmlService: (MockConfigYmlService as unknown) as ConfigYmlService,
   usersService: (MockUsersService as unknown) as UsersService,
   isomerAdminsService: (MockIsomerAdminsService as unknown) as IsomerAdminsService,
+  reviewRequestService: (MockReviewRequestService as unknown) as ReviewRequestService,
 })
 
 const mockSiteName = "some site name"

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -379,6 +379,39 @@ export default class ReviewRequestService {
     return possibleReviewRequest
   }
 
+  getLatestMergedReviewRequest = async (site: Site) => {
+    const possibleReviewRequest = await this.repository.findOne({
+      where: {
+        siteId: site.id,
+        reviewStatus: ReviewRequestStatus.Merged,
+      },
+      include: [
+        {
+          model: ReviewMeta,
+          as: "reviewMeta",
+        },
+        {
+          model: User,
+          as: "requestor",
+        },
+        {
+          model: User,
+          as: "reviewers",
+        },
+        {
+          model: Site,
+        },
+      ],
+      order: [[ReviewMeta, "pullRequestNumber", "DESC"]],
+    })
+
+    if (!possibleReviewRequest) {
+      return new RequestNotFoundError()
+    }
+
+    return possibleReviewRequest
+  }
+
   getFullReviewRequest = async (
     userWithSiteSessionData: UserWithSiteSessionData,
     site: Site,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Currently, the email address of the user that published the site shows the email address stored in the GitHub commit to the master branch. However, as we are using a common access token to interface with GitHub, this email address will always be the same.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The email address of the user that last published the site is now obtained from the review requests table, provided that the commit starts with `isomergithub`, which is the user accounts for Isomer's common access tokens.

## Tests

<!-- What tests should be run to confirm functionality? -->

There are no tests 😭 

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*