### PR TITLE
Feat: add generic notification handler tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
       - run: npm run dev:services
-      - run: . .env.test && npx jest
+      - run: . .env.test && npx jest --runInBand
       - run: docker compose down
 
   gatekeep:

--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -110,6 +110,18 @@ describe("Notifications Router", () => {
       changed_files: [],
       created_at: new Date(),
     })
+
+    // We need to force the relevant tables to start from a clean slate
+    // Otherwise, some tests may fail due to the auto-incrementing IDs
+    // not starting from 1
+    await User.sync({ force: true })
+    await Site.sync({ force: true })
+    await Repo.sync({ force: true })
+    await SiteMember.sync({ force: true })
+    await Notification.sync({ force: true })
+    await ReviewMeta.sync({ force: true })
+    await ReviewRequest.sync({ force: true })
+
     // Set up User and Site table entries
     await User.create({
       id: mockIsomerUserId,

--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -1,0 +1,221 @@
+import express from "express"
+import request from "supertest"
+
+import {
+  Notification,
+  Repo,
+  Reviewer,
+  ReviewMeta,
+  ReviewRequest,
+  ReviewRequestView,
+  Site,
+  SiteMember,
+  User,
+  Whitelist,
+} from "@database/models"
+import { generateRouter } from "@fixtures/app"
+import UserSessionData from "@root/classes/UserSessionData"
+import {
+  mockEmail,
+  mockIsomerUserId,
+  mockSiteName,
+} from "@root/fixtures/sessionData"
+import { NotificationOnEditHandler } from "@root/middleware/notificationOnEditHandler"
+import { GitHubService } from "@root/services/db/GitHubService"
+import { ConfigYmlService } from "@root/services/fileServices/YmlFileServices/ConfigYmlService"
+import CollaboratorsService from "@root/services/identity/CollaboratorsService"
+import IsomerAdminsService from "@root/services/identity/IsomerAdminsService"
+import SitesService from "@root/services/identity/SitesService"
+import ReviewRequestService from "@root/services/review/ReviewRequestService"
+import { getUsersService, notificationsService } from "@services/identity"
+import { sequelize } from "@tests/database"
+
+const mockSiteId = "1"
+const mockSiteMemberId = "1"
+
+const mockGithubService = {
+  getPullRequest: jest.fn(),
+  getComments: jest.fn(),
+}
+const usersService = getUsersService(sequelize)
+const reviewRequestService = new ReviewRequestService(
+  (mockGithubService as unknown) as GitHubService,
+  User,
+  ReviewRequest,
+  Reviewer,
+  ReviewMeta,
+  ReviewRequestView
+)
+const sitesService = new SitesService({
+  siteRepository: Site,
+  gitHubService: (mockGithubService as unknown) as GitHubService,
+  configYmlService: (jest.fn() as unknown) as ConfigYmlService,
+  usersService,
+  isomerAdminsService: (jest.fn() as unknown) as IsomerAdminsService,
+  reviewRequestService,
+})
+const collaboratorsService = new CollaboratorsService({
+  siteRepository: Site,
+  siteMemberRepository: SiteMember,
+  sitesService,
+  usersService,
+  whitelist: Whitelist,
+})
+
+const notificationsHandler = new NotificationOnEditHandler({
+  reviewRequestService,
+  collaboratorsService,
+  sitesService,
+  notificationsService,
+})
+
+// Set up express with defaults and use the router under test
+const subrouter = express()
+// As we set certain properties on res.locals when the user signs in using github
+// In order to do integration testing, we must expose a middleware
+// that allows us to set this properties also
+subrouter.use((req, res, next) => {
+  const userSessionData = new UserSessionData({
+    isomerUserId: mockIsomerUserId,
+    email: mockEmail,
+  })
+  res.locals.userSessionData = userSessionData
+  next()
+})
+const subSubrouter = express()
+subSubrouter.get("/:siteName/test", async (req, res, next) =>
+  // Dummy subrouter
+  next()
+)
+subrouter.use(subSubrouter)
+
+// We handle the test slightly diferently - jest interprets the end of the test as when the response is sent,
+// but we normally create a notification after this response, due to the position of the middleware
+// the solution to get tests working is to send a response only after the notification middleware
+subrouter.use(async (req, res, next) => {
+  await notificationsHandler.createNotification(req as any, res as any, next)
+  res.status(200).send(200)
+})
+const app = generateRouter(subrouter)
+
+describe("Notifications Router", () => {
+  const mockAdditionalUserId = "2"
+  const mockAdditionalSiteId = "2"
+  const mockAdditionalSiteMemberId = "2"
+  const mockAnotherSiteMemberId = "3"
+
+  beforeAll(async () => {
+    // Mock github service return
+    mockGithubService.getPullRequest.mockResolvedValue({
+      title: "title",
+      body: "body",
+      changed_files: [],
+      created_at: new Date(),
+    })
+    // Set up User and Site table entries
+    await User.create({
+      id: mockIsomerUserId,
+    })
+    await User.create({
+      id: mockAdditionalUserId,
+    })
+    await Site.create({
+      id: mockSiteId,
+      name: mockSiteName,
+      apiTokenName: "token",
+      jobStatus: "READY",
+      siteStatus: "LAUNCHED",
+      creatorId: mockIsomerUserId,
+    })
+    await SiteMember.create({
+      userId: mockIsomerUserId,
+      siteId: mockSiteId,
+      role: "ADMIN",
+      id: mockSiteMemberId,
+    })
+    await Repo.create({
+      name: mockSiteName,
+      url: "url",
+      siteId: mockSiteId,
+    })
+    await SiteMember.create({
+      userId: mockAdditionalUserId,
+      siteId: mockSiteId,
+      role: "ADMIN",
+      id: mockAdditionalSiteMemberId,
+    })
+    await Site.create({
+      id: mockAdditionalSiteId,
+      name: mockSiteName,
+      apiTokenName: "token",
+      jobStatus: "READY",
+      siteStatus: "LAUNCHED",
+      creatorId: mockIsomerUserId,
+    })
+    await SiteMember.create({
+      userId: mockIsomerUserId,
+      siteId: mockAdditionalSiteId,
+      role: "ADMIN",
+      id: mockAnotherSiteMemberId,
+    })
+    await Repo.create({
+      name: `${mockSiteName}2`,
+      url: "url",
+      siteId: mockAdditionalSiteId,
+    })
+  })
+  describe("createNotification handler", () => {
+    afterEach(async () => {
+      // Clean up so that different tests using
+      // the same notifications don't interfere with each other
+      await Notification.sync({ force: true })
+      await ReviewMeta.sync({ force: true })
+      await ReviewRequest.sync({ force: true })
+    })
+    it("should create a new notification when called", async () => {
+      // Arrange
+      await ReviewRequest.create({
+        id: 1,
+        requestorId: mockIsomerUserId,
+        siteId: mockSiteId,
+        reviewStatus: "OPEN",
+      })
+      await ReviewMeta.create({
+        reviewId: 1,
+        pullRequestNumber: 1,
+        reviewLink: "test",
+      })
+      mockGithubService.getComments.mockResolvedValueOnce([])
+
+      // Act
+      await request(app).get(`/${mockSiteName}/test`)
+
+      // Assert
+      // Notification should be sent to all site members other than the creator
+      expect(
+        (
+          await Notification.findAll({
+            where: {
+              userId: mockAdditionalUserId,
+              siteId: mockSiteId,
+              siteMemberId: mockAdditionalSiteMemberId,
+              firstReadTime: null,
+            },
+          })
+        ).length
+      ).toEqual(1)
+      expect(
+        (
+          await Notification.findAll({
+            where: {
+              userId: mockIsomerUserId,
+              siteId: mockSiteId,
+              siteMemberId: mockSiteMemberId,
+              firstReadTime: null,
+            },
+          })
+        ).length
+      ).toEqual(0)
+    })
+  })
+})

--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -27,6 +27,7 @@ import CollaboratorsService from "@root/services/identity/CollaboratorsService"
 import IsomerAdminsService from "@root/services/identity/IsomerAdminsService"
 import SitesService from "@root/services/identity/SitesService"
 import ReviewRequestService from "@root/services/review/ReviewRequestService"
+import * as ReviewApi from "@services/db/review"
 import { getUsersService, notificationsService } from "@services/identity"
 import { sequelize } from "@tests/database"
 
@@ -39,7 +40,7 @@ const mockGithubService = {
 }
 const usersService = getUsersService(sequelize)
 const reviewRequestService = new ReviewRequestService(
-  (mockGithubService as unknown) as GitHubService,
+  (mockGithubService as unknown) as typeof ReviewApi,
   User,
   ReviewRequest,
   Reviewer,
@@ -143,7 +144,7 @@ describe("Notifications Router", () => {
     })
     await Site.create({
       id: mockAdditionalSiteId,
-      name: mockSiteName,
+      name: "mockSite2",
       apiTokenName: "token",
       jobStatus: "READY",
       siteStatus: "LAUNCHED",

--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -81,7 +81,7 @@ subSubrouter.get("/:siteName/test", async (req, res, next) =>
 )
 subrouter.use(subSubrouter)
 
-// We handle the test slightly diferently - jest interprets the end of the test as when the response is sent,
+// We handle the test slightly differently - jest interprets the end of the test as when the response is sent,
 // but we normally create a notification after this response, due to the position of the middleware
 // the solution to get tests working is to send a response only after the notification middleware
 subrouter.use(async (req, res, next) => {

--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -1,6 +1,10 @@
 import express from "express"
 import request from "supertest"
 
+import { NotificationOnEditHandler } from "@middleware/notificationOnEditHandler"
+
+import UserSessionData from "@classes/UserSessionData"
+
 import {
   Notification,
   Repo,
@@ -14,21 +18,19 @@ import {
   Whitelist,
 } from "@database/models"
 import { generateRouterForUserWithSite } from "@fixtures/app"
-import UserSessionData from "@root/classes/UserSessionData"
 import {
   mockEmail,
   mockIsomerUserId,
   mockSiteName,
-} from "@root/fixtures/sessionData"
-import { NotificationOnEditHandler } from "@root/middleware/notificationOnEditHandler"
-import { GitHubService } from "@root/services/db/GitHubService"
-import { ConfigYmlService } from "@root/services/fileServices/YmlFileServices/ConfigYmlService"
-import CollaboratorsService from "@root/services/identity/CollaboratorsService"
-import IsomerAdminsService from "@root/services/identity/IsomerAdminsService"
-import SitesService from "@root/services/identity/SitesService"
-import ReviewRequestService from "@root/services/review/ReviewRequestService"
+} from "@fixtures/sessionData"
+import { GitHubService } from "@services/db/GitHubService"
 import * as ReviewApi from "@services/db/review"
+import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
 import { getUsersService, notificationsService } from "@services/identity"
+import CollaboratorsService from "@services/identity/CollaboratorsService"
+import IsomerAdminsService from "@services/identity/IsomerAdminsService"
+import SitesService from "@services/identity/SitesService"
+import ReviewRequestService from "@services/review/ReviewRequestService"
 import { sequelize } from "@tests/database"
 
 const mockSiteId = "1"

--- a/src/integration/Notifications.spec.ts
+++ b/src/integration/Notifications.spec.ts
@@ -39,6 +39,7 @@ import { ConfigYmlService } from "@root/services/fileServices/YmlFileServices/Co
 import CollaboratorsService from "@root/services/identity/CollaboratorsService"
 import SitesService from "@root/services/identity/SitesService"
 import ReviewRequestService from "@root/services/review/ReviewRequestService"
+import * as ReviewApi from "@services/db/review"
 import {
   getIdentityAuthService,
   getUsersService,
@@ -58,7 +59,7 @@ const identityAuthService = getIdentityAuthService(gitHubService)
 const usersService = getUsersService(sequelize)
 const configYmlService = new ConfigYmlService({ gitHubService })
 const reviewRequestService = new ReviewRequestService(
-  gitHubService,
+  (gitHubService as unknown) as typeof ReviewApi,
   User,
   ReviewRequest,
   Reviewer,

--- a/src/integration/Notifications.spec.ts
+++ b/src/integration/Notifications.spec.ts
@@ -110,6 +110,15 @@ describe("Notifications Router", () => {
   const MOCK_ANOTHER_SITE_MEMBER_ID = "3"
 
   beforeAll(async () => {
+    // We need to force the relevant tables to start from a clean slate
+    // Otherwise, some tests may fail due to the auto-incrementing IDs
+    // not starting from 1
+    await User.sync({ force: true })
+    await Site.sync({ force: true })
+    await Repo.sync({ force: true })
+    await SiteMember.sync({ force: true })
+    await Notification.sync({ force: true })
+
     // Set up User and Site table entries
     await User.create({
       id: mockIsomerUserId,

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -7,6 +7,7 @@ import { SitesRouter as _SitesRouter } from "@routes/v2/authenticated/sites"
 
 import {
   IsomerAdmin,
+  Notification,
   Repo,
   Reviewer,
   ReviewMeta,
@@ -70,8 +71,9 @@ import {
 import { ReviewRequestStatus } from "@root/constants"
 import { ReviewRequestDto } from "@root/types/dto/review"
 import { GitHubService } from "@services/db/GitHubService"
+import * as ReviewApi from "@services/db/review"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
-import { getUsersService } from "@services/identity"
+import { getUsersService, notificationsService } from "@services/identity"
 import CollaboratorsService from "@services/identity/CollaboratorsService"
 import IsomerAdminsService from "@services/identity/IsomerAdminsService"
 import SitesService from "@services/identity/SitesService"
@@ -83,7 +85,7 @@ const configYmlService = new ConfigYmlService({ gitHubService })
 const usersService = getUsersService(sequelize)
 const isomerAdminsService = new IsomerAdminsService({ repository: IsomerAdmin })
 const reviewRequestService = new ReviewRequestService(
-  gitHubService,
+  (gitHubService as unknown) as typeof ReviewApi,
   User,
   ReviewRequest,
   Reviewer,
@@ -110,7 +112,8 @@ const ReviewsRouter = new _ReviewsRouter(
   reviewRequestService,
   usersService,
   sitesService,
-  collaboratorsService
+  collaboratorsService,
+  notificationsService
 )
 const reviewsSubrouter = ReviewsRouter.getRouter()
 const subrouter = express()

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -139,6 +139,8 @@ describe("Review Requests Integration Tests", () => {
     await Site.sync({ force: true })
     await Repo.sync({ force: true })
     await SiteMember.sync({ force: true })
+    await Notification.sync({ force: true })
+    await ReviewMeta.sync({ force: true })
 
     await User.create(MOCK_USER_DBENTRY_ONE)
     await User.create(MOCK_USER_DBENTRY_TWO)


### PR DESCRIPTION
This PR adds tests for the notification middleware introduced in #514.

Of special note is the format of the router setup for the test - our actual setup involves invoking the notification creation method only after the response has been sent, but jest ends the test once the response has been received. As such, the test setup involves creating a custom wrapper over the existing notification creation handler to add in the response sent.