### PR TITLE
fix(review): allow rr creation by users of the site

### DIFF
--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -117,7 +117,7 @@ export class ReviewsRouter {
       userWithSiteSessionData.isomerUserId
     )
 
-    if (!role || role !== CollaboratorRoles.Admin) {
+    if (!role) {
       logger.error({
         message:
           "User attempted to create review request with invalid permissions",
@@ -129,7 +129,7 @@ export class ReviewsRouter {
         },
       })
       return res.status(404).send({
-        message: "Only admins can request reviews!",
+        message: "Only site members can request reviews!",
       })
     }
 


### PR DESCRIPTION
## Problem
Previously, rr creation was gated only to admins of a site. This was erroneous and rr creation should be allowed by **any site member**. This updates the check + error message

## Solution
don't check for `admin` role explicitly, merely existence of a role.