### PR TITLE
tests: add remaining tests for identity features in SitesService

### DIFF
--- a/src/fixtures/identity.ts
+++ b/src/fixtures/identity.ts
@@ -162,3 +162,5 @@ export const MOCK_COMMIT_MESSAGE_OBJECT_TWO = {
   fileName: MOCK_COMMIT_FILENAME_TWO,
   userId: mockIsomerUserId,
 }
+
+export const MOCK_COMMON_ACCESS_TOKEN_GITHUB_NAME = "isomergithub1"

--- a/src/fixtures/repoInfo.ts
+++ b/src/fixtures/repoInfo.ts
@@ -1,10 +1,19 @@
 import { GitHubRepositoryData } from "@root/types/repoInfo"
 
+export const MOCK_STAGING_URL_GITHUB = "https://repo-staging.netlify.app"
+export const MOCK_STAGING_URL_CONFIGYML =
+  "https://repo-staging-configyml.netlify.app"
+export const MOCK_STAGING_URL_DB = "https://repo-staging-db.netlify.app"
+
+export const MOCK_PRODUCTION_URL_GITHUB = "https://repo-prod.netlify.app"
+export const MOCK_PRODUCTION_URL_CONFIGYML =
+  "https://repo-prod-configyml.netlify.app"
+export const MOCK_PRODUCTION_URL_DB = "https://repo-prod-db.netlify.app"
+
 export const repoInfo: GitHubRepositoryData = {
   name: "repo",
   private: false,
-  description:
-    "Staging: https://repo-staging.netlify.app | Production: https://repo-prod.netlify.app",
+  description: `Staging: ${MOCK_STAGING_URL_GITHUB} | Production: ${MOCK_PRODUCTION_URL_GITHUB}`,
   pushed_at: "2021-09-09T02:41:37Z",
   permissions: {
     admin: true,

--- a/src/services/identity/SitesService.ts
+++ b/src/services/identity/SitesService.ts
@@ -16,7 +16,11 @@ import { UnprocessableError } from "@root/errors/UnprocessableError"
 import { genericGitHubAxiosInstance } from "@root/services/api/AxiosInstance"
 import { GitHubCommitData } from "@root/types/commitData"
 import { ConfigYmlData } from "@root/types/configYml"
-import type { GitHubRepositoryData, RepositoryData } from "@root/types/repoInfo"
+import type {
+  GitHubRepositoryData,
+  RepositoryData,
+  SiteUrls,
+} from "@root/types/repoInfo"
 import { SiteInfo } from "@root/types/siteInfo"
 import { GitHubService } from "@services/db/GitHubService"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
@@ -32,9 +36,6 @@ interface SitesServiceProps {
   isomerAdminsService: IsomerAdminsService
   reviewRequestService: ReviewRequestService
 }
-
-type SiteUrlTypes = "staging" | "prod"
-type SiteUrls = { [key in SiteUrlTypes]: string }
 
 class SitesService {
   // NOTE: Explicitly specifying using keyed properties to ensure

--- a/src/services/identity/__tests__/SitesService.spec.ts
+++ b/src/services/identity/__tests__/SitesService.spec.ts
@@ -84,6 +84,10 @@ const SitesService = new _SitesService({
   reviewRequestService: (MockReviewRequestService as unknown) as ReviewRequestService,
 })
 
+const SpySitesService = {
+  extractAuthorEmail: jest.spyOn(SitesService, "extractAuthorEmail"),
+}
+
 const mockSiteName = "some site name"
 const mockSite = ({
   name: "i m a site",
@@ -587,6 +591,7 @@ describe("SitesService", () => {
       // Assert
       expect(actual).toBe(expected)
       expect(MockUsersService.findById).toHaveBeenCalledWith(mockIsomerUserId)
+      expect(SpySitesService.extractAuthorEmail).not.toHaveBeenCalled()
     })
 
     it("should return the email of the commit author who is a GitHub login user", async () => {
@@ -607,6 +612,7 @@ describe("SitesService", () => {
       // Assert
       expect(actual).toBe(expected)
       expect(MockUsersService.findById).not.toHaveBeenCalled()
+      expect(SpySitesService.extractAuthorEmail).toHaveBeenCalled()
     })
   })
 
@@ -634,6 +640,7 @@ describe("SitesService", () => {
       expect(
         MockReviewRequestService.getLatestMergedReviewRequest
       ).not.toHaveBeenCalled()
+      expect(SpySitesService.extractAuthorEmail).toHaveBeenCalled()
     })
 
     it("should return the email of the merge commit author if the site cannot be found", async () => {
@@ -660,6 +667,7 @@ describe("SitesService", () => {
       expect(
         MockReviewRequestService.getLatestMergedReviewRequest
       ).not.toHaveBeenCalled()
+      expect(SpySitesService.extractAuthorEmail).toHaveBeenCalled()
     })
 
     it("should return the email of the merge commit author if there are no merged review requests", async () => {
@@ -689,6 +697,7 @@ describe("SitesService", () => {
       expect(
         MockReviewRequestService.getLatestMergedReviewRequest
       ).toHaveBeenCalledWith(mockSite)
+      expect(SpySitesService.extractAuthorEmail).toHaveBeenCalled()
     })
 
     it("should return the email of the requestor for the latest merged review request", async () => {
@@ -723,6 +732,7 @@ describe("SitesService", () => {
       expect(
         MockReviewRequestService.getLatestMergedReviewRequest
       ).toHaveBeenCalledWith(mockSite)
+      expect(SpySitesService.extractAuthorEmail).not.toHaveBeenCalled()
     })
 
     it("should return the email of the merge commit author if the requestor for the latest merged review request does not have an email", async () => {
@@ -757,6 +767,7 @@ describe("SitesService", () => {
       expect(
         MockReviewRequestService.getLatestMergedReviewRequest
       ).toHaveBeenCalledWith(mockSite)
+      expect(SpySitesService.extractAuthorEmail).toHaveBeenCalled()
     })
   })
 

--- a/src/services/identity/__tests__/SitesService.spec.ts
+++ b/src/services/identity/__tests__/SitesService.spec.ts
@@ -18,6 +18,12 @@ import {
   repoInfo2,
   adminRepo,
   noAccessRepo,
+  MOCK_STAGING_URL_CONFIGYML,
+  MOCK_PRODUCTION_URL_CONFIGYML,
+  MOCK_PRODUCTION_URL_DB,
+  MOCK_STAGING_URL_DB,
+  MOCK_STAGING_URL_GITHUB,
+  MOCK_PRODUCTION_URL_GITHUB,
 } from "@fixtures/repoInfo"
 import {
   mockUserWithSiteSessionData,
@@ -151,24 +157,24 @@ describe("SitesService", () => {
 
   describe("getUrlsOfSite", () => {
     const deployment: Partial<Deployment> = {
-      stagingUrl: "https://repo-deployment-staging.netlify.app",
-      productionUrl: "https://repo-deployment-prod.netlify.app",
+      stagingUrl: MOCK_STAGING_URL_DB,
+      productionUrl: MOCK_PRODUCTION_URL_DB,
     }
     const emptyDeployment: Partial<Deployment> = {
       stagingUrl: "",
       productionUrl: "",
     }
     const configYmlData: Partial<ConfigYmlData> = {
-      staging: "https://repo-configyml-staging.netlify.app",
-      prod: "https://repo-configyml-prod.netlify.app",
+      staging: MOCK_STAGING_URL_CONFIGYML,
+      prod: MOCK_PRODUCTION_URL_CONFIGYML,
     }
     const emptyConfigYmlData: Partial<ConfigYmlData> = {
       staging: "",
       prod: "",
     }
     const gitHubUrls = {
-      staging: "https://repo-repoinfo-staging.netlify.app",
-      prod: "https://repo-repoinfo-prod.netlify.app",
+      staging: MOCK_STAGING_URL_GITHUB,
+      prod: MOCK_PRODUCTION_URL_GITHUB,
     }
     const repoInfo: { description: string } = {
       description: `Staging: ${gitHubUrls.staging} | Production: ${gitHubUrls.prod}`,
@@ -464,14 +470,14 @@ describe("SitesService", () => {
   })
 
   describe("getStagingUrl", () => {
-    const stagingUrl = "https://repo-staging.netlify.app"
-    const productionUrl = "https://repo-prod.netlify.app"
-
     it("should return the staging URL if it is available", async () => {
       // Arrange
       const mockSiteWithDeployment = {
         ...mockSite,
-        deployment: { stagingUrl, productionUrl },
+        deployment: {
+          stagingUrl: MOCK_STAGING_URL_DB,
+          productionUrl: MOCK_PRODUCTION_URL_DB,
+        },
       }
 
       MockRepository.findOne.mockResolvedValueOnce(mockSiteWithDeployment)
@@ -482,7 +488,7 @@ describe("SitesService", () => {
       )
 
       // Assert
-      expect(actual).toEqual(stagingUrl)
+      expect(actual).toEqual(MOCK_STAGING_URL_DB)
       expect(MockRepository.findOne).toHaveBeenCalled()
     })
 
@@ -509,14 +515,14 @@ describe("SitesService", () => {
   })
 
   describe("getSiteUrl", () => {
-    const stagingUrl = "https://repo-staging.netlify.app"
-    const productionUrl = "https://repo-prod.netlify.app"
-
     it("should return the site URL if it is available", async () => {
       // Arrange
       const mockSiteWithDeployment = {
         ...mockSite,
-        deployment: { stagingUrl, productionUrl },
+        deployment: {
+          stagingUrl: MOCK_STAGING_URL_DB,
+          productionUrl: MOCK_PRODUCTION_URL_DB,
+        },
       }
 
       MockRepository.findOne.mockResolvedValueOnce(mockSiteWithDeployment)
@@ -527,7 +533,7 @@ describe("SitesService", () => {
       )
 
       // Assert
-      expect(actual).toEqual(productionUrl)
+      expect(actual).toEqual(MOCK_PRODUCTION_URL_DB)
       expect(MockRepository.findOne).toHaveBeenCalled()
     })
 
@@ -554,13 +560,11 @@ describe("SitesService", () => {
   })
 
   describe("getSiteInfo", () => {
-    const stagingUrl = "https://repo-staging.netlify.app"
-    const productionUrl = "https://repo-prod.netlify.app"
     const mockSiteWithDeployment = {
       ...mockSite,
       deployment: {
-        stagingUrl,
-        productionUrl,
+        stagingUrl: MOCK_STAGING_URL_DB,
+        productionUrl: MOCK_PRODUCTION_URL_DB,
       },
     }
 
@@ -593,8 +597,8 @@ describe("SitesService", () => {
         savedBy: MOCK_GITHUB_EMAIL_ADDRESS_ONE,
         publishedAt: new Date(MOCK_GITHUB_DATE_TWO).getTime(),
         publishedBy: MOCK_GITHUB_EMAIL_ADDRESS_TWO,
-        stagingUrl,
-        siteUrl: productionUrl,
+        stagingUrl: MOCK_STAGING_URL_DB,
+        siteUrl: MOCK_PRODUCTION_URL_DB,
       }
 
       MockRepository.findOne.mockResolvedValueOnce(mockSiteWithDeployment)
@@ -644,8 +648,8 @@ describe("SitesService", () => {
         savedBy: MOCK_GITHUB_EMAIL_ADDRESS_ONE,
         publishedAt: new Date(MOCK_GITHUB_DATE_TWO).getTime(),
         publishedBy: MOCK_GITHUB_EMAIL_ADDRESS_TWO,
-        stagingUrl,
-        siteUrl: productionUrl,
+        stagingUrl: MOCK_STAGING_URL_DB,
+        siteUrl: MOCK_PRODUCTION_URL_DB,
       }
 
       MockRepository.findOne.mockResolvedValueOnce(mockSiteWithDeployment)
@@ -712,8 +716,8 @@ describe("SitesService", () => {
         savedBy: "Unknown Author",
         publishedAt: 0,
         publishedBy: "Unknown Author",
-        stagingUrl,
-        siteUrl: productionUrl,
+        stagingUrl: MOCK_STAGING_URL_DB,
+        siteUrl: MOCK_PRODUCTION_URL_DB,
       }
 
       const mockEmptyCommit: GitHubCommitData = {

--- a/src/types/repoInfo.ts
+++ b/src/types/repoInfo.ts
@@ -18,3 +18,6 @@ export type RepositoryData = {
   repoName: GitHubRepositoryData["name"]
   isPrivate: GitHubRepositoryData["private"]
 }
+
+type SiteUrlTypes = "staging" | "prod"
+export type SiteUrls = { [key in SiteUrlTypes]: string }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The new identity features do not have sufficient unit test coverage in SitesService, which can be dangerous.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- The remaining unit tests for SitesService has been added for the new identity features.
- The SiteUrl type has been moved into the repoInfo.ts types file, so that it can also be used in the unit tests.

## Tests

<!-- What tests should be run to confirm functionality? -->

**Unit tests**: Run `npm run test` on this branch to verify that all the new unit tests pass

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*