### PR TITLE
Fix/reference sitename from repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node -r ts-node/register/transpile-only -r tsconfig-paths/register build/server.js",
     "dev:services": "docker compose up -d",
     "dev": "source .env && ts-node-dev --respawn src/server.js",
-    "test": "source .env.test && jest",
+    "test": "source .env.test && jest --runInBand",
     "release": "npm version $npm_config_isomer_update && git push --tags",
     "lint": "npx eslint .",
     "lint-fix": "eslint --ignore-path .gitignore . --fix",

--- a/src/services/identity/CollaboratorsService.ts
+++ b/src/services/identity/CollaboratorsService.ts
@@ -93,7 +93,6 @@ class CollaboratorsService {
         },
         {
           model: Repo,
-          required: true,
           where: {
             name: siteName,
           },
@@ -192,7 +191,6 @@ class CollaboratorsService {
         },
         {
           model: Repo,
-          required: true,
           where: {
             name: siteName,
           },
@@ -238,7 +236,6 @@ class CollaboratorsService {
         },
         {
           model: Repo,
-          required: true,
           where: {
             name: siteName,
           },
@@ -262,7 +259,6 @@ class CollaboratorsService {
         },
         {
           model: Repo,
-          required: true,
           where: {
             name: siteName,
           },

--- a/src/services/identity/CollaboratorsService.ts
+++ b/src/services/identity/CollaboratorsService.ts
@@ -11,7 +11,7 @@ import {
   INACTIVE_USER_THRESHOLD_DAYS,
 } from "@constants/constants"
 
-import { Whitelist, User, Site, SiteMember } from "@database/models"
+import { Whitelist, User, Site, SiteMember, Repo } from "@database/models"
 import { BadRequestError } from "@root/errors/BadRequestError"
 import { ConflictError } from "@root/errors/ConflictError"
 import logger from "@root/logger/logger"
@@ -86,11 +86,17 @@ class CollaboratorsService {
     // However, the converse is possible, i.e. we can query the Sites table and retrieve joined
     // records from the Users table, along with the SiteMember records.
     const site = await this.siteRepository.findOne({
-      where: { name: siteName },
       include: [
         {
           model: User,
           as: "site_members",
+        },
+        {
+          model: Repo,
+          required: true,
+          where: {
+            name: siteName,
+          },
         },
       ],
     })
@@ -179,11 +185,17 @@ class CollaboratorsService {
 
   delete = async (siteName: string, userId: string) => {
     const site = await this.siteRepository.findOne({
-      where: { name: siteName },
       include: [
         {
           model: User,
           as: "site_members",
+        },
+        {
+          model: Repo,
+          required: true,
+          where: {
+            name: siteName,
+          },
         },
       ],
     })
@@ -216,13 +228,19 @@ class CollaboratorsService {
     userId: string
   ): Promise<CollaboratorRoles | null> => {
     const site = await this.siteRepository.findOne({
-      where: { name: siteName },
       include: [
         {
           model: User,
           as: "site_members",
           where: {
             id: userId,
+          },
+        },
+        {
+          model: Repo,
+          required: true,
+          where: {
+            name: siteName,
           },
         },
       ],
@@ -237,11 +255,17 @@ class CollaboratorsService {
       inactiveLimit.getDate() - INACTIVE_USER_THRESHOLD_DAYS
     )
     const site = await this.siteRepository.findOne({
-      where: { name: siteName },
       include: [
         {
           model: User,
           as: "site_members",
+        },
+        {
+          model: Repo,
+          required: true,
+          where: {
+            name: siteName,
+          },
         },
       ],
     })

--- a/src/services/identity/SitesService.ts
+++ b/src/services/identity/SitesService.ts
@@ -159,7 +159,6 @@ class SitesService {
       include: [
         {
           model: Repo,
-          required: true,
           where: {
             name: siteName,
           },
@@ -261,7 +260,6 @@ class SitesService {
         },
         {
           model: Repo,
-          required: true,
           where: {
             name: siteName,
           },

--- a/src/services/identity/SitesService.ts
+++ b/src/services/identity/SitesService.ts
@@ -1,7 +1,7 @@
 import _ from "lodash"
 import { ModelStatic } from "sequelize"
 
-import { Deployment, Site } from "@database/models"
+import { Deployment, Site, Repo } from "@database/models"
 import type UserSessionData from "@root/classes/UserSessionData"
 import type UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import {
@@ -156,7 +156,15 @@ class SitesService {
 
   async getBySiteName(siteName: string): Promise<Site | null> {
     const site = await this.siteRepository.findOne({
-      where: { name: siteName },
+      include: [
+        {
+          model: Repo,
+          required: true,
+          where: {
+            name: siteName,
+          },
+        },
+      ],
     })
 
     return site
@@ -246,11 +254,19 @@ class SitesService {
     const { siteName } = sessionData
 
     const site = await this.siteRepository.findOne({
-      where: { name: siteName },
-      include: {
-        model: Deployment,
-        as: "deployment",
-      },
+      include: [
+        {
+          model: Deployment,
+          as: "deployment",
+        },
+        {
+          model: Repo,
+          required: true,
+          where: {
+            name: siteName,
+          },
+        },
+      ],
     })
 
     // Note: site may be null if the site does not exist

--- a/src/services/identity/__tests__/SitesService.spec.ts
+++ b/src/services/identity/__tests__/SitesService.spec.ts
@@ -539,7 +539,6 @@ describe("SitesService", () => {
         include: [
           {
             model: Repo,
-            required: true,
             where: {
               name: mockSiteName,
             },

--- a/src/services/identity/__tests__/SitesService.spec.ts
+++ b/src/services/identity/__tests__/SitesService.spec.ts
@@ -1,6 +1,6 @@
 import { ModelStatic } from "sequelize"
 
-import { Deployment, Site, User } from "@database/models"
+import { Deployment, Site, User, Repo } from "@database/models"
 import {
   MOCK_COMMIT_MESSAGE_OBJECT_ONE,
   MOCK_COMMIT_MESSAGE_OBJECT_TWO,
@@ -536,9 +536,15 @@ describe("SitesService", () => {
       // Assert
       expect(actual).toBe(expected)
       expect(MockRepository.findOne).toBeCalledWith({
-        where: {
-          name: mockSiteName,
-        },
+        include: [
+          {
+            model: Repo,
+            required: true,
+            where: {
+              name: mockSiteName,
+            },
+          },
+        ],
       })
     })
   })


### PR DESCRIPTION
## Problem

This PR fixes an issue with our existing implementation of CollaboratorsService and SitesService - we were attempting to search for entries matching the `name` param inside a `Site` entry. However, this is actually meant to be the human readable title of the repo (e.g. `Example Repo`), while the value we should be referencing is the title of the github repo stored in the `name` param of a `Repo` entry (e.g. `example-repo`).

We should also fix the entries in our local db to bring our local test db closer to our prod db and ensure this issue can be caught more easily in future.