### PR TITLE
tests: add review requests routes unit tests

### DIFF
--- a/src/routes/v2/authenticated/__tests__/review.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/review.spec.ts
@@ -1,0 +1,1272 @@
+import express from "express"
+import request from "supertest"
+
+import { attachReadRouteHandlerWrapper } from "@middleware/routeHandler"
+
+import { ReviewsRouter as _ReviewsRouter } from "@routes/v2/authenticated/review"
+
+import { generateRouterForDefaultUserWithSite } from "@fixtures/app"
+import { CollaboratorRoles } from "@root/constants"
+import RequestNotFoundError from "@root/errors/RequestNotFoundError"
+import { MOCK_USER_EMAIL_ONE, MOCK_USER_EMAIL_TWO } from "@root/fixtures/users"
+import CollaboratorsService from "@services/identity/CollaboratorsService"
+import SitesService from "@services/identity/SitesService"
+import UsersService from "@services/identity/UsersService"
+import ReviewRequestService from "@services/review/ReviewRequestService"
+
+describe("Review Requests Router", () => {
+  const mockReviewRequestService = {
+    approveReviewRequest: jest.fn(),
+    closeReviewRequest: jest.fn(),
+    compareDiff: jest.fn(),
+    createComment: jest.fn(),
+    createReviewRequest: jest.fn(),
+    deleteAllReviewRequestViews: jest.fn(),
+    deleteReviewRequestApproval: jest.fn(),
+    getComments: jest.fn(),
+    getFullReviewRequest: jest.fn(),
+    getReviewRequest: jest.fn(),
+    listReviewRequest: jest.fn(),
+    markAllReviewRequestsAsViewed: jest.fn(),
+    markReviewRequestAsViewed: jest.fn(),
+    mergeReviewRequest: jest.fn(),
+    updateReviewRequest: jest.fn(),
+    updateReviewRequestLastViewedAt: jest.fn(),
+  }
+
+  const mockIdentityUsersService = {
+    findByEmail: jest.fn(),
+    getSiteMember: jest.fn(),
+  }
+
+  const mockSitesService = {
+    getBySiteName: jest.fn(),
+  }
+
+  const mockCollaboratorsService = {
+    getRole: jest.fn(),
+    list: jest.fn(),
+  }
+
+  const ReviewsRouter = new _ReviewsRouter(
+    (mockReviewRequestService as unknown) as ReviewRequestService,
+    (mockIdentityUsersService as unknown) as UsersService,
+    (mockSitesService as unknown) as SitesService,
+    (mockCollaboratorsService as unknown) as CollaboratorsService
+  )
+
+  const subrouter = express()
+  // We can use read route handler here because we don't need to lock the repo
+  subrouter.get(
+    "/:siteName/review/compare",
+    attachReadRouteHandlerWrapper(ReviewsRouter.compareDiff)
+  )
+  subrouter.post(
+    "/:siteName/review/request",
+    attachReadRouteHandlerWrapper(ReviewsRouter.createReviewRequest)
+  )
+  subrouter.get(
+    "/:siteName/review/summary",
+    attachReadRouteHandlerWrapper(ReviewsRouter.listReviews)
+  )
+  subrouter.post(
+    "/:siteName/review/viewed",
+    attachReadRouteHandlerWrapper(ReviewsRouter.markAllReviewRequestsAsViewed)
+  )
+  subrouter.get(
+    "/:siteName/review/:requestId",
+    attachReadRouteHandlerWrapper(ReviewsRouter.getReviewRequest)
+  )
+  subrouter.post(
+    "/:siteName/review/:requestId/viewed",
+    attachReadRouteHandlerWrapper(ReviewsRouter.markReviewRequestAsViewed)
+  )
+  subrouter.post(
+    "/:siteName/review/:requestId/merge",
+    attachReadRouteHandlerWrapper(ReviewsRouter.mergeReviewRequest)
+  )
+  subrouter.post(
+    "/:siteName/review/:requestId/approve",
+    attachReadRouteHandlerWrapper(ReviewsRouter.approveReviewRequest)
+  )
+  subrouter.get(
+    "/:siteName/review/:requestId/comments",
+    attachReadRouteHandlerWrapper(ReviewsRouter.getComments)
+  )
+  subrouter.post(
+    "/:siteName/review/:requestId/comments",
+    attachReadRouteHandlerWrapper(ReviewsRouter.createComment)
+  )
+  subrouter.delete(
+    "/:siteName/review/:requestId/approve",
+    attachReadRouteHandlerWrapper(ReviewsRouter.deleteReviewRequestApproval)
+  )
+  subrouter.post(
+    "/:siteName/review/:requestId/comments/viewedComments",
+    attachReadRouteHandlerWrapper(
+      ReviewsRouter.markReviewRequestCommentsAsViewed
+    )
+  )
+  subrouter.post(
+    "/:siteName/review/:requestId",
+    attachReadRouteHandlerWrapper(ReviewsRouter.updateReviewRequest)
+  )
+  subrouter.delete(
+    "/:siteName/review/:requestId",
+    attachReadRouteHandlerWrapper(ReviewsRouter.closeReviewRequest)
+  )
+
+  const app = generateRouterForDefaultUserWithSite(subrouter)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("compareDiff", () => {
+    it("should return 200 with the list of changed files", async () => {
+      // Arrange
+      const mockFilesChanged = ["file1", "file2"]
+      mockIdentityUsersService.getSiteMember.mockResolvedValueOnce("user")
+      mockReviewRequestService.compareDiff.mockResolvedValueOnce(
+        mockFilesChanged
+      )
+
+      // Act
+      const response = await request(app).get("/mockSite/review/compare")
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(response.body).toEqual({ items: mockFilesChanged })
+      expect(mockIdentityUsersService.getSiteMember).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.compareDiff).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 404 if user is not a site member", async () => {
+      // Arrange
+      mockIdentityUsersService.getSiteMember.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).get("/mockSite/review/compare")
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockIdentityUsersService.getSiteMember).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.compareDiff).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("createReviewRequest", () => {
+    it("should return 200 with the pull request number of the created review request", async () => {
+      // Arrange
+      const mockPullRequestNumber = 1
+      const mockReviewer = "reviewer@test.gov.sg"
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockIdentityUsersService.findByEmail.mockResolvedValueOnce("user")
+      mockCollaboratorsService.list.mockResolvedValueOnce([
+        {
+          email: mockReviewer,
+          SiteMember: {
+            role: CollaboratorRoles.Admin,
+          },
+        },
+      ])
+      mockReviewRequestService.createReviewRequest.mockResolvedValueOnce(
+        mockPullRequestNumber
+      )
+
+      // Act
+      const response = await request(app)
+        .post("/mockSite/review/request")
+        .send({
+          reviewers: [mockReviewer],
+          title: "mockTitle",
+          description: "mockDescription",
+        })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(response.body).toEqual({
+        pullRequestNumber: mockPullRequestNumber,
+      })
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockIdentityUsersService.findByEmail).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.list).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.createReviewRequest
+      ).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 404 if the site does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app)
+        .post("/mockSite/review/request")
+        .send({})
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).not.toHaveBeenCalled()
+      expect(mockIdentityUsersService.findByEmail).not.toHaveBeenCalled()
+      expect(mockCollaboratorsService.list).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.createReviewRequest
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if user is not a site collaborator", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app)
+        .post("/mockSite/review/request")
+        .send({})
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockIdentityUsersService.findByEmail).not.toHaveBeenCalled()
+      expect(mockCollaboratorsService.list).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.createReviewRequest
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 400 if no reviewers are provided", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockIdentityUsersService.findByEmail.mockResolvedValueOnce("user")
+
+      // Act
+      const response = await request(app)
+        .post("/mockSite/review/request")
+        .send({
+          reviewers: [],
+          title: "mockTitle",
+          description: "mockDescription",
+        })
+
+      // Assert
+      expect(response.status).toEqual(400)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockIdentityUsersService.findByEmail).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.list).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.createReviewRequest
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 400 if provided reviewer is not an admin", async () => {
+      // Arrange
+      const mockReviewer = "reviewer@test.gov.sg"
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockIdentityUsersService.findByEmail.mockResolvedValueOnce("user")
+      mockCollaboratorsService.list.mockResolvedValueOnce([])
+
+      // Act
+      const response = await request(app)
+        .post("/mockSite/review/request")
+        .send({
+          reviewers: [mockReviewer],
+          title: "mockTitle",
+          description: "mockDescription",
+        })
+
+      // Assert
+      expect(response.status).toEqual(400)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockIdentityUsersService.findByEmail).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.list).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.createReviewRequest
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("listReviews", () => {
+    it("should return 200 with the list of reviews", async () => {
+      // Arrange
+      const mockReviews = ["review1", "review2"]
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockReviewRequestService.listReviewRequest.mockResolvedValueOnce(
+        mockReviews
+      )
+
+      // Act
+      const response = await request(app).get("/mockSite/review/summary")
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(response.body).toEqual({ reviews: mockReviews })
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.listReviewRequest).toHaveBeenCalledTimes(
+        1
+      )
+    })
+
+    it("should return 404 if the site does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).get("/mockSite/review/summary")
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).not.toHaveBeenCalled()
+      expect(mockReviewRequestService.listReviewRequest).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if user is not a site collaborator", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).get("/mockSite/review/summary")
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.listReviewRequest).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("markAllReviewRequestsAsViewed", () => {
+    it("should return 200 and mark all review requests as viewed", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+
+      // Act
+      const response = await request(app).post("/mockSite/review/viewed")
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.markAllReviewRequestsAsViewed
+      ).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 404 if the site does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).post("/mockSite/review/viewed")
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.markAllReviewRequestsAsViewed
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if user is not a site collaborator", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).post("/mockSite/review/viewed")
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.markAllReviewRequestsAsViewed
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("markReviewRequestAsViewed", () => {
+    it("should return 200 and mark review request as viewed", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce({
+        id: 12345,
+      })
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345/viewed`)
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.markReviewRequestAsViewed
+      ).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 404 if the site does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345/viewed`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).not.toHaveBeenCalled()
+      expect(mockReviewRequestService.getReviewRequest).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.markReviewRequestAsViewed
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if user is not a site collaborator", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345/viewed`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.markReviewRequestAsViewed
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if review request does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        new RequestNotFoundError()
+      )
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345/viewed`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.markReviewRequestAsViewed
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("getReviewRequest", () => {
+    it("should return 200 with the full review request", async () => {
+      // Arrange
+      const mockReviewRequest = "review request"
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockReviewRequestService.getFullReviewRequest.mockResolvedValueOnce(
+        mockReviewRequest
+      )
+
+      // Act
+      const response = await request(app).get(`/mockSite/review/12345`)
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(response.body).toEqual({ reviewRequest: mockReviewRequest })
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.getFullReviewRequest
+      ).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 404 if the site does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).get(`/mockSite/review/12345`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.getFullReviewRequest
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if user is not a site collaborator", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).get(`/mockSite/review/12345`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.getFullReviewRequest
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if review request does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockReviewRequestService.getFullReviewRequest.mockResolvedValueOnce(
+        new RequestNotFoundError()
+      )
+
+      // Act
+      const response = await request(app).get(`/mockSite/review/12345`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.getFullReviewRequest
+      ).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("updateReviewRequest", () => {
+    it("should return 200 with the updated review request", async () => {
+      // Arrange
+      const mockReviewRequest = { requestor: { email: MOCK_USER_EMAIL_ONE } }
+      const mockReviewer = "reviewer@test.gov.sg"
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        mockReviewRequest
+      )
+      mockCollaboratorsService.list.mockResolvedValueOnce([
+        {
+          email: mockReviewer,
+          SiteMember: {
+            role: CollaboratorRoles.Admin,
+          },
+        },
+      ])
+      mockReviewRequestService.updateReviewRequest.mockResolvedValueOnce(
+        mockReviewRequest
+      )
+
+      // Act
+      const response = await request(app)
+        .post(`/mockSite/review/12345`)
+        .send({
+          reviewers: [mockReviewer],
+        })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.list).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.updateReviewRequest
+      ).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 404 if the site does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).not.toHaveBeenCalled()
+      expect(mockCollaboratorsService.list).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.updateReviewRequest
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if the review request is not found", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        new RequestNotFoundError()
+      )
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.list).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.updateReviewRequest
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 403 if user is not the original requestor", async () => {
+      // Arrange
+      const mockReviewRequest = { requestor: { email: "other@test.gov.sg" } }
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        mockReviewRequest
+      )
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345`)
+
+      // Assert
+      expect(response.status).toEqual(403)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.list).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.updateReviewRequest
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 400 if the given reviewers are not admins of the site", async () => {
+      // Arrange
+      const mockReviewRequest = { requestor: { email: MOCK_USER_EMAIL_ONE } }
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        mockReviewRequest
+      )
+      mockCollaboratorsService.list.mockResolvedValueOnce([])
+
+      // Act
+      const response = await request(app)
+        .post(`/mockSite/review/12345`)
+        .send({
+          reviewers: [MOCK_USER_EMAIL_TWO],
+        })
+
+      // Assert
+      expect(response.status).toEqual(400)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.list).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.updateReviewRequest
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("mergeReviewRequest", () => {
+    it("should return 200 with the review request successfully merged", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        "review request"
+      )
+      mockReviewRequestService.mergeReviewRequest.mockResolvedValueOnce(
+        undefined
+      )
+      mockReviewRequestService.deleteAllReviewRequestViews.mockResolvedValueOnce(
+        undefined
+      )
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345/merge`)
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.mergeReviewRequest).toHaveBeenCalledTimes(
+        1
+      )
+      expect(
+        mockReviewRequestService.deleteAllReviewRequestViews
+      ).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 404 if the site does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345/merge`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).not.toHaveBeenCalled()
+      expect(mockReviewRequestService.getReviewRequest).not.toHaveBeenCalled()
+      expect(mockReviewRequestService.mergeReviewRequest).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.deleteAllReviewRequestViews
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if user is not a site member", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345/merge`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).not.toHaveBeenCalled()
+      expect(mockReviewRequestService.mergeReviewRequest).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.deleteAllReviewRequestViews
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if the review request does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        new RequestNotFoundError()
+      )
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345/merge`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.mergeReviewRequest).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.deleteAllReviewRequestViews
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("approveReviewRequest", () => {
+    it("should return 200 with the review request successfully marked as approved", async () => {
+      // Arrange
+      const mockReviewRequest = { reviewers: [{ email: MOCK_USER_EMAIL_ONE }] }
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        mockReviewRequest
+      )
+      mockReviewRequestService.approveReviewRequest.mockResolvedValueOnce(
+        undefined
+      )
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345/approve`)
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.approveReviewRequest
+      ).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 404 if the site does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345/approve`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.approveReviewRequest
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if the review request does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        new RequestNotFoundError()
+      )
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345/approve`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.approveReviewRequest
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 403 if the user is not a reviewer", async () => {
+      // Arrange
+      const mockReviewRequest = { reviewers: [{ email: "other@test.gov.sg" }] }
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        mockReviewRequest
+      )
+
+      // Act
+      const response = await request(app).post(`/mockSite/review/12345/approve`)
+
+      // Assert
+      expect(response.status).toEqual(403)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.approveReviewRequest
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("getComments", () => {
+    it("should return 200 with the comments for a review request", async () => {
+      // Arrange
+      const mockComments = ["comment1", "comment2"]
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        "review request"
+      )
+      mockReviewRequestService.getComments.mockResolvedValueOnce(mockComments)
+
+      // Act
+      const response = await request(app).get(`/mockSite/review/12345/comments`)
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(response.body).toEqual(mockComments)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getComments).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 404 if the site does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).get(`/mockSite/review/12345/comments`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).not.toHaveBeenCalled()
+      expect(mockReviewRequestService.getReviewRequest).not.toHaveBeenCalled()
+      expect(mockReviewRequestService.getComments).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if user is not a valid site member", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).get(`/mockSite/review/12345/comments`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).not.toHaveBeenCalled()
+      expect(mockReviewRequestService.getComments).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if the review request does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        new RequestNotFoundError()
+      )
+
+      // Act
+      const response = await request(app).get(`/mockSite/review/12345/comments`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getComments).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("createComment", () => {
+    it("should return 200 with the comment created successfully", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        "review request"
+      )
+      mockReviewRequestService.createComment.mockResolvedValueOnce(undefined)
+
+      // Act
+      const response = await request(app)
+        .post(`/mockSite/review/12345/comments`)
+        .send({ message: "comment" })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.createComment).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 404 if the site does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app)
+        .post(`/mockSite/review/12345/comments`)
+        .send({ message: "comment" })
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).not.toHaveBeenCalled()
+      expect(mockReviewRequestService.getReviewRequest).not.toHaveBeenCalled()
+      expect(mockReviewRequestService.createComment).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if user is not a valid site member", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app)
+        .post(`/mockSite/review/12345/comments`)
+        .send({ message: "comment" })
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).not.toHaveBeenCalled()
+      expect(mockReviewRequestService.createComment).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if the review request does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        new RequestNotFoundError()
+      )
+
+      // Act
+      const response = await request(app)
+        .post(`/mockSite/review/12345/comments`)
+        .send({ message: "comment" })
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.createComment).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("markReviewRequestCommentsAsViewed", () => {
+    it("should return 200 with the lastViewedAt timestamp updated successfully", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        "review request"
+      )
+      mockReviewRequestService.updateReviewRequestLastViewedAt.mockResolvedValueOnce(
+        undefined
+      )
+
+      // Act
+      const response = await request(app).post(
+        `/mockSite/review/12345/comments/viewedComments`
+      )
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.updateReviewRequestLastViewedAt
+      ).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 404 if the site does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).post(
+        `/mockSite/review/12345/comments/viewedComments`
+      )
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).not.toHaveBeenCalled()
+      expect(mockReviewRequestService.getReviewRequest).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.updateReviewRequestLastViewedAt
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if user is not a valid site member", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).post(
+        `/mockSite/review/12345/comments/viewedComments`
+      )
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.updateReviewRequestLastViewedAt
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if the review request does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        new RequestNotFoundError()
+      )
+
+      // Act
+      const response = await request(app).post(
+        `/mockSite/review/12345/comments/viewedComments`
+      )
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.updateReviewRequestLastViewedAt
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("closeReviewRequest", () => {
+    it("should return 200 with the review request closed successfully", async () => {
+      // Arrange
+      const mockReviewRequest = { requestor: { email: MOCK_USER_EMAIL_ONE } }
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        mockReviewRequest
+      )
+      mockReviewRequestService.closeReviewRequest.mockResolvedValueOnce(
+        undefined
+      )
+      mockReviewRequestService.deleteAllReviewRequestViews.mockResolvedValueOnce(
+        undefined
+      )
+
+      // Act
+      const response = await request(app).delete(`/mockSite/review/12345`)
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.closeReviewRequest).toHaveBeenCalledTimes(
+        1
+      )
+      expect(
+        mockReviewRequestService.deleteAllReviewRequestViews
+      ).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 404 if the site does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).delete(`/mockSite/review/12345`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).not.toHaveBeenCalled()
+      expect(mockReviewRequestService.closeReviewRequest).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.deleteAllReviewRequestViews
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if the review request does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        new RequestNotFoundError()
+      )
+
+      // Act
+      const response = await request(app).delete(`/mockSite/review/12345`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.closeReviewRequest).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.deleteAllReviewRequestViews
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if the user is not the requestor of the review request", async () => {
+      // Arrange
+      const mockReviewRequest = { requestor: { email: "other@test.gov.sg" } }
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        mockReviewRequest
+      )
+
+      // Act
+      const response = await request(app).delete(`/mockSite/review/12345`)
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.closeReviewRequest).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.deleteAllReviewRequestViews
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("deleteReviewRequestApproval", () => {
+    it("should return 200 with the review request approval deleted successfully", async () => {
+      // Arrange
+      const mockReviewRequest = { reviewers: [{ email: MOCK_USER_EMAIL_ONE }] }
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        mockReviewRequest
+      )
+      mockReviewRequestService.deleteReviewRequestApproval.mockResolvedValueOnce(
+        undefined
+      )
+
+      // Act
+      const response = await request(app).delete(
+        `/mockSite/review/12345/approve`
+      )
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.deleteReviewRequestApproval
+      ).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 404 if the site does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
+
+      // Act
+      const response = await request(app).delete(
+        `/mockSite/review/12345/approve`
+      )
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.deleteReviewRequestApproval
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if the review request does not exist", async () => {
+      // Arrange
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        new RequestNotFoundError()
+      )
+
+      // Act
+      const response = await request(app).delete(
+        `/mockSite/review/12345/approve`
+      )
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.deleteReviewRequestApproval
+      ).not.toHaveBeenCalled()
+    })
+
+    it("should return 404 if the user is not a reviewer of the review request", async () => {
+      // Arrange
+      const mockReviewRequest = { reviewers: [{ email: "other@test.gov.sg" }] }
+      mockSitesService.getBySiteName.mockResolvedValueOnce("site")
+      mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
+        mockReviewRequest
+      )
+
+      // Act
+      const response = await request(app).delete(
+        `/mockSite/review/12345/approve`
+      )
+
+      // Assert
+      expect(response.status).toEqual(404)
+      expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
+      expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
+      expect(
+        mockReviewRequestService.deleteReviewRequestApproval
+      ).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

There are currently no unit tests for the review requests routes, which can be dangerous.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Introduced unit tests for the review requests routes

## Tests

<!-- What tests should be run to confirm functionality? -->

**Unit tests**: Run `npm run test` on this branch

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*