### PR TITLE
chore(collaborators): update typings

### DIFF
--- a/src/routes/v2/authenticated/collaborators.ts
+++ b/src/routes/v2/authenticated/collaborators.ts
@@ -1,11 +1,14 @@
 import autoBind from "auto-bind"
 import express from "express"
+import _ from "lodash"
+import { Jsonify } from "type-fest"
 
 import { AuthorizationMiddleware } from "@middleware/authorization"
 import { attachReadRouteHandlerWrapper } from "@middleware/routeHandler"
 
 import UserWithSiteSessionData from "@classes/UserWithSiteSessionData"
 
+import { SiteMember, User } from "@root/database/models"
 import { BaseIsomerError } from "@root/errors/BaseError"
 import { attachSiteHandler } from "@root/middleware"
 import { RequestHandler } from "@root/types"
@@ -84,8 +87,8 @@ export class CollaboratorsRouter {
       siteName,
       userWithSiteSessionData.isomerUserId
     )
-    const collaborators = rawCollaborators.map((collaborator) => ({
-      ...collaborator.toJSON(),
+    const collaborators: UserDto[] = rawCollaborators.map((collaborator) => ({
+      ..._.omit(collaborator.toJSON(), "SiteMember"),
       email: collaborator.email || "",
       role: collaborator.SiteMember.role,
     }))

--- a/src/routes/v2/authenticated/collaborators.ts
+++ b/src/routes/v2/authenticated/collaborators.ts
@@ -1,14 +1,12 @@
 import autoBind from "auto-bind"
 import express from "express"
 import _ from "lodash"
-import { Jsonify } from "type-fest"
 
 import { AuthorizationMiddleware } from "@middleware/authorization"
 import { attachReadRouteHandlerWrapper } from "@middleware/routeHandler"
 
 import UserWithSiteSessionData from "@classes/UserWithSiteSessionData"
 
-import { SiteMember, User } from "@root/database/models"
 import { BaseIsomerError } from "@root/errors/BaseError"
 import { attachSiteHandler } from "@root/middleware"
 import { RequestHandler } from "@root/types"
@@ -88,7 +86,7 @@ export class CollaboratorsRouter {
       userWithSiteSessionData.isomerUserId
     )
     const collaborators: UserDto[] = rawCollaborators.map((collaborator) => ({
-      ..._.omit(collaborator.toJSON(), "SiteMember"),
+      ..._.omit(collaborator.toJSON<UserDto>(), "SiteMember"),
       email: collaborator.email || "",
       role: collaborator.SiteMember.role,
     }))

--- a/src/types/dto/review.ts
+++ b/src/types/dto/review.ts
@@ -1,4 +1,8 @@
+import { Jsonify } from "type-fest"
+
 import { CollaboratorRoles } from "@constants/constants"
+
+import { User } from "@root/database/models"
 
 export type ReviewRequestStatus = "OPEN" | "APPROVED" | "MERGED" | "CLOSED"
 
@@ -13,7 +17,7 @@ export interface EditedItemDto {
   lastEditedTime: number
 }
 
-export interface UserDto {
+export interface UserDto extends Jsonify<User> {
   email: string
   role: CollaboratorRoles
 }

--- a/src/types/dto/review.ts
+++ b/src/types/dto/review.ts
@@ -1,8 +1,4 @@
-import { Jsonify } from "type-fest"
-
 import { CollaboratorRoles } from "@constants/constants"
-
-import { User } from "@root/database/models"
 
 export type ReviewRequestStatus = "OPEN" | "APPROVED" | "MERGED" | "CLOSED"
 
@@ -17,9 +13,11 @@ export interface EditedItemDto {
   lastEditedTime: number
 }
 
-export interface UserDto extends Jsonify<User> {
+export interface UserDto {
   email: string
   role: CollaboratorRoles
+  id: string
+  lastLoggedIn: string
 }
 
 export type DashboardReviewRequestDto = {


### PR DESCRIPTION
## Problem
The FE had outdated typings for collaborators, which was fixed by the PR [here](https://github.com/isomerpages/isomercms-frontend/pull/1152); this PR adds the relevant properties to the return value for the `/collaborators` route 

## Solution
1. use `Jsonify` type to indicate properties
2. omit `SiteMembers` model and parse it to `role`
