### PR TITLE
fix(collaborators): add required middleware

### DIFF
--- a/src/routes/v2/authenticated/collaborators.ts
+++ b/src/routes/v2/authenticated/collaborators.ts
@@ -129,7 +129,10 @@ export class CollaboratorsRouter {
 
   getRouter() {
     const router = express.Router({ mergeParams: true })
-    router.use(this.authorizationMiddleware.verifyIsEmailUser)
+    router.use(
+      attachSiteHandler,
+      this.authorizationMiddleware.verifyIsEmailUser
+    )
     router.get(
       "/role",
       attachSiteHandler,

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -64,7 +64,7 @@ export class ReviewsRouter {
     const { siteName } = req.params
 
     // Check if they have access to site
-    const possibleSiteMember = this.identityUsersService.getSiteMember(
+    const possibleSiteMember = await this.identityUsersService.getSiteMember(
       userWithSiteSessionData.isomerUserId,
       siteName
     )


### PR DESCRIPTION
## Problem
previously, #573 added a new middleware for verification of email users and called it in collaborator routes. however, this missed adding a middleware to attach the property that we were verifying, leading to runtime errors.

## Solution
add required middleware call