### PR TITLE
fix: include full model in order by due to presence of alias

### DIFF
--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -443,7 +443,16 @@ export default class ReviewRequestService {
           model: Site,
         },
       ],
-      order: [[ReviewMeta, "pullRequestNumber", "DESC"]],
+      order: [
+        [
+          {
+            model: ReviewMeta,
+            as: "reviewMeta",
+          },
+          "pullRequestNumber",
+          "DESC",
+        ],
+      ],
     })
 
     if (!possibleReviewRequest) {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The order by syntax is incorrect for getting the latest merged review request, which has a cascading effect of causing the whole site info endpoint to not work.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The full ReviewMeta model is now included in the order attribute, as suggested by [this StackOverflow answer](https://stackoverflow.com/a/58524200)

## Tests

<!-- What tests should be run to confirm functionality? -->

There are no tests.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*