### PR TITLE
tests: add integration tests for review requests and comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node -r ts-node/register/transpile-only -r tsconfig-paths/register build/server.js",
     "dev:services": "docker compose up -d",
     "dev": "source .env && ts-node-dev --respawn src/server.js",
-    "test": "source .env.test && jest",
+    "test": "source .env.test && jest --runInBand",
     "release": "npm version $npm_config_isomer_update && git push --tags",
     "lint": "npx eslint .",
     "lint-fix": "eslint --ignore-path .gitignore . --fix",

--- a/src/fixtures/app.ts
+++ b/src/fixtures/app.ts
@@ -140,3 +140,17 @@ export const generateRouterForUserWithSite = (
   app.use(router)
   return generateFinalRouter(app)
 }
+
+export const generateRouterForDefaultUser = (router: Express) => {
+  const app = express()
+  app.use(attachDefaultUserSessionData)
+  app.use(router)
+  return generateFinalRouter(app)
+}
+
+export const generateRouterForDefaultUserWithSite = (router: Express) => {
+  const app = express()
+  app.use(attachDefaultUserSessionDataWithSite)
+  app.use(router)
+  return generateFinalRouter(app)
+}

--- a/src/fixtures/app.ts
+++ b/src/fixtures/app.ts
@@ -16,7 +16,7 @@ import {
   mockGithubSessionData,
   MOCK_USER_SESSION_DATA_ONE,
 } from "./sessionData"
-import { MOCK_SITE_NAME_ONE } from "./sites"
+import { MOCK_REPO_NAME_ONE } from "./sites"
 
 /**
  * @deprecated
@@ -93,7 +93,7 @@ const attachDefaultUserSessionDataWithSite: RequestHandler<
   }
 > = attachUserSessionDataWithSite(
   MOCK_USER_SESSION_DATA_ONE,
-  MOCK_SITE_NAME_ONE
+  MOCK_REPO_NAME_ONE
 )
 
 /**

--- a/src/fixtures/github.ts
+++ b/src/fixtures/github.ts
@@ -1,9 +1,4 @@
-import {
-  Commit,
-  RawComment,
-  RawFileChangeInfo,
-  RawPullRequest,
-} from "@root/types/github"
+import { Commit, RawComment, RawFileChangeInfo } from "@root/types/github"
 
 import { MOCK_USER_ID_ONE, MOCK_USER_ID_TWO } from "./users"
 
@@ -25,8 +20,14 @@ export const MOCK_GITHUB_COMMIT_DATE_TWO = "2022-10-13T05:39:43Z"
 export const MOCK_GITHUB_COMMIT_DATE_THREE = "2022-11-07T16:32:08Z"
 export const MOCK_GITHUB_FILENAME_ALPHA_ONE = "index.md"
 export const MOCK_GITHUB_FILEPATH_ALPHA_ONE = ""
+export const MOCK_GITHUB_FULL_FILEPATH_ALPHA_ONE = encodeURIComponent(
+  MOCK_GITHUB_FILENAME_ALPHA_ONE
+)
 export const MOCK_GITHUB_FILENAME_ALPHA_TWO = "Example Title 22.md"
 export const MOCK_GITHUB_FILEPATH_ALPHA_TWO = "pages/"
+export const MOCK_GITHUB_FULL_FILEPATH_ALPHA_TWO = encodeURIComponent(
+  MOCK_GITHUB_FILEPATH_ALPHA_TWO + MOCK_GITHUB_FILENAME_ALPHA_TWO
+)
 export const MOCK_GITHUB_COMMIT_MESSAGE_ALPHA_ONE = `Update file: ${MOCK_GITHUB_FILENAME_ALPHA_ONE}`
 export const MOCK_GITHUB_COMMIT_MESSAGE_ALPHA_TWO = `Update file: ${MOCK_GITHUB_FILENAME_ALPHA_TWO}`
 export const MOCK_GITHUB_COMMIT_MESSAGE_OBJECT_ALPHA_ONE = {
@@ -52,20 +53,20 @@ export const MOCK_GITHUB_FILE_CHANGE_INFO_ALPHA_ONE: RawFileChangeInfo = {
   additions: 1,
   deletions: 2,
   changes: 3,
-  blob_url: `https://github.com/isomerpages/a-test-v4/blob/${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}/index.md`,
-  raw_url: `https://github.com/isomerpages/a-test-v4/raw/${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}/index.md`,
-  contents_url: `https://api.github.com/repos/isomerpages/a-test-v4/contents/index.md?ref=${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}`,
+  blob_url: `https://github.com/isomerpages/a-test-v4/blob/${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}/${MOCK_GITHUB_FULL_FILEPATH_ALPHA_ONE}`,
+  raw_url: `https://github.com/isomerpages/a-test-v4/raw/${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}/${MOCK_GITHUB_FULL_FILEPATH_ALPHA_ONE}`,
+  contents_url: `https://api.github.com/repos/isomerpages/a-test-v4/contents/${MOCK_GITHUB_FULL_FILEPATH_ALPHA_ONE}?ref=${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}`,
 }
 export const MOCK_GITHUB_FILE_CHANGE_INFO_ALPHA_TWO: RawFileChangeInfo = {
   sha: "f04f18eaa8d31fffc9f8cf5020b1f6a765ac225f",
-  filename: `${MOCK_GITHUB_FILEPATH_ALPHA_TWO}/${MOCK_GITHUB_FILENAME_ALPHA_TWO}`,
+  filename: `${MOCK_GITHUB_FILEPATH_ALPHA_TWO}${MOCK_GITHUB_FILENAME_ALPHA_TWO}`,
   status: "modified",
   additions: 13,
   deletions: 2,
   changes: 15,
-  blob_url: `https://github.com/isomerpages/a-test-v4/blob/${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}/pages%2FExample%20Title%2022.md`,
-  raw_url: `https://github.com/isomerpages/a-test-v4/raw/${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}/pages%2FExample%20Title%2022.md`,
-  contents_url: `https://api.github.com/repos/isomerpages/a-test-v4/contents/pages%2FExample%20Title%2022.md?ref=${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}`,
+  blob_url: `https://github.com/isomerpages/a-test-v4/blob/${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}/${MOCK_GITHUB_FULL_FILEPATH_ALPHA_TWO}`,
+  raw_url: `https://github.com/isomerpages/a-test-v4/raw/${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}/${MOCK_GITHUB_FULL_FILEPATH_ALPHA_TWO}`,
+  contents_url: `https://api.github.com/repos/isomerpages/a-test-v4/contents/${MOCK_GITHUB_FULL_FILEPATH_ALPHA_TWO}?ref=${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}`,
 }
 
 export const MOCK_GITHUB_COMMIT_ALPHA_ONE: Commit = {

--- a/src/fixtures/github.ts
+++ b/src/fixtures/github.ts
@@ -1,0 +1,138 @@
+import {
+  Commit,
+  RawComment,
+  RawFileChangeInfo,
+  RawPullRequest,
+} from "@root/types/github"
+
+import { MOCK_USER_ID_ONE, MOCK_USER_ID_TWO } from "./users"
+
+export const MOCK_GITHUB_USER_NAME_ONE = "isomergithub1"
+export const MOCK_GITHUB_USER_NAME_TWO = "isomergithub2"
+
+export const MOCK_GITHUB_USER_EMAIL_ONE =
+  "111718653+isomergithub1@users.noreply.github.com"
+export const MOCK_GITHUB_USER_EMAIL_TWO =
+  "111725612+isomergithub2@users.noreply.github.com"
+
+export const MOCK_GITHUB_PULL_REQUEST_NUMBER = 251
+
+// This is one set of commits and file changes which should be used together
+export const MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA =
+  "a15a7c8b23324f680cd7c5011ca763e36d350f41"
+export const MOCK_GITHUB_COMMIT_DATE_ONE = "2022-10-12T06:31:05Z"
+export const MOCK_GITHUB_COMMIT_DATE_TWO = "2022-10-13T05:39:43Z"
+export const MOCK_GITHUB_COMMIT_DATE_THREE = "2022-11-07T16:32:08Z"
+export const MOCK_GITHUB_FILENAME_ALPHA_ONE = "index.md"
+export const MOCK_GITHUB_FILEPATH_ALPHA_ONE = ""
+export const MOCK_GITHUB_FILENAME_ALPHA_TWO = "Example Title 22.md"
+export const MOCK_GITHUB_FILEPATH_ALPHA_TWO = "pages/"
+export const MOCK_GITHUB_COMMIT_MESSAGE_ALPHA_ONE = `Update file: ${MOCK_GITHUB_FILENAME_ALPHA_ONE}`
+export const MOCK_GITHUB_COMMIT_MESSAGE_ALPHA_TWO = `Update file: ${MOCK_GITHUB_FILENAME_ALPHA_TWO}`
+export const MOCK_GITHUB_COMMIT_MESSAGE_OBJECT_ALPHA_ONE = {
+  message: MOCK_GITHUB_COMMIT_MESSAGE_ALPHA_ONE,
+  fileName: MOCK_GITHUB_FILENAME_ALPHA_ONE,
+  userId: MOCK_USER_ID_ONE,
+}
+export const MOCK_GITHUB_COMMIT_MESSAGE_OBJECT_ALPHA_TWO = {
+  message: MOCK_GITHUB_COMMIT_MESSAGE_ALPHA_TWO,
+  fileName: MOCK_GITHUB_FILENAME_ALPHA_TWO,
+  userId: MOCK_USER_ID_ONE,
+}
+export const MOCK_GITHUB_COMMIT_MESSAGE_OBJECT_ALPHA_THREE = {
+  message: MOCK_GITHUB_COMMIT_MESSAGE_ALPHA_TWO,
+  fileName: MOCK_GITHUB_FILENAME_ALPHA_TWO,
+  userId: MOCK_USER_ID_TWO,
+}
+
+export const MOCK_GITHUB_FILE_CHANGE_INFO_ALPHA_ONE: RawFileChangeInfo = {
+  sha: "66804d21ba86f1a193c31714bc15e388c2013a57",
+  filename: MOCK_GITHUB_FILENAME_ALPHA_ONE,
+  status: "modified",
+  additions: 1,
+  deletions: 2,
+  changes: 3,
+  blob_url: `https://github.com/isomerpages/a-test-v4/blob/${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}/index.md`,
+  raw_url: `https://github.com/isomerpages/a-test-v4/raw/${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}/index.md`,
+  contents_url: `https://api.github.com/repos/isomerpages/a-test-v4/contents/index.md?ref=${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}`,
+}
+export const MOCK_GITHUB_FILE_CHANGE_INFO_ALPHA_TWO: RawFileChangeInfo = {
+  sha: "f04f18eaa8d31fffc9f8cf5020b1f6a765ac225f",
+  filename: `${MOCK_GITHUB_FILEPATH_ALPHA_TWO}/${MOCK_GITHUB_FILENAME_ALPHA_TWO}`,
+  status: "modified",
+  additions: 13,
+  deletions: 2,
+  changes: 15,
+  blob_url: `https://github.com/isomerpages/a-test-v4/blob/${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}/pages%2FExample%20Title%2022.md`,
+  raw_url: `https://github.com/isomerpages/a-test-v4/raw/${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}/pages%2FExample%20Title%2022.md`,
+  contents_url: `https://api.github.com/repos/isomerpages/a-test-v4/contents/pages%2FExample%20Title%2022.md?ref=${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}`,
+}
+
+export const MOCK_GITHUB_COMMIT_ALPHA_ONE: Commit = {
+  url:
+    "https://api.github.com/repos/isomerpages/a-test-v4/commits/a79525f0d188880b965053bc0df25a041b476fad",
+  sha: "a79525f0d188880b965053bc0df25a041b476fad",
+  commit: {
+    url:
+      "https://api.github.com/repos/isomerpages/a-test-v4/git/commits/a79525f0d188880b965053bc0df25a041b476fad",
+    author: {
+      name: MOCK_GITHUB_USER_NAME_ONE,
+      email: MOCK_GITHUB_USER_EMAIL_ONE,
+      date: MOCK_GITHUB_COMMIT_DATE_ONE,
+    },
+    message: JSON.stringify(MOCK_GITHUB_COMMIT_MESSAGE_OBJECT_ALPHA_ONE),
+  },
+}
+export const MOCK_GITHUB_COMMIT_ALPHA_TWO: Commit = {
+  url:
+    "https://api.github.com/repos/isomerpages/a-test-v4/commits/ad2b13184f8ee1030636c304737941146bd67f4d",
+  sha: "ad2b13184f8ee1030636c304737941146bd67f4d",
+  commit: {
+    url:
+      "https://api.github.com/repos/isomerpages/a-test-v4/git/commits/ad2b13184f8ee1030636c304737941146bd67f4d",
+    author: {
+      name: MOCK_GITHUB_USER_NAME_TWO,
+      email: MOCK_GITHUB_USER_EMAIL_TWO,
+      date: MOCK_GITHUB_COMMIT_DATE_TWO,
+    },
+    message: JSON.stringify(MOCK_GITHUB_COMMIT_MESSAGE_OBJECT_ALPHA_TWO),
+  },
+}
+export const MOCK_GITHUB_COMMIT_ALPHA_THREE: Commit = {
+  url: `https://api.github.com/repos/isomerpages/a-test-v4/commits/${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}`,
+  sha: MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA,
+  commit: {
+    url: `https://api.github.com/repos/isomerpages/a-test-v4/git/commits/${MOCK_GITHUB_COMMIT_SHA_LATEST_ALPHA}`,
+    author: {
+      name: MOCK_GITHUB_USER_NAME_ONE,
+      email: MOCK_GITHUB_USER_EMAIL_ONE,
+      date: MOCK_GITHUB_COMMIT_DATE_THREE,
+    },
+    message: JSON.stringify(MOCK_GITHUB_COMMIT_MESSAGE_OBJECT_ALPHA_THREE),
+  },
+}
+// end of set
+
+export const MOCK_GITHUB_COMMENT_BODY_ONE = "Comment 1"
+export const MOCK_GITHUB_COMMENT_BODY_TWO = "Comment 2"
+
+export const MOCK_GITHUB_COMMENT_OBJECT_ONE = {
+  message: MOCK_GITHUB_COMMENT_BODY_ONE,
+  fileName: MOCK_GITHUB_FILENAME_ALPHA_ONE,
+  userId: MOCK_USER_ID_ONE,
+}
+
+export const MOCK_GITHUB_COMMENT_OBJECT_TWO = {
+  message: MOCK_GITHUB_COMMENT_BODY_TWO,
+  fileName: MOCK_GITHUB_FILENAME_ALPHA_TWO,
+  userId: MOCK_USER_ID_TWO,
+}
+
+export const MOCK_GITHUB_RAWCOMMENT_ONE: RawComment = {
+  body: JSON.stringify(MOCK_GITHUB_COMMENT_OBJECT_ONE),
+  created_at: MOCK_GITHUB_COMMIT_DATE_ONE,
+}
+export const MOCK_GITHUB_RAWCOMMENT_TWO: RawComment = {
+  body: JSON.stringify(MOCK_GITHUB_COMMENT_OBJECT_TWO),
+  created_at: MOCK_GITHUB_COMMIT_DATE_THREE,
+}

--- a/src/fixtures/review.ts
+++ b/src/fixtures/review.ts
@@ -2,7 +2,7 @@ import { Attributes } from "sequelize/types"
 
 import { ReviewRequestStatus } from "@root/constants"
 import { ReviewRequest, ReviewRequestView } from "@root/database/models"
-import { Commit } from "@root/types/github"
+import { Commit, RawPullRequest } from "@root/types/github"
 
 import {
   mockCollaboratorAdmin1,
@@ -56,10 +56,14 @@ export const MOCK_PULL_REQUEST_COMMIT_TWO: Commit = {
   },
 }
 
-export const MOCK_PULL_REQUEST_ONE = {
-  title: "Pull Request 1",
-  body: "Pull Request 1 Description",
-  changed_files: 3,
+export const MOCK_PULL_REQUEST_TITLE_ONE = "Pull Request 1"
+export const MOCK_PULL_REQUEST_BODY_ONE = "Pull Request 1 Description"
+export const MOCK_PULL_REQUEST_CHANGED_FILES_ONE = 3
+
+export const MOCK_PULL_REQUEST_ONE: RawPullRequest = {
+  title: MOCK_PULL_REQUEST_TITLE_ONE,
+  body: MOCK_PULL_REQUEST_BODY_ONE,
+  changed_files: MOCK_PULL_REQUEST_CHANGED_FILES_ONE,
   created_at: MOCK_GITHUB_DATE_ONE,
 }
 

--- a/src/fixtures/sites.ts
+++ b/src/fixtures/sites.ts
@@ -13,11 +13,14 @@ import {
 export const MOCK_SITE_ID_ONE = 1
 export const MOCK_SITE_ID_TWO = 2
 
-export const MOCK_SITE_NAME_ONE = "test-site-one"
-export const MOCK_SITE_NAME_TWO = "test-site-two"
+export const MOCK_SITE_NAME_ONE = "Human readable site name one"
+export const MOCK_SITE_NAME_TWO = "Human readable site name two"
 
 export const MOCK_SITE_DATE_ONE = new Date("2022-09-23T00:00:00Z")
 export const MOCK_SITE_DATE_TWO = new Date("2022-09-25T00:00:00Z")
+
+export const MOCK_REPO_NAME_ONE = "repo-name-test-one"
+export const MOCK_REPO_NAME_TWO = "repo-name-test-two"
 
 export const MOCK_REPO_URL_ONE = "https://github.com/example/repo-one"
 export const MOCK_REPO_URL_TWO = "https://github.com/example/repo-two"
@@ -34,7 +37,7 @@ export const MOCK_DEPLOYMENT_STAGING_URL_TWO =
 
 export const MOCK_SITE_DBENTRY_ONE: Attributes<Site> = {
   id: MOCK_SITE_ID_ONE,
-  name: MOCK_SITE_NAME_ONE,
+  name: MOCK_REPO_NAME_ONE,
   apiTokenName: "unused",
   siteStatus: SiteStatus.Launched,
   jobStatus: JobStatus.Ready,
@@ -45,7 +48,7 @@ export const MOCK_SITE_DBENTRY_ONE: Attributes<Site> = {
 
 export const MOCK_SITE_DBENTRY_TWO: Attributes<Site> = {
   id: MOCK_SITE_ID_TWO,
-  name: MOCK_SITE_NAME_TWO,
+  name: MOCK_REPO_NAME_TWO,
   apiTokenName: "unused",
   siteStatus: SiteStatus.Launched,
   jobStatus: JobStatus.Ready,
@@ -56,7 +59,7 @@ export const MOCK_SITE_DBENTRY_TWO: Attributes<Site> = {
 
 export const MOCK_REPO_DBENTRY_ONE: Attributes<Repo> = {
   id: 1,
-  name: MOCK_SITE_NAME_ONE,
+  name: MOCK_REPO_NAME_ONE,
   url: MOCK_REPO_URL_ONE,
   siteId: MOCK_SITE_ID_ONE,
   createdAt: MOCK_SITE_DATE_ONE,
@@ -65,7 +68,7 @@ export const MOCK_REPO_DBENTRY_ONE: Attributes<Repo> = {
 
 export const MOCK_REPO_DBENTRY_TWO: Attributes<Repo> = {
   id: 2,
-  name: MOCK_SITE_NAME_TWO,
+  name: MOCK_REPO_NAME_TWO,
   url: MOCK_REPO_URL_TWO,
   siteId: MOCK_SITE_ID_TWO,
   createdAt: MOCK_SITE_DATE_TWO,

--- a/src/fixtures/sites.ts
+++ b/src/fixtures/sites.ts
@@ -1,2 +1,129 @@
+import { Attributes } from "sequelize/types"
+
+import { Deployment, Repo, Site, SiteMember } from "@database/models"
+import { CollaboratorRoles, JobStatus, SiteStatus } from "@root/constants"
+
+import {
+  MOCK_USER_ID_FOUR,
+  MOCK_USER_ID_ONE,
+  MOCK_USER_ID_THREE,
+  MOCK_USER_ID_TWO,
+} from "./users"
+
+export const MOCK_SITE_ID_ONE = 1
+export const MOCK_SITE_ID_TWO = 2
+
 export const MOCK_SITE_NAME_ONE = "test-site-one"
 export const MOCK_SITE_NAME_TWO = "test-site-two"
+
+export const MOCK_SITE_DATE_ONE = new Date("2022-09-23T00:00:00Z")
+export const MOCK_SITE_DATE_TWO = new Date("2022-09-25T00:00:00Z")
+
+export const MOCK_REPO_URL_ONE = "https://github.com/example/repo-one"
+export const MOCK_REPO_URL_TWO = "https://github.com/example/repo-two"
+
+export const MOCK_DEPLOYMENT_PROD_URL_ONE =
+  "https://master.gibberishone.amplifyapp.com"
+export const MOCK_DEPLOYMENT_PROD_URL_TWO =
+  "https://master.gibberishtwo.amplifyapp.com"
+
+export const MOCK_DEPLOYMENT_STAGING_URL_ONE =
+  "https://staging.gibberishone.amplifyapp.com"
+export const MOCK_DEPLOYMENT_STAGING_URL_TWO =
+  "https://staging.gibberishtwo.amplifyapp.com"
+
+export const MOCK_SITE_DBENTRY_ONE: Attributes<Site> = {
+  id: MOCK_SITE_ID_ONE,
+  name: MOCK_SITE_NAME_ONE,
+  apiTokenName: "unused",
+  siteStatus: SiteStatus.Launched,
+  jobStatus: JobStatus.Ready,
+  creatorId: MOCK_USER_ID_ONE,
+  createdAt: MOCK_SITE_DATE_ONE,
+  updatedAt: MOCK_SITE_DATE_ONE,
+}
+
+export const MOCK_SITE_DBENTRY_TWO: Attributes<Site> = {
+  id: MOCK_SITE_ID_TWO,
+  name: MOCK_SITE_NAME_TWO,
+  apiTokenName: "unused",
+  siteStatus: SiteStatus.Launched,
+  jobStatus: JobStatus.Ready,
+  creatorId: MOCK_USER_ID_TWO,
+  createdAt: MOCK_SITE_DATE_TWO,
+  updatedAt: MOCK_SITE_DATE_TWO,
+}
+
+export const MOCK_REPO_DBENTRY_ONE: Attributes<Repo> = {
+  id: 1,
+  name: MOCK_SITE_NAME_ONE,
+  url: MOCK_REPO_URL_ONE,
+  siteId: MOCK_SITE_ID_ONE,
+  createdAt: MOCK_SITE_DATE_ONE,
+  updatedAt: MOCK_SITE_DATE_ONE,
+}
+
+export const MOCK_REPO_DBENTRY_TWO: Attributes<Repo> = {
+  id: 2,
+  name: MOCK_SITE_NAME_TWO,
+  url: MOCK_REPO_URL_TWO,
+  siteId: MOCK_SITE_ID_TWO,
+  createdAt: MOCK_SITE_DATE_TWO,
+  updatedAt: MOCK_SITE_DATE_TWO,
+}
+
+export const MOCK_DEPLOYMENT_DBENTRY_ONE: Attributes<Deployment> = {
+  id: 1,
+  siteId: MOCK_SITE_ID_ONE,
+  productionUrl: MOCK_DEPLOYMENT_PROD_URL_ONE,
+  stagingUrl: MOCK_DEPLOYMENT_STAGING_URL_ONE,
+  createdAt: MOCK_SITE_DATE_ONE,
+  updatedAt: MOCK_SITE_DATE_ONE,
+  hostingId: "1",
+}
+
+export const MOCK_DEPLOYMENT_DBENTRY_TWO: Attributes<Deployment> = {
+  id: 2,
+  siteId: MOCK_SITE_ID_TWO,
+  productionUrl: MOCK_DEPLOYMENT_PROD_URL_TWO,
+  stagingUrl: MOCK_DEPLOYMENT_STAGING_URL_TWO,
+  createdAt: MOCK_SITE_DATE_TWO,
+  updatedAt: MOCK_SITE_DATE_TWO,
+  hostingId: "1",
+}
+
+export const MOCK_SITEMEMBER_DBENTRY_ONE: Attributes<SiteMember> = {
+  id: 1,
+  userId: MOCK_USER_ID_ONE,
+  siteId: MOCK_SITE_ID_ONE,
+  role: CollaboratorRoles.Admin,
+  createdAt: MOCK_SITE_DATE_ONE,
+  updatedAt: MOCK_SITE_DATE_ONE,
+}
+
+export const MOCK_SITEMEMBER_DBENTRY_TWO: Attributes<SiteMember> = {
+  id: 2,
+  userId: MOCK_USER_ID_TWO,
+  siteId: MOCK_SITE_ID_ONE,
+  role: CollaboratorRoles.Contributor,
+  createdAt: MOCK_SITE_DATE_ONE,
+  updatedAt: MOCK_SITE_DATE_ONE,
+}
+
+export const MOCK_SITEMEMBER_DBENTRY_THREE: Attributes<SiteMember> = {
+  id: 3,
+  userId: MOCK_USER_ID_THREE,
+  siteId: MOCK_SITE_ID_TWO,
+  role: CollaboratorRoles.Admin,
+  createdAt: MOCK_SITE_DATE_TWO,
+  updatedAt: MOCK_SITE_DATE_TWO,
+}
+
+export const MOCK_SITEMEMBER_DBENTRY_FOUR: Attributes<SiteMember> = {
+  id: 4,
+  userId: MOCK_USER_ID_FOUR,
+  siteId: MOCK_SITE_ID_TWO,
+  role: CollaboratorRoles.Contributor,
+  createdAt: MOCK_SITE_DATE_TWO,
+  updatedAt: MOCK_SITE_DATE_TWO,
+}

--- a/src/fixtures/users.ts
+++ b/src/fixtures/users.ts
@@ -1,3 +1,7 @@
+import { Attributes } from "sequelize/types"
+
+import { User } from "@database/models"
+
 export const MOCK_USER_ID_ONE = 1
 export const MOCK_USER_ID_TWO = 2
 export const MOCK_USER_ID_THREE = 3
@@ -7,3 +11,45 @@ export const MOCK_USER_EMAIL_ONE = "one@test.gov.sg"
 export const MOCK_USER_EMAIL_TWO = "two@test.gov.sg"
 export const MOCK_USER_EMAIL_THREE = "three@test.gov.sg"
 export const MOCK_USER_EMAIL_FOUR = "four@test.gov.sg"
+
+export const MOCK_USER_DATE_ONE = new Date("2022-08-23T00:00:00Z")
+export const MOCK_USER_DATE_TWO = new Date("2022-08-25T00:00:00Z")
+export const MOCK_USER_DATE_THREE = new Date("2022-08-27T00:00:00Z")
+export const MOCK_USER_DATE_FOUR = new Date("2022-08-29T00:00:00Z")
+
+export const MOCK_USER_LAST_LOGIN_ONE = new Date("2022-09-12T00:00:00Z")
+export const MOCK_USER_LAST_LOGIN_TWO = new Date("2022-09-14T00:00:00Z")
+export const MOCK_USER_LAST_LOGIN_THREE = new Date("2022-09-16T00:00:00Z")
+export const MOCK_USER_LAST_LOGIN_FOUR = new Date("2022-09-18T00:00:00Z")
+
+export const MOCK_USER_DBENTRY_ONE: Attributes<User> = {
+  id: MOCK_USER_ID_ONE,
+  email: MOCK_USER_EMAIL_ONE,
+  lastLoggedIn: MOCK_USER_LAST_LOGIN_ONE,
+  createdAt: MOCK_USER_DATE_ONE,
+  updatedAt: MOCK_USER_DATE_ONE,
+}
+
+export const MOCK_USER_DBENTRY_TWO: Attributes<User> = {
+  id: MOCK_USER_ID_TWO,
+  email: MOCK_USER_EMAIL_TWO,
+  lastLoggedIn: MOCK_USER_LAST_LOGIN_TWO,
+  createdAt: MOCK_USER_DATE_TWO,
+  updatedAt: MOCK_USER_DATE_TWO,
+}
+
+export const MOCK_USER_DBENTRY_THREE: Attributes<User> = {
+  id: MOCK_USER_ID_THREE,
+  email: MOCK_USER_EMAIL_THREE,
+  lastLoggedIn: MOCK_USER_LAST_LOGIN_THREE,
+  createdAt: MOCK_USER_DATE_THREE,
+  updatedAt: MOCK_USER_DATE_THREE,
+}
+
+export const MOCK_USER_DBENTRY_FOUR: Attributes<User> = {
+  id: MOCK_USER_ID_FOUR,
+  email: MOCK_USER_EMAIL_FOUR,
+  lastLoggedIn: MOCK_USER_LAST_LOGIN_FOUR,
+  createdAt: MOCK_USER_DATE_FOUR,
+  updatedAt: MOCK_USER_DATE_FOUR,
+}

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -1,0 +1,503 @@
+import express from "express"
+import mockAxios from "jest-mock-axios"
+import request from "supertest"
+
+import { ReviewsRouter as _ReviewsRouter } from "@routes/v2/authenticated/review"
+import { SitesRouter as _SitesRouter } from "@routes/v2/authenticated/sites"
+
+import {
+  IsomerAdmin,
+  Repo,
+  Reviewer,
+  ReviewMeta,
+  ReviewRequest,
+  ReviewRequestView,
+  Site,
+  SiteMember,
+  User,
+  Whitelist,
+} from "@database/models"
+import { generateRouterForUserWithSite } from "@fixtures/app"
+import {
+  MOCK_USER_SESSION_DATA_ONE,
+  MOCK_USER_SESSION_DATA_THREE,
+  MOCK_USER_SESSION_DATA_TWO,
+} from "@fixtures/sessionData"
+import {
+  MOCK_REPO_DBENTRY_ONE,
+  MOCK_SITEMEMBER_DBENTRY_ONE,
+  MOCK_SITEMEMBER_DBENTRY_TWO,
+  MOCK_SITE_DATE_ONE,
+  MOCK_SITE_DBENTRY_ONE,
+  MOCK_SITE_ID_ONE,
+  MOCK_SITE_NAME_ONE,
+  MOCK_SITE_NAME_TWO,
+} from "@fixtures/sites"
+import {
+  MOCK_USER_DBENTRY_ONE,
+  MOCK_USER_DBENTRY_THREE,
+  MOCK_USER_DBENTRY_TWO,
+  MOCK_USER_EMAIL_ONE,
+  MOCK_USER_EMAIL_TWO,
+  MOCK_USER_ID_ONE,
+  MOCK_USER_ID_TWO,
+} from "@fixtures/users"
+import { ReviewRequestStatus } from "@root/constants"
+import {
+  MOCK_GITHUB_COMMIT_ALPHA_ONE,
+  MOCK_GITHUB_COMMIT_ALPHA_THREE,
+  MOCK_GITHUB_COMMIT_ALPHA_TWO,
+  MOCK_GITHUB_COMMIT_DATE_THREE,
+  MOCK_GITHUB_FILENAME_ALPHA_ONE,
+  MOCK_GITHUB_FILENAME_ALPHA_TWO,
+  MOCK_GITHUB_FILEPATH_ALPHA_TWO,
+  MOCK_GITHUB_FILE_CHANGE_INFO_ALPHA_ONE,
+  MOCK_GITHUB_FILE_CHANGE_INFO_ALPHA_TWO,
+  MOCK_GITHUB_PULL_REQUEST_NUMBER,
+  MOCK_GITHUB_RAWCOMMENT_ONE,
+  MOCK_GITHUB_RAWCOMMENT_TWO,
+} from "@root/fixtures/github"
+import { MOCK_GITHUB_DATE_ONE } from "@root/fixtures/identity"
+import {
+  MOCK_PULL_REQUEST_BODY_ONE,
+  MOCK_PULL_REQUEST_CHANGED_FILES_ONE,
+  MOCK_PULL_REQUEST_ONE,
+  MOCK_PULL_REQUEST_TITLE_ONE,
+} from "@root/fixtures/review"
+import { GitHubService } from "@services/db/GitHubService"
+import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
+import { getUsersService } from "@services/identity"
+import CollaboratorsService from "@services/identity/CollaboratorsService"
+import IsomerAdminsService from "@services/identity/IsomerAdminsService"
+import SitesService from "@services/identity/SitesService"
+import ReviewRequestService from "@services/review/ReviewRequestService"
+import { sequelize } from "@tests/database"
+
+const gitHubService = new GitHubService({ axiosInstance: mockAxios.create() })
+const configYmlService = new ConfigYmlService({ gitHubService })
+const usersService = getUsersService(sequelize)
+const isomerAdminsService = new IsomerAdminsService({ repository: IsomerAdmin })
+const reviewRequestService = new ReviewRequestService(
+  gitHubService,
+  User,
+  ReviewRequest,
+  Reviewer,
+  ReviewMeta,
+  ReviewRequestView
+)
+const sitesService = new SitesService({
+  siteRepository: Site,
+  gitHubService,
+  configYmlService,
+  usersService,
+  isomerAdminsService,
+  reviewRequestService,
+})
+const collaboratorsService = new CollaboratorsService({
+  siteRepository: Site,
+  siteMemberRepository: SiteMember,
+  sitesService,
+  usersService,
+  whitelist: Whitelist,
+})
+
+const ReviewsRouter = new _ReviewsRouter(
+  reviewRequestService,
+  usersService,
+  sitesService,
+  collaboratorsService
+)
+const reviewsSubrouter = ReviewsRouter.getRouter()
+const subrouter = express()
+subrouter.use("/:siteName", reviewsSubrouter)
+
+const mockGenericAxios = mockAxios.create()
+
+describe("Review Requests Router", () => {
+  beforeAll(async () => {
+    // NOTE: Because SitesService uses an axios instance,
+    // we need to mock the axios instance using es5 named exports
+    // to ensure that the calls for .get() on the instance
+    // will actually return a value and not fail.
+    jest.mock("../services/api/AxiosInstance.ts", () => ({
+      __esModule: true, // this property makes it work
+      genericGitHubAxiosInstance: mockGenericAxios,
+    }))
+    await User.sync({ force: true })
+    await Site.sync({ force: true })
+    await Repo.sync({ force: true })
+    await SiteMember.sync({ force: true })
+
+    await User.create(MOCK_USER_DBENTRY_ONE)
+    await User.create(MOCK_USER_DBENTRY_TWO)
+    await User.create(MOCK_USER_DBENTRY_THREE)
+    await Site.create(MOCK_SITE_DBENTRY_ONE)
+    await Repo.create(MOCK_REPO_DBENTRY_ONE)
+    await SiteMember.create(MOCK_SITEMEMBER_DBENTRY_ONE)
+    await SiteMember.create(MOCK_SITEMEMBER_DBENTRY_TWO)
+  })
+
+  afterAll(async () => {
+    await SiteMember.destroy({
+      where: {
+        siteId: MOCK_SITE_ID_ONE,
+      },
+    })
+    await User.destroy({
+      where: {
+        id: MOCK_USER_ID_ONE,
+      },
+    })
+    await User.destroy({
+      where: {
+        id: MOCK_USER_ID_TWO,
+      },
+    })
+    await Repo.destroy({
+      where: {
+        siteId: MOCK_SITE_ID_ONE,
+      },
+    })
+    await Site.destroy({
+      where: {
+        id: MOCK_SITE_ID_ONE,
+      },
+    })
+  })
+
+  describe("/compare", () => {
+    it("should get GitHub diff response for a valid site member", async () => {
+      // Arrange
+      const app = generateRouterForUserWithSite(
+        subrouter,
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_SITE_NAME_ONE
+      )
+      mockGenericAxios.get.mockResolvedValueOnce({
+        data: {
+          files: [
+            MOCK_GITHUB_FILE_CHANGE_INFO_ALPHA_ONE,
+            MOCK_GITHUB_FILE_CHANGE_INFO_ALPHA_TWO,
+          ],
+          commits: [
+            MOCK_GITHUB_COMMIT_ALPHA_ONE,
+            MOCK_GITHUB_COMMIT_ALPHA_TWO,
+            MOCK_GITHUB_COMMIT_ALPHA_THREE,
+          ],
+        },
+      })
+      const expected = {
+        items: [
+          {
+            type: ["page"],
+            name: MOCK_GITHUB_FILENAME_ALPHA_ONE,
+            path: [],
+            url: "www.google.com",
+            lastEditedBy: MOCK_USER_EMAIL_TWO, // TODO: This should be MOCK_USER_EMAIL_ONE
+            lastEditedTime: new Date(MOCK_GITHUB_COMMIT_DATE_THREE).getTime(),
+          },
+          {
+            type: ["page"],
+            name: MOCK_GITHUB_FILENAME_ALPHA_TWO,
+            path: MOCK_GITHUB_FILEPATH_ALPHA_TWO.split("/"),
+            url: "www.google.com",
+            lastEditedBy: MOCK_USER_EMAIL_TWO,
+            lastEditedTime: new Date(MOCK_GITHUB_COMMIT_DATE_THREE).getTime(),
+          },
+        ],
+      }
+
+      // Act
+      const actual = await request(app).get(`/${MOCK_SITE_NAME_ONE}/compare`)
+
+      // Assert
+      expect(actual.statusCode).toEqual(200)
+      expect(actual.body).toMatchObject(expected)
+    })
+
+    it("should return 404 if user is not a valid site member", async () => {
+      // Arrange
+      const app = generateRouterForUserWithSite(
+        subrouter,
+        MOCK_USER_SESSION_DATA_THREE,
+        MOCK_SITE_NAME_ONE
+      )
+
+      // Act
+      const actual = await request(app).get(`/${MOCK_SITE_NAME_ONE}/compare`)
+
+      // Assert
+      expect(actual.statusCode).toEqual(404)
+    })
+  })
+
+  describe("/request", () => {
+    afterAll(async () => {
+      await ReviewMeta.destroy({
+        where: {},
+      })
+      await Reviewer.destroy({
+        where: {},
+      })
+      await ReviewRequest.destroy({
+        where: {},
+      })
+    })
+
+    it("should successfully create a review request when valid inputs are provided", async () => {
+      // Arrange
+      const app = generateRouterForUserWithSite(
+        subrouter,
+        MOCK_USER_SESSION_DATA_TWO,
+        MOCK_SITE_NAME_ONE
+      )
+      const mockPullRequest = {
+        reviewers: [MOCK_USER_EMAIL_ONE],
+        title: "Fake title",
+        description: "Fake description",
+      }
+      const expected = {
+        pullRequestNumber: MOCK_GITHUB_PULL_REQUEST_NUMBER,
+      }
+      mockGenericAxios.post.mockResolvedValueOnce({
+        data: {
+          number: MOCK_GITHUB_PULL_REQUEST_NUMBER,
+        },
+      })
+
+      // Act
+      const actual = await request(app)
+        .post(`/${MOCK_SITE_NAME_ONE}/request`)
+        .send(mockPullRequest)
+
+      // Assert
+      expect(actual.body).toMatchObject(expected)
+      expect(actual.statusCode).toEqual(200)
+      const actualReviewRequest = await ReviewRequest.findOne({
+        where: {
+          requestorId: MOCK_USER_ID_TWO,
+          siteId: MOCK_SITE_ID_ONE,
+        },
+      })
+      const actualReviewer = await Reviewer.findOne({
+        where: {
+          requestId: actualReviewRequest?.id,
+          reviewerId: MOCK_USER_ID_ONE,
+        },
+      })
+      const actualReviewMeta = await ReviewMeta.findOne({
+        where: {
+          reviewId: actualReviewRequest?.id,
+        },
+      })
+      expect(actualReviewRequest).not.toBeNull()
+      expect(actualReviewer).not.toBeNull()
+      expect(actualReviewMeta).not.toBeNull()
+    })
+
+    it("should return 404 if site is not found", async () => {
+      // Arrange
+      const app = generateRouterForUserWithSite(
+        subrouter,
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_SITE_NAME_TWO
+      )
+      const mockPullRequest = {
+        reviewers: [MOCK_USER_EMAIL_TWO],
+        title: "Fake title",
+        description: "Fake description",
+      }
+
+      // Act
+      const actual = await request(app)
+        .post(`/${MOCK_SITE_NAME_TWO}/request`)
+        .send(mockPullRequest)
+
+      // Assert
+      expect(actual.statusCode).toEqual(404)
+    })
+
+    it("should return 404 if user is not a valid site member", async () => {
+      // Arrange
+      const app = generateRouterForUserWithSite(
+        subrouter,
+        MOCK_USER_SESSION_DATA_THREE,
+        MOCK_SITE_NAME_ONE
+      )
+      const mockPullRequest = {
+        reviewers: [MOCK_USER_EMAIL_TWO],
+        title: "Fake title",
+        description: "Fake description",
+      }
+
+      // Act
+      const actual = await request(app)
+        .post(`/${MOCK_SITE_NAME_ONE}/request`)
+        .send(mockPullRequest)
+
+      // Assert
+      expect(actual.statusCode).toEqual(404)
+    })
+
+    it("should return 400 if no reviewers are provided", async () => {
+      // Arrange
+      const app = generateRouterForUserWithSite(
+        subrouter,
+        MOCK_USER_SESSION_DATA_TWO,
+        MOCK_SITE_NAME_ONE
+      )
+      const mockPullRequest = {
+        reviewers: [],
+        title: "Fake title",
+        description: "Fake description",
+      }
+
+      // Act
+      const actual = await request(app)
+        .post(`/${MOCK_SITE_NAME_ONE}/request`)
+        .send(mockPullRequest)
+
+      // Assert
+      expect(actual.statusCode).toEqual(400)
+    })
+
+    it("should return 400 if selected reviewers are not admins", async () => {
+      // Arrange
+      const app = generateRouterForUserWithSite(
+        subrouter,
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_SITE_NAME_ONE
+      )
+      const mockPullRequest = {
+        reviewers: [MOCK_USER_EMAIL_TWO],
+        title: "Fake title",
+        description: "Fake description",
+      }
+
+      // Act
+      const actual = await request(app)
+        .post(`/${MOCK_SITE_NAME_ONE}/request`)
+        .send(mockPullRequest)
+
+      // Assert
+      expect(actual.statusCode).toEqual(400)
+    })
+  })
+
+  describe("/summary", () => {
+    beforeAll(async () => {
+      await ReviewRequest.create({
+        requestorId: MOCK_USER_ID_ONE,
+        siteId: MOCK_SITE_ID_ONE,
+      })
+      const reviewRequest = await ReviewRequest.findOne({
+        where: {
+          requestorId: MOCK_USER_ID_ONE,
+          siteId: MOCK_SITE_ID_ONE,
+        },
+      })
+      await Reviewer.create({
+        requestId: reviewRequest?.id,
+        reviewerId: MOCK_USER_ID_TWO,
+      })
+      await ReviewMeta.create({
+        reviewId: reviewRequest?.id,
+        pullRequestNumber: MOCK_GITHUB_PULL_REQUEST_NUMBER,
+        reviewLink: `cms.isomer.gov.sg/sites/${MOCK_SITE_NAME_ONE}/review/${MOCK_GITHUB_PULL_REQUEST_NUMBER}`,
+      })
+    })
+
+    afterAll(async () => {
+      await ReviewMeta.destroy({
+        where: {},
+      })
+      await Reviewer.destroy({
+        where: {},
+      })
+      await ReviewRequest.destroy({
+        where: {},
+      })
+    })
+
+    it("should get the summary of all existing review requests", async () => {
+      // Arrange
+      const app = generateRouterForUserWithSite(
+        subrouter,
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_SITE_NAME_ONE
+      )
+      mockGenericAxios.get.mockResolvedValueOnce({
+        data: MOCK_PULL_REQUEST_ONE,
+      })
+      mockGenericAxios.get.mockResolvedValueOnce({
+        data: [MOCK_GITHUB_RAWCOMMENT_ONE, MOCK_GITHUB_RAWCOMMENT_TWO],
+      })
+      const expected = {
+        reviews: [
+          {
+            id: String(MOCK_GITHUB_PULL_REQUEST_NUMBER),
+            author: MOCK_USER_EMAIL_ONE,
+            status: ReviewRequestStatus.Open,
+            title: MOCK_PULL_REQUEST_TITLE_ONE,
+            description: MOCK_PULL_REQUEST_BODY_ONE,
+            changedFiles: MOCK_PULL_REQUEST_CHANGED_FILES_ONE,
+            createdAt: new Date(MOCK_GITHUB_DATE_ONE).getTime(),
+            newComments: 2,
+            firstView: true,
+          },
+        ],
+      }
+
+      // Act
+      const actual = await request(app).get(`/${MOCK_SITE_NAME_ONE}/summary`)
+
+      // Assert
+      expect(actual.statusCode).toEqual(200)
+      expect(actual.body).toMatchObject(expected)
+    })
+
+    it("should return 404 if site is not found", async () => {
+      // Arrange
+      const app = generateRouterForUserWithSite(
+        subrouter,
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_SITE_NAME_TWO
+      )
+
+      // Act
+      const actual = await request(app).get(`/${MOCK_SITE_NAME_TWO}/summary`)
+
+      // Assert
+      expect(actual.statusCode).toEqual(404)
+    })
+
+    it("should return 404 if user is not a valid site member", async () => {
+      // Arrange
+      const app = generateRouterForUserWithSite(
+        subrouter,
+        MOCK_USER_SESSION_DATA_THREE,
+        MOCK_SITE_NAME_ONE
+      )
+
+      // Act
+      const actual = await request(app).get(`/${MOCK_SITE_NAME_ONE}/summary`)
+
+      // Assert
+      expect(actual.statusCode).toEqual(404)
+    })
+  })
+
+  describe("/viewed", () => {})
+
+  describe("/:requestId", () => {})
+
+  describe("/:requestId/viewed", () => {})
+
+  describe("/:requestId/merge", () => {})
+
+  describe("/:requestId/approve", () => {})
+
+  describe("/:requestId/comments", () => {})
+
+  describe("/:requestId/comments/viewedComments", () => {})
+})

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -19,6 +19,30 @@ import {
 } from "@database/models"
 import { generateRouterForUserWithSite } from "@fixtures/app"
 import {
+  MOCK_GITHUB_COMMENT_BODY_ONE,
+  MOCK_GITHUB_COMMENT_BODY_TWO,
+  MOCK_GITHUB_COMMIT_ALPHA_ONE,
+  MOCK_GITHUB_COMMIT_ALPHA_THREE,
+  MOCK_GITHUB_COMMIT_ALPHA_TWO,
+  MOCK_GITHUB_COMMIT_DATE_ONE,
+  MOCK_GITHUB_COMMIT_DATE_THREE,
+  MOCK_GITHUB_FILENAME_ALPHA_ONE,
+  MOCK_GITHUB_FILENAME_ALPHA_TWO,
+  MOCK_GITHUB_FILEPATH_ALPHA_TWO,
+  MOCK_GITHUB_FILE_CHANGE_INFO_ALPHA_ONE,
+  MOCK_GITHUB_FILE_CHANGE_INFO_ALPHA_TWO,
+  MOCK_GITHUB_PULL_REQUEST_NUMBER,
+  MOCK_GITHUB_RAWCOMMENT_ONE,
+  MOCK_GITHUB_RAWCOMMENT_TWO,
+} from "@fixtures/github"
+import { MOCK_GITHUB_DATE_ONE } from "@fixtures/identity"
+import {
+  MOCK_PULL_REQUEST_BODY_ONE,
+  MOCK_PULL_REQUEST_CHANGED_FILES_ONE,
+  MOCK_PULL_REQUEST_ONE,
+  MOCK_PULL_REQUEST_TITLE_ONE,
+} from "@fixtures/review"
+import {
   MOCK_USER_SESSION_DATA_ONE,
   MOCK_USER_SESSION_DATA_THREE,
   MOCK_USER_SESSION_DATA_TWO,
@@ -44,30 +68,6 @@ import {
   MOCK_USER_ID_TWO,
 } from "@fixtures/users"
 import { ReviewRequestStatus } from "@root/constants"
-import {
-  MOCK_GITHUB_COMMENT_BODY_ONE,
-  MOCK_GITHUB_COMMENT_BODY_TWO,
-  MOCK_GITHUB_COMMIT_ALPHA_ONE,
-  MOCK_GITHUB_COMMIT_ALPHA_THREE,
-  MOCK_GITHUB_COMMIT_ALPHA_TWO,
-  MOCK_GITHUB_COMMIT_DATE_ONE,
-  MOCK_GITHUB_COMMIT_DATE_THREE,
-  MOCK_GITHUB_FILENAME_ALPHA_ONE,
-  MOCK_GITHUB_FILENAME_ALPHA_TWO,
-  MOCK_GITHUB_FILEPATH_ALPHA_TWO,
-  MOCK_GITHUB_FILE_CHANGE_INFO_ALPHA_ONE,
-  MOCK_GITHUB_FILE_CHANGE_INFO_ALPHA_TWO,
-  MOCK_GITHUB_PULL_REQUEST_NUMBER,
-  MOCK_GITHUB_RAWCOMMENT_ONE,
-  MOCK_GITHUB_RAWCOMMENT_TWO,
-} from "@root/fixtures/github"
-import { MOCK_GITHUB_DATE_ONE } from "@root/fixtures/identity"
-import {
-  MOCK_PULL_REQUEST_BODY_ONE,
-  MOCK_PULL_REQUEST_CHANGED_FILES_ONE,
-  MOCK_PULL_REQUEST_ONE,
-  MOCK_PULL_REQUEST_TITLE_ONE,
-} from "@root/fixtures/review"
 import { ReviewRequestDto } from "@root/types/dto/review"
 import { GitHubService } from "@services/db/GitHubService"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
@@ -118,7 +118,7 @@ subrouter.use("/:siteName", reviewsSubrouter)
 
 const mockGenericAxios = mockAxios.create()
 
-describe("Review Requests Router", () => {
+describe("Review Requests Integration Tests", () => {
   beforeAll(async () => {
     // NOTE: Because SitesService uses an axios instance,
     // we need to mock the axios instance using es5 named exports

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -128,6 +128,10 @@ describe("Review Requests Integration Tests", () => {
       __esModule: true, // this property makes it work
       genericGitHubAxiosInstance: mockGenericAxios,
     }))
+
+    // We need to force the relevant tables to start from a clean slate
+    // Otherwise, some tests may fail due to the auto-incrementing IDs
+    // not starting from 1
     await User.sync({ force: true })
     await Site.sync({ force: true })
     await Repo.sync({ force: true })

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -27,11 +27,10 @@ import {
   MOCK_REPO_DBENTRY_ONE,
   MOCK_SITEMEMBER_DBENTRY_ONE,
   MOCK_SITEMEMBER_DBENTRY_TWO,
-  MOCK_SITE_DATE_ONE,
   MOCK_SITE_DBENTRY_ONE,
   MOCK_SITE_ID_ONE,
-  MOCK_SITE_NAME_ONE,
-  MOCK_SITE_NAME_TWO,
+  MOCK_REPO_NAME_ONE,
+  MOCK_REPO_NAME_TWO,
 } from "@fixtures/sites"
 import {
   MOCK_USER_DBENTRY_ONE,
@@ -171,7 +170,7 @@ describe("Review Requests Router", () => {
       const app = generateRouterForUserWithSite(
         subrouter,
         MOCK_USER_SESSION_DATA_ONE,
-        MOCK_SITE_NAME_ONE
+        MOCK_REPO_NAME_ONE
       )
       mockGenericAxios.get.mockResolvedValueOnce({
         data: {
@@ -199,7 +198,7 @@ describe("Review Requests Router", () => {
           {
             type: ["page"],
             name: MOCK_GITHUB_FILENAME_ALPHA_TWO,
-            path: MOCK_GITHUB_FILEPATH_ALPHA_TWO.split("/"),
+            path: MOCK_GITHUB_FILEPATH_ALPHA_TWO.split("/").filter((x) => x),
             url: "www.google.com",
             lastEditedBy: MOCK_USER_EMAIL_TWO,
             lastEditedTime: new Date(MOCK_GITHUB_COMMIT_DATE_THREE).getTime(),
@@ -208,7 +207,7 @@ describe("Review Requests Router", () => {
       }
 
       // Act
-      const actual = await request(app).get(`/${MOCK_SITE_NAME_ONE}/compare`)
+      const actual = await request(app).get(`/${MOCK_REPO_NAME_ONE}/compare`)
 
       // Assert
       expect(actual.statusCode).toEqual(200)
@@ -220,11 +219,11 @@ describe("Review Requests Router", () => {
       const app = generateRouterForUserWithSite(
         subrouter,
         MOCK_USER_SESSION_DATA_THREE,
-        MOCK_SITE_NAME_ONE
+        MOCK_REPO_NAME_ONE
       )
 
       // Act
-      const actual = await request(app).get(`/${MOCK_SITE_NAME_ONE}/compare`)
+      const actual = await request(app).get(`/${MOCK_REPO_NAME_ONE}/compare`)
 
       // Assert
       expect(actual.statusCode).toEqual(404)
@@ -249,7 +248,7 @@ describe("Review Requests Router", () => {
       const app = generateRouterForUserWithSite(
         subrouter,
         MOCK_USER_SESSION_DATA_TWO,
-        MOCK_SITE_NAME_ONE
+        MOCK_REPO_NAME_ONE
       )
       const mockPullRequest = {
         reviewers: [MOCK_USER_EMAIL_ONE],
@@ -267,7 +266,7 @@ describe("Review Requests Router", () => {
 
       // Act
       const actual = await request(app)
-        .post(`/${MOCK_SITE_NAME_ONE}/request`)
+        .post(`/${MOCK_REPO_NAME_ONE}/request`)
         .send(mockPullRequest)
 
       // Assert
@@ -300,7 +299,7 @@ describe("Review Requests Router", () => {
       const app = generateRouterForUserWithSite(
         subrouter,
         MOCK_USER_SESSION_DATA_ONE,
-        MOCK_SITE_NAME_TWO
+        MOCK_REPO_NAME_TWO
       )
       const mockPullRequest = {
         reviewers: [MOCK_USER_EMAIL_TWO],
@@ -310,7 +309,7 @@ describe("Review Requests Router", () => {
 
       // Act
       const actual = await request(app)
-        .post(`/${MOCK_SITE_NAME_TWO}/request`)
+        .post(`/${MOCK_REPO_NAME_TWO}/request`)
         .send(mockPullRequest)
 
       // Assert
@@ -322,7 +321,7 @@ describe("Review Requests Router", () => {
       const app = generateRouterForUserWithSite(
         subrouter,
         MOCK_USER_SESSION_DATA_THREE,
-        MOCK_SITE_NAME_ONE
+        MOCK_REPO_NAME_ONE
       )
       const mockPullRequest = {
         reviewers: [MOCK_USER_EMAIL_TWO],
@@ -332,7 +331,7 @@ describe("Review Requests Router", () => {
 
       // Act
       const actual = await request(app)
-        .post(`/${MOCK_SITE_NAME_ONE}/request`)
+        .post(`/${MOCK_REPO_NAME_ONE}/request`)
         .send(mockPullRequest)
 
       // Assert
@@ -344,7 +343,7 @@ describe("Review Requests Router", () => {
       const app = generateRouterForUserWithSite(
         subrouter,
         MOCK_USER_SESSION_DATA_TWO,
-        MOCK_SITE_NAME_ONE
+        MOCK_REPO_NAME_ONE
       )
       const mockPullRequest = {
         reviewers: [],
@@ -354,7 +353,7 @@ describe("Review Requests Router", () => {
 
       // Act
       const actual = await request(app)
-        .post(`/${MOCK_SITE_NAME_ONE}/request`)
+        .post(`/${MOCK_REPO_NAME_ONE}/request`)
         .send(mockPullRequest)
 
       // Assert
@@ -366,7 +365,7 @@ describe("Review Requests Router", () => {
       const app = generateRouterForUserWithSite(
         subrouter,
         MOCK_USER_SESSION_DATA_ONE,
-        MOCK_SITE_NAME_ONE
+        MOCK_REPO_NAME_ONE
       )
       const mockPullRequest = {
         reviewers: [MOCK_USER_EMAIL_TWO],
@@ -376,7 +375,7 @@ describe("Review Requests Router", () => {
 
       // Act
       const actual = await request(app)
-        .post(`/${MOCK_SITE_NAME_ONE}/request`)
+        .post(`/${MOCK_REPO_NAME_ONE}/request`)
         .send(mockPullRequest)
 
       // Assert
@@ -403,7 +402,7 @@ describe("Review Requests Router", () => {
       await ReviewMeta.create({
         reviewId: reviewRequest?.id,
         pullRequestNumber: MOCK_GITHUB_PULL_REQUEST_NUMBER,
-        reviewLink: `cms.isomer.gov.sg/sites/${MOCK_SITE_NAME_ONE}/review/${MOCK_GITHUB_PULL_REQUEST_NUMBER}`,
+        reviewLink: `cms.isomer.gov.sg/sites/${MOCK_REPO_NAME_ONE}/review/${MOCK_GITHUB_PULL_REQUEST_NUMBER}`,
       })
     })
 
@@ -424,7 +423,7 @@ describe("Review Requests Router", () => {
       const app = generateRouterForUserWithSite(
         subrouter,
         MOCK_USER_SESSION_DATA_ONE,
-        MOCK_SITE_NAME_ONE
+        MOCK_REPO_NAME_ONE
       )
       mockGenericAxios.get.mockResolvedValueOnce({
         data: MOCK_PULL_REQUEST_ONE,
@@ -449,7 +448,7 @@ describe("Review Requests Router", () => {
       }
 
       // Act
-      const actual = await request(app).get(`/${MOCK_SITE_NAME_ONE}/summary`)
+      const actual = await request(app).get(`/${MOCK_REPO_NAME_ONE}/summary`)
 
       // Assert
       expect(actual.statusCode).toEqual(200)
@@ -461,11 +460,11 @@ describe("Review Requests Router", () => {
       const app = generateRouterForUserWithSite(
         subrouter,
         MOCK_USER_SESSION_DATA_ONE,
-        MOCK_SITE_NAME_TWO
+        MOCK_REPO_NAME_TWO
       )
 
       // Act
-      const actual = await request(app).get(`/${MOCK_SITE_NAME_TWO}/summary`)
+      const actual = await request(app).get(`/${MOCK_REPO_NAME_TWO}/summary`)
 
       // Assert
       expect(actual.statusCode).toEqual(404)
@@ -476,11 +475,11 @@ describe("Review Requests Router", () => {
       const app = generateRouterForUserWithSite(
         subrouter,
         MOCK_USER_SESSION_DATA_THREE,
-        MOCK_SITE_NAME_ONE
+        MOCK_REPO_NAME_ONE
       )
 
       // Act
-      const actual = await request(app).get(`/${MOCK_SITE_NAME_ONE}/summary`)
+      const actual = await request(app).get(`/${MOCK_REPO_NAME_ONE}/summary`)
 
       // Assert
       expect(actual.statusCode).toEqual(404)

--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -109,6 +109,9 @@ describe("Sites Router", () => {
 
   describe("/", () => {
     beforeAll(async () => {
+      // We need to force the relevant tables to start from a clean slate
+      // Otherwise, some tests may fail due to the auto-incrementing IDs
+      // not starting from 1
       await User.sync({ force: true })
       await Site.sync({ force: true })
       await Repo.sync({ force: true })

--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -109,6 +109,11 @@ describe("Sites Router", () => {
 
   describe("/", () => {
     beforeAll(async () => {
+      await User.sync({ force: true })
+      await Site.sync({ force: true })
+      await Repo.sync({ force: true })
+      await SiteMember.sync({ force: true })
+
       // Set up User and Site table entries
       await User.create({
         id: mockIsomerUserId,

--- a/src/integration/Users.spec.ts
+++ b/src/integration/Users.spec.ts
@@ -56,6 +56,9 @@ const extractMobileOtp = (mobileBody: string): string =>
 
 describe("Users Router", () => {
   beforeAll(async () => {
+    // We need to force the relevant tables to start from a clean slate
+    // Otherwise, some tests may fail due to the auto-incrementing IDs
+    // not starting from 1
     await User.sync({ force: true })
     await Whitelist.sync({ force: true })
   })

--- a/src/integration/Users.spec.ts
+++ b/src/integration/Users.spec.ts
@@ -55,6 +55,11 @@ const extractMobileOtp = (mobileBody: string): string =>
   mobileBody.slice(12, 12 + 6)
 
 describe("Users Router", () => {
+  beforeAll(async () => {
+    await User.sync({ force: true })
+    await Whitelist.sync({ force: true })
+  })
+
   afterEach(() => {
     jest.resetAllMocks()
     mockAxios.reset()

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -141,7 +141,7 @@ export class ReviewsRouter {
     // Step 3: Check if reviewers are admins of repo
     // Check if number of requested reviewers > 0
     if (reviewers.length === 0) {
-      res.status(400).json({
+      return res.status(400).json({
         message: "Please ensure that you have selected at least 1 reviewer!",
       })
     }

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -64,7 +64,7 @@ export class ReviewsRouter {
     const { siteName } = req.params
 
     // Check if they have access to site
-    const possibleSiteMember = this.identityUsersService.getSiteMember(
+    const possibleSiteMember = await this.identityUsersService.getSiteMember(
       userWithSiteSessionData.isomerUserId,
       siteName
     )

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -282,7 +282,7 @@ export class ReviewsRouter {
     )
 
     if (!role) {
-      return res.status(400).send({
+      return res.status(404).send({
         message: "User is not a collaborator of this site!",
       })
     }
@@ -325,7 +325,7 @@ export class ReviewsRouter {
     )
 
     if (!role) {
-      return res.status(400).send({
+      return res.status(404).send({
         message: "User is not a collaborator of this site!",
       })
     }
@@ -783,7 +783,7 @@ export class ReviewsRouter {
     )
 
     if (!role) {
-      return res.status(400).send({
+      return res.status(404).send({
         message: "User is not a collaborator of this site!",
       })
     }

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -529,7 +529,7 @@ export default class ReviewRequestService {
     { reviewers }: RequestChangeInfo
   ) => {
     // Update db state with new reviewers
-    reviewRequest.$set("reviewers", reviewers)
+    await reviewRequest.$set("reviewers", reviewers)
     await reviewRequest.save()
   }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

There are currently no integration tests for the review requests feature. This can be dangerous.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Added some integration tests for the review requests feature

**Bug Fixes**:

- Fixed an issue with the reviews route not waiting for the results of IdentityService first, which can cause the validation check to be skipped when the user is not a member
- Added more sanity checks for comments-related functionality to prevent unauthorised users from adding or retrieving comments
- Standardised the response codes for the non-happy paths

## Tests

<!-- What tests should be run to confirm functionality? -->

**Unit tests**: Run `npm run test` on this branch

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*