### PR TITLE
Feat/add middleware for verifying email user

### DIFF
--- a/src/middleware/authorization.ts
+++ b/src/middleware/authorization.ts
@@ -20,6 +20,19 @@ export class AuthorizationMiddleware {
     autoBind(this)
   }
 
+  // Check whether a user is using email login or github login
+  verifyIsEmailUser: RequestHandler<
+    never,
+    unknown,
+    unknown,
+    never,
+    { userWithSiteSessionData: UserWithSiteSessionData }
+  > = async (req, res, next) => {
+    const { userWithSiteSessionData } = res.locals
+    if (!userWithSiteSessionData.isEmailUser()) return next("router")
+    return next()
+  }
+
   // Check whether a user is a site admin
   verifySiteAdmin: RequestHandler<
     never,

--- a/src/routes/v2/authenticated/collaborators.ts
+++ b/src/routes/v2/authenticated/collaborators.ts
@@ -129,6 +129,7 @@ export class CollaboratorsRouter {
 
   getRouter() {
     const router = express.Router({ mergeParams: true })
+    router.use(this.authorizationMiddleware.verifyIsEmailUser)
     router.get(
       "/role",
       attachSiteHandler,


### PR DESCRIPTION
## Problem

Currently, we have no restrictions on accessing identity specific routes (collaborators, review requests, notifications) for users using github login. This PR introduces middleware to check if a user is an email user and restricts access to that route if not. This PR currently only restricts collaborators - the restrictions for reviews and notifications will be added in with #523 as the structure of these routes were modified in that PR. To be reviewed in conjunction with PR #[1157](https://github.com/isomerpages/isomercms-frontend/pull/1157) on the isomercms-frontend repo.