### PR TITLE
test(app): updated specs to fit with new API  

### DIFF
--- a/src/classes/Settings.js
+++ b/src/classes/Settings.js
@@ -14,7 +14,7 @@ const {
 // Constants
 const FOOTER_PATH = "footer.yml"
 const NAVIGATION_PATH = "navigation.yml"
-const HOMEPAGE_INDEX_PATH = "index.md" // Empty string
+const { HOMEPAGE_NAME } = require("@root/constants")
 
 const retrieveSettingsFiles = async (
   accessToken,
@@ -42,7 +42,7 @@ const retrieveSettingsFiles = async (
 
   // Retrieve homepage only if flag is set to true
   if (shouldRetrieveHomepage) {
-    fileRetrievalObj.homepage = HomepageFile.read(HOMEPAGE_INDEX_PATH)
+    fileRetrievalObj.homepage = HomepageFile.read(HOMEPAGE_NAME)
   }
 
   const fileContentsArr = await Bluebird.map(
@@ -233,7 +233,7 @@ class Settings {
         const homepageContent = ["---\n", homepageFrontMatter, "---"].join("")
         const newHomepageContent = Base64.encode(homepageContent)
 
-        await HomepageFile.update(HOMEPAGE_INDEX_PATH, newHomepageContent, sha)
+        await HomepageFile.update(HOMEPAGE_NAME, newHomepageContent, sha)
       }
     }
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,2 @@
 export * from "./constants"
+export * from "./pages"

--- a/src/constants/pages.ts
+++ b/src/constants/pages.ts
@@ -1,0 +1,1 @@
+export const HOMEPAGE_NAME = "index.md"

--- a/src/constants/pages.ts
+++ b/src/constants/pages.ts
@@ -1,1 +1,3 @@
 export const HOMEPAGE_NAME = "index.md"
+
+export const CONTACT_US_FILENAME = "contact-us.md"

--- a/src/constants/pages.ts
+++ b/src/constants/pages.ts
@@ -1,3 +1,3 @@
-export const HOMEPAGE_NAME = "index.md"
+export const HOMEPAGE_FILENAME = "index.md"
 
 export const CONTACT_US_FILENAME = "contact-us.md"

--- a/src/errors/DatabaseError.ts
+++ b/src/errors/DatabaseError.ts
@@ -2,9 +2,6 @@ import { BaseIsomerError } from "./BaseError"
 
 export default class DatabaseError extends BaseIsomerError {
   constructor(message = "Unable to retrieve data from database") {
-    super()
-    Error.captureStackTrace(this, this.constructor)
-    this.name = this.constructor.name
-    this.message = message
+    super(500, message)
   }
 }

--- a/src/errors/DatabaseError.ts
+++ b/src/errors/DatabaseError.ts
@@ -1,0 +1,10 @@
+import { BaseIsomerError } from "./BaseError"
+
+export default class DatabaseError extends BaseIsomerError {
+  constructor(message = "Unable to retrieve data from database") {
+    super()
+    Error.captureStackTrace(this, this.constructor)
+    this.name = this.constructor.name
+    this.message = message
+  }
+}

--- a/src/fixtures/github.ts
+++ b/src/fixtures/github.ts
@@ -137,3 +137,13 @@ export const MOCK_GITHUB_RAWCOMMENT_TWO: RawComment = {
   body: JSON.stringify(MOCK_GITHUB_COMMENT_OBJECT_TWO),
   created_at: MOCK_GITHUB_COMMIT_DATE_THREE,
 }
+
+export const MOCK_PAGE_PERMALINK = "/department/english"
+
+export const MOCK_GITHUB_FRONTMATTER = Buffer.from(
+  `---
+permalink: ${MOCK_PAGE_PERMALINK}
+---
+`,
+  "binary"
+).toString("base64")

--- a/src/fixtures/repoInfo.ts
+++ b/src/fixtures/repoInfo.ts
@@ -1,14 +1,26 @@
+import { ConfigYmlData } from "@root/types/configYml"
 import { GitHubRepositoryData } from "@root/types/repoInfo"
+import { Brand } from "@root/types/util"
 
-export const MOCK_STAGING_URL_GITHUB = "https://repo-staging.netlify.app"
-export const MOCK_STAGING_URL_CONFIGYML =
-  "https://repo-staging-configyml.netlify.app"
-export const MOCK_STAGING_URL_DB = "https://repo-staging-db.netlify.app"
+export const MOCK_STAGING_URL_GITHUB: NonNullable<
+  ConfigYmlData["staging"]
+> = Brand.fromString("https://repo-staging.netlify.app")
+export const MOCK_STAGING_URL_CONFIGYML: NonNullable<
+  ConfigYmlData["staging"]
+> = Brand.fromString("https://repo-staging-configyml.netlify.app")
+export const MOCK_STAGING_URL_DB: NonNullable<
+  ConfigYmlData["staging"]
+> = Brand.fromString("https://repo-staging-db.netlify.app")
 
-export const MOCK_PRODUCTION_URL_GITHUB = "https://repo-prod.netlify.app"
-export const MOCK_PRODUCTION_URL_CONFIGYML =
-  "https://repo-prod-configyml.netlify.app"
-export const MOCK_PRODUCTION_URL_DB = "https://repo-prod-db.netlify.app"
+export const MOCK_PRODUCTION_URL_GITHUB: NonNullable<
+  ConfigYmlData["prod"]
+> = Brand.fromString("https://repo-prod.netlify.app")
+export const MOCK_PRODUCTION_URL_CONFIGYML: NonNullable<
+  ConfigYmlData["prod"]
+> = Brand.fromString("https://repo-prod-configyml.netlify.app")
+export const MOCK_PRODUCTION_URL_DB: NonNullable<
+  ConfigYmlData["prod"]
+> = Brand.fromString("https://repo-prod-db.netlify.app")
 
 export const repoInfo: GitHubRepositoryData = {
   name: "repo",

--- a/src/fixtures/sites.ts
+++ b/src/fixtures/sites.ts
@@ -75,7 +75,7 @@ export const MOCK_REPO_DBENTRY_TWO: Attributes<Repo> = {
   updatedAt: MOCK_SITE_DATE_TWO,
 }
 
-export const MOCK_DEPLOYMENT_DBENTRY_ONE: Attributes<Deployment> = {
+export const MOCK_DEPLOYMENT_DBENTRY_ONE = {
   id: 1,
   siteId: MOCK_SITE_ID_ONE,
   productionUrl: MOCK_DEPLOYMENT_PROD_URL_ONE,

--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -23,6 +23,17 @@ import {
   mockIsomerUserId,
   mockSiteName,
 } from "@fixtures/sessionData"
+import { BaseDirectoryService } from "@root/services/directoryServices/BaseDirectoryService"
+import { ResourceRoomDirectoryService } from "@root/services/directoryServices/ResourceRoomDirectoryService"
+import { CollectionPageService } from "@root/services/fileServices/MdPageServices/CollectionPageService"
+import { ContactUsPageService } from "@root/services/fileServices/MdPageServices/ContactUsPageService"
+import { HomepagePageService } from "@root/services/fileServices/MdPageServices/HomepagePageService"
+import { PageService } from "@root/services/fileServices/MdPageServices/PageService"
+import { ResourcePageService } from "@root/services/fileServices/MdPageServices/ResourcePageService"
+import { SubcollectionPageService } from "@root/services/fileServices/MdPageServices/SubcollectionPageService"
+import { UnlinkedPageService } from "@root/services/fileServices/MdPageServices/UnlinkedPageService"
+import { CollectionYmlService } from "@root/services/fileServices/YmlFileServices/CollectionYmlService"
+import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/FooterYmlService"
 import { GitHubService } from "@services/db/GitHubService"
 import * as ReviewApi from "@services/db/review"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
@@ -41,13 +52,62 @@ const mockGithubService = {
   getComments: jest.fn(),
 }
 const usersService = getUsersService(sequelize)
+const footerYmlService = new FooterYmlService({
+  gitHubService: mockGithubService,
+})
+const collectionYmlService = new CollectionYmlService({
+  gitHubService: mockGithubService,
+})
+const baseDirectoryService = new BaseDirectoryService({
+  gitHubService: mockGithubService,
+})
+
+const contactUsService = new ContactUsPageService({
+  gitHubService: mockGithubService,
+  footerYmlService,
+})
+const collectionPageService = new CollectionPageService({
+  gitHubService: mockGithubService,
+  collectionYmlService,
+})
+const subCollectionPageService = new SubcollectionPageService({
+  gitHubService: mockGithubService,
+  collectionYmlService,
+})
+const homepageService = new HomepagePageService({
+  gitHubService: mockGithubService,
+})
+const resourcePageService = new ResourcePageService({
+  gitHubService: mockGithubService,
+})
+const unlinkedPageService = new UnlinkedPageService({
+  gitHubService: mockGithubService,
+})
+const configYmlService = new ConfigYmlService({
+  gitHubService: mockGithubService,
+})
+const resourceRoomDirectoryService = new ResourceRoomDirectoryService({
+  baseDirectoryService,
+  configYmlService,
+  gitHubService: mockGithubService,
+})
+const pageService = new PageService({
+  collectionPageService,
+  contactUsService,
+  subCollectionPageService,
+  homepageService,
+  resourcePageService,
+  unlinkedPageService,
+  resourceRoomDirectoryService,
+})
 const reviewRequestService = new ReviewRequestService(
   (mockGithubService as unknown) as typeof ReviewApi,
   User,
   ReviewRequest,
   Reviewer,
   ReviewMeta,
-  ReviewRequestView
+  ReviewRequestView,
+  pageService
 )
 const sitesService = new SitesService({
   siteRepository: Site,

--- a/src/integration/Notifications.spec.ts
+++ b/src/integration/Notifications.spec.ts
@@ -13,9 +13,8 @@ import {
   User,
   Whitelist,
 } from "@database/models"
-import { generateRouter, generateRouterForUserWithSite } from "@fixtures/app"
+import { generateRouterForUserWithSite } from "@fixtures/app"
 import UserSessionData from "@root/classes/UserSessionData"
-import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import {
   formatNotification,
   highPriorityOldReadNotification,
@@ -35,7 +34,18 @@ import { NotificationsRouter as _NotificationsRouter } from "@root/routes/v2/aut
 import { SitesRouter as _SitesRouter } from "@root/routes/v2/authenticated/sites"
 import { genericGitHubAxiosInstance } from "@root/services/api/AxiosInstance"
 import { GitHubService } from "@root/services/db/GitHubService"
+import { BaseDirectoryService } from "@root/services/directoryServices/BaseDirectoryService"
+import { ResourceRoomDirectoryService } from "@root/services/directoryServices/ResourceRoomDirectoryService"
+import { CollectionPageService } from "@root/services/fileServices/MdPageServices/CollectionPageService"
+import { ContactUsPageService } from "@root/services/fileServices/MdPageServices/ContactUsPageService"
+import { HomepagePageService } from "@root/services/fileServices/MdPageServices/HomepagePageService"
+import { PageService } from "@root/services/fileServices/MdPageServices/PageService"
+import { ResourcePageService } from "@root/services/fileServices/MdPageServices/ResourcePageService"
+import { SubcollectionPageService } from "@root/services/fileServices/MdPageServices/SubcollectionPageService"
+import { UnlinkedPageService } from "@root/services/fileServices/MdPageServices/UnlinkedPageService"
+import { CollectionYmlService } from "@root/services/fileServices/YmlFileServices/CollectionYmlService"
 import { ConfigYmlService } from "@root/services/fileServices/YmlFileServices/ConfigYmlService"
+import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/FooterYmlService"
 import CollaboratorsService from "@root/services/identity/CollaboratorsService"
 import SitesService from "@root/services/identity/SitesService"
 import ReviewRequestService from "@root/services/review/ReviewRequestService"
@@ -58,13 +68,47 @@ const gitHubService = new GitHubService({
 const identityAuthService = getIdentityAuthService(gitHubService)
 const usersService = getUsersService(sequelize)
 const configYmlService = new ConfigYmlService({ gitHubService })
+const footerYmlService = new FooterYmlService({ gitHubService })
+const collectionYmlService = new CollectionYmlService({ gitHubService })
+const baseDirectoryService = new BaseDirectoryService({ gitHubService })
+
+const contactUsService = new ContactUsPageService({
+  gitHubService,
+  footerYmlService,
+})
+const collectionPageService = new CollectionPageService({
+  gitHubService,
+  collectionYmlService,
+})
+const subCollectionPageService = new SubcollectionPageService({
+  gitHubService,
+  collectionYmlService,
+})
+const homepageService = new HomepagePageService({ gitHubService })
+const resourcePageService = new ResourcePageService({ gitHubService })
+const unlinkedPageService = new UnlinkedPageService({ gitHubService })
+const resourceRoomDirectoryService = new ResourceRoomDirectoryService({
+  baseDirectoryService,
+  configYmlService,
+  gitHubService,
+})
+const pageService = new PageService({
+  collectionPageService,
+  contactUsService,
+  subCollectionPageService,
+  homepageService,
+  resourcePageService,
+  unlinkedPageService,
+  resourceRoomDirectoryService,
+})
 const reviewRequestService = new ReviewRequestService(
   (gitHubService as unknown) as typeof ReviewApi,
   User,
   ReviewRequest,
   Reviewer,
   ReviewMeta,
-  ReviewRequestView
+  ReviewRequestView,
+  pageService
 )
 const sitesService = new SitesService({
   siteRepository: Site,

--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -19,8 +19,20 @@ import UserSessionData from "@root/classes/UserSessionData"
 import { mockEmail, mockIsomerUserId } from "@root/fixtures/sessionData"
 import { getAuthorizationMiddleware } from "@root/middleware"
 import { SitesRouter as _SitesRouter } from "@root/routes/v2/authenticated/sites"
+import { isomerRepoAxiosInstance } from "@root/services/api/AxiosInstance"
 import { GitHubService } from "@root/services/db/GitHubService"
+import { BaseDirectoryService } from "@root/services/directoryServices/BaseDirectoryService"
+import { ResourceRoomDirectoryService } from "@root/services/directoryServices/ResourceRoomDirectoryService"
+import { CollectionPageService } from "@root/services/fileServices/MdPageServices/CollectionPageService"
+import { ContactUsPageService } from "@root/services/fileServices/MdPageServices/ContactUsPageService"
+import { HomepagePageService } from "@root/services/fileServices/MdPageServices/HomepagePageService"
+import { PageService } from "@root/services/fileServices/MdPageServices/PageService"
+import { ResourcePageService } from "@root/services/fileServices/MdPageServices/ResourcePageService"
+import { SubcollectionPageService } from "@root/services/fileServices/MdPageServices/SubcollectionPageService"
+import { UnlinkedPageService } from "@root/services/fileServices/MdPageServices/UnlinkedPageService"
+import { CollectionYmlService } from "@root/services/fileServices/YmlFileServices/CollectionYmlService"
 import { ConfigYmlService } from "@root/services/fileServices/YmlFileServices/ConfigYmlService"
+import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/FooterYmlService"
 import IsomerAdminsService from "@root/services/identity/IsomerAdminsService"
 import SitesService from "@root/services/identity/SitesService"
 import ReviewRequestService from "@root/services/review/ReviewRequestService"
@@ -35,18 +47,53 @@ const mockUpdatedAt = "now"
 const mockPermissions = { push: true }
 const mockPrivate = true
 
-const gitHubService = new GitHubService({ axiosInstance: mockAxios.create() })
+const gitHubService = new GitHubService({
+  axiosInstance: isomerRepoAxiosInstance,
+})
 const configYmlService = new ConfigYmlService({ gitHubService })
 const usersService = getUsersService(sequelize)
 const isomerAdminsService = new IsomerAdminsService({ repository: IsomerAdmin })
 const identityAuthService = getIdentityAuthService(gitHubService)
+const unlinkedPageService = new UnlinkedPageService({ gitHubService })
+const collectionYmlService = new CollectionYmlService({ gitHubService })
+const homepageService = new HomepagePageService({ gitHubService })
+const footerYmlService = new FooterYmlService({ gitHubService })
+const collectionPageService = new CollectionPageService({
+  gitHubService,
+  collectionYmlService,
+})
+const subCollectionPageService = new SubcollectionPageService({
+  gitHubService,
+  collectionYmlService,
+})
+const contactUsService = new ContactUsPageService({
+  gitHubService,
+  footerYmlService,
+})
+const baseDirectoryService = new BaseDirectoryService({ gitHubService })
+const resourcePageService = new ResourcePageService({ gitHubService })
+const resourceRoomDirectoryService = new ResourceRoomDirectoryService({
+  baseDirectoryService,
+  configYmlService,
+  gitHubService,
+})
+const pageService = new PageService({
+  contactUsService,
+  collectionPageService,
+  subCollectionPageService,
+  homepageService,
+  resourcePageService,
+  unlinkedPageService,
+  resourceRoomDirectoryService,
+})
 const reviewRequestService = new ReviewRequestService(
   gitHubService,
   User,
   ReviewRequest,
   Reviewer,
   ReviewMeta,
-  ReviewRequestView
+  ReviewRequestView,
+  pageService
 )
 const sitesService = new SitesService({
   siteRepository: Site,

--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -163,7 +163,6 @@ describe("Sites Router", () => {
       await Site.sync({ force: true })
       await Repo.sync({ force: true })
       await SiteMember.sync({ force: true })
-
       // Set up User and Site table entries
       await User.create({
         id: mockIsomerUserId,

--- a/src/integration/Users.spec.ts
+++ b/src/integration/Users.spec.ts
@@ -21,7 +21,6 @@ const mockValidEmail = "open@up.gov.sg"
 const mockInvalidEmail = "stay@home.sg"
 const mockUnwhitelistedEmail = "blacklisted@sad.sg"
 const mockWhitelistedDomain = ".gov.sg"
-const mockGithubId = "i m a git"
 const mockValidNumber = "92341234"
 const mockInvalidNumber = "00000000"
 const maxNumOfOtpAttempts = config.get("auth.maxNumOtpAttempts")

--- a/src/routes/v1/authenticatedSites/homepage.js
+++ b/src/routes/v1/authenticatedSites/homepage.js
@@ -12,7 +12,7 @@ const {
 const { File, HomepageType } = require("@classes/File")
 
 // Constants
-const HOMEPAGE_INDEX_PATH = "index.md" // Empty string
+const { HOMEPAGE_NAME } = require("@root/constants")
 
 // Read homepage index file
 async function readHomepage(req, res) {
@@ -24,9 +24,7 @@ async function readHomepage(req, res) {
   const IsomerFile = new File(accessToken, siteName)
   const homepageType = new HomepageType()
   IsomerFile.setFileType(homepageType)
-  const { sha, content: encodedContent } = await IsomerFile.read(
-    HOMEPAGE_INDEX_PATH
-  )
+  const { sha, content: encodedContent } = await IsomerFile.read(HOMEPAGE_NAME)
   const content = Base64.decode(encodedContent)
 
   // TO-DO:
@@ -50,7 +48,7 @@ async function updateHomepage(req, res) {
   const homepageType = new HomepageType()
   IsomerFile.setFileType(homepageType)
   const { newSha } = await IsomerFile.update(
-    HOMEPAGE_INDEX_PATH,
+    HOMEPAGE_NAME,
     Base64.encode(content),
     sha
   )

--- a/src/routes/v2/authenticated/__tests__/review.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/review.spec.ts
@@ -151,7 +151,8 @@ describe("Review Requests Router", () => {
       mockReviewRequestService.compareDiff.mockResolvedValueOnce(
         mockFilesChanged
       )
-      mockSitesService.getBySiteName.mockResolvedValueOnce(true)
+      mockSitesService.getBySiteName.mockResolvedValueOnce(ok(true))
+
       // Act
       const response = await request(app).get("/mockSite/review/compare")
 
@@ -165,7 +166,7 @@ describe("Review Requests Router", () => {
     it("should return 404 if user is not a site member", async () => {
       // Arrange
       mockIdentityUsersService.getSiteMember.mockResolvedValueOnce(null)
-      mockSitesService.getBySiteName.mockResolvedValueOnce(true)
+      mockSitesService.getBySiteName.mockResolvedValueOnce(ok(true))
 
       // Act
       const response = await request(app).get("/mockSite/review/compare")
@@ -531,7 +532,6 @@ describe("Review Requests Router", () => {
     it("should return 200 with the full review request", async () => {
       // Arrange
       const mockReviewRequest = "review request"
-
       mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
       mockReviewRequestService.getFullReviewRequest.mockReturnValueOnce(
         okAsync(mockReviewRequest)
@@ -552,10 +552,10 @@ describe("Review Requests Router", () => {
 
     it("should return 404 if the site does not exist", async () => {
       // Arrange
-      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
       mockSitesService.getBySiteName.mockReturnValueOnce(
         errAsync(new MissingSiteError("site"))
       )
+      mockGithubService.getRepoInfo.mockRejectedValueOnce(null)
 
       // Act
       const response = await request(app).get(`/mockSite/review/12345`)

--- a/src/services/fileServices/MdPageServices/ContactUsPageService.js
+++ b/src/services/fileServices/MdPageServices/ContactUsPageService.js
@@ -3,7 +3,8 @@ const {
   convertDataToMarkdown,
 } = require("@utils/markdown-utils")
 
-const CONTACT_US_FILE_NAME = "contact-us.md"
+const { CONTACT_US_FILENAME } = require("@root/constants/pages")
+
 const CONTACT_US_DIRECTORY_NAME = "pages"
 
 class ContactUsPageService {
@@ -18,7 +19,7 @@ class ContactUsPageService {
     const { content: rawContent, sha } = await this.gitHubService.read(
       sessionData,
       {
-        fileName: CONTACT_US_FILE_NAME,
+        fileName: CONTACT_US_FILENAME,
         directoryName: CONTACT_US_DIRECTORY_NAME,
       }
     )
@@ -37,7 +38,7 @@ class ContactUsPageService {
     const { newSha } = await this.gitHubService.update(sessionData, {
       fileContent: newContent,
       sha,
-      fileName: CONTACT_US_FILE_NAME,
+      fileName: CONTACT_US_FILENAME,
       directoryName: CONTACT_US_DIRECTORY_NAME,
     })
     const {

--- a/src/services/fileServices/MdPageServices/HomepagePageService.js
+++ b/src/services/fileServices/MdPageServices/HomepagePageService.js
@@ -3,7 +3,7 @@ const {
   convertDataToMarkdown,
 } = require("@utils/markdown-utils")
 
-const HOMEPAGE_FILE_NAME = "index.md"
+const { HOMEPAGE_NAME } = require("@root/constants")
 
 class HomepagePageService {
   constructor({ gitHubService }) {
@@ -14,7 +14,7 @@ class HomepagePageService {
     const { content: rawContent, sha } = await this.gitHubService.read(
       sessionData,
       {
-        fileName: HOMEPAGE_FILE_NAME,
+        fileName: HOMEPAGE_NAME,
       }
     )
     const { frontMatter, pageContent } = retrieveDataFromMarkdown(rawContent)
@@ -26,7 +26,7 @@ class HomepagePageService {
     const { newSha } = await this.gitHubService.update(sessionData, {
       fileContent: newContent,
       sha,
-      fileName: HOMEPAGE_FILE_NAME,
+      fileName: HOMEPAGE_NAME,
     })
     return {
       content: { frontMatter, pageBody: content },

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -141,10 +141,6 @@ export class PageService {
           CollectionPageName | SubcollectionPageName,
           NotFoundError
         >((rawPath) => {
-          // NOTE: Only 2 levels of nesting
-          if (rawPath.length > 2) {
-            return errAsync(new NotFoundError())
-          }
           if (rawPath.length === 1 && !!rawPath[0]) {
             return okAsync({
               name: Brand.fromString(name),

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -145,19 +145,22 @@ export class PageService {
           if (rawPath.length > 2) {
             return errAsync(new NotFoundError())
           }
-          if (rawPath.length === 1) {
+          if (rawPath.length === 1 && !!rawPath[0]) {
             return okAsync({
               name: Brand.fromString(name),
               collection: rawPath[0],
               kind: "CollectionPage",
             })
           }
-          return okAsync({
-            name: Brand.fromString(name),
-            collection: rawPath[0],
-            subCollection: rawPath[1],
-            kind: "SubcollectionPage",
-          })
+          if (rawPath.length === 2 && !!rawPath[0] && !!rawPath[1]) {
+            return okAsync({
+              name: Brand.fromString(name),
+              collection: rawPath[0],
+              subCollection: rawPath[1],
+              kind: "SubcollectionPage",
+            })
+          }
+          return errAsync(new NotFoundError())
         })
       )
       .mapErr(() => new NotFoundError())

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -1,7 +1,7 @@
 import { ok, err, Result, ResultAsync, okAsync, errAsync } from "neverthrow"
 
 import UserSessionData from "@root/classes/UserSessionData"
-import { CONTACT_US_FILENAME, HOMEPAGE_NAME } from "@root/constants"
+import { CONTACT_US_FILENAME, HOMEPAGE_FILENAME } from "@root/constants"
 import { BaseIsomerError } from "@root/errors/BaseError"
 import EmptyStringError from "@root/errors/EmptyStringError"
 import MissingResourceRoomError from "@root/errors/MissingResourceRoomError"
@@ -170,7 +170,7 @@ export class PageService {
   ): Result<HomepageName, NotFoundError> =>
     this.extractPathInfo(pageName).andThen<HomepageName, NotFoundError>(
       ({ name, path }) => {
-        if (path.isErr() && name === HOMEPAGE_NAME) {
+        if (path.isErr() && name === HOMEPAGE_FILENAME) {
           return ok({ name: Brand.fromString(name), kind: "Homepage" })
         }
         return err(new NotFoundError())

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -1,7 +1,7 @@
-import _ from "lodash"
 import { ok, err, Result, ResultAsync, okAsync, errAsync } from "neverthrow"
 
 import UserSessionData from "@root/classes/UserSessionData"
+import { HOMEPAGE_NAME } from "@root/constants"
 import { BaseIsomerError } from "@root/errors/BaseError"
 import EmptyStringError from "@root/errors/EmptyStringError"
 import MissingResourceRoomError from "@root/errors/MissingResourceRoomError"
@@ -167,7 +167,7 @@ export class PageService {
   ): Result<HomepageName, NotFoundError> =>
     this.extractPathInfo(pageName).andThen<HomepageName, NotFoundError>(
       ({ name, path }) => {
-        if (path.isErr() && name === "index.md") {
+        if (path.isErr() && name === HOMEPAGE_NAME) {
           return ok({ name: Brand.fromString(name), kind: "Homepage" })
         }
         return err(new NotFoundError())

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -1,7 +1,7 @@
 import { ok, err, Result, ResultAsync, okAsync, errAsync } from "neverthrow"
 
 import UserSessionData from "@root/classes/UserSessionData"
-import { HOMEPAGE_NAME } from "@root/constants"
+import { CONTACT_US_FILENAME, HOMEPAGE_NAME } from "@root/constants"
 import { BaseIsomerError } from "@root/errors/BaseError"
 import EmptyStringError from "@root/errors/EmptyStringError"
 import MissingResourceRoomError from "@root/errors/MissingResourceRoomError"
@@ -187,7 +187,7 @@ export class PageService {
         if (
           path.isOk() &&
           path.value.pop() === "pages" &&
-          name === "contact-us.md"
+          name === CONTACT_US_FILENAME
         ) {
           return ok({ name: Brand.fromString(name), kind: "ContactUsPage" })
         }

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -159,7 +159,7 @@ export class PageService {
           }
           return errAsync(
             new NotFoundError(
-              `Error when parsig path: ${rawPath}, please ensure that the file exists!`
+              `Error when parsing path: ${rawPath}, please ensure that the file exists!`
             )
           )
         })

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -156,7 +156,7 @@ export class PageService {
             return okAsync({
               name: Brand.fromString(name),
               collection: rawPath[0],
-              subCollection: rawPath[1],
+              subcollection: rawPath[1],
               kind: "SubcollectionPage",
             })
           }
@@ -346,7 +346,7 @@ export class PageService {
             .read(sessionData, {
               fileName: pageName.name,
               collectionName: pageName.collection.slice(1),
-              subcollectionName: pageName.subCollection,
+              subcollectionName: pageName.subcollection,
             })
             .then((subcollectionPage) => subcollectionPage as SubcollectionPage)
         ).map(withPermalink)

--- a/src/services/fileServices/MdPageServices/__tests__/ContactUsPageService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/ContactUsPageService.spec.js
@@ -7,6 +7,7 @@ const {
   footerContent: mockFooterContent,
   footerSha: mockFooterSha,
 } = require("@fixtures/footer")
+const { CONTACT_US_FILENAME } = require("@root/constants/pages")
 const { NotFoundError } = require("@root/errors/NotFoundError")
 
 describe("ContactUs Page Service", () => {
@@ -14,7 +15,6 @@ describe("ContactUs Page Service", () => {
   const accessToken = "test-token"
   const reqDetails = { siteName, accessToken }
 
-  const CONTACT_US_FILE_NAME = "contact-us.md"
   const CONTACT_US_DIRECTORY_NAME = "pages"
 
   const mockFrontMatter = {
@@ -80,7 +80,7 @@ describe("ContactUs Page Service", () => {
         mockRawContactUsContent
       )
       expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
-        fileName: CONTACT_US_FILE_NAME,
+        fileName: CONTACT_US_FILENAME,
         directoryName: CONTACT_US_DIRECTORY_NAME,
       })
       expect(mockFooterYmlService.read).toHaveBeenCalledWith(reqDetails)
@@ -95,7 +95,7 @@ describe("ContactUs Page Service", () => {
         mockRawContactUsContent
       )
       expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
-        fileName: CONTACT_US_FILE_NAME,
+        fileName: CONTACT_US_FILENAME,
         directoryName: CONTACT_US_DIRECTORY_NAME,
       })
       expect(mockFooterYmlService.read).toHaveBeenCalledWith(reqDetails)
@@ -112,7 +112,7 @@ describe("ContactUs Page Service", () => {
         feedback: updatedFeedback,
       }
       const updateReq = {
-        fileName: CONTACT_US_FILE_NAME,
+        fileName: CONTACT_US_FILENAME,
         content: mockContent,
         frontMatter: mockUpdatedFrontMatter,
         sha: oldSha,
@@ -132,7 +132,7 @@ describe("ContactUs Page Service", () => {
         mockContent
       )
       expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
-        fileName: CONTACT_US_FILE_NAME,
+        fileName: CONTACT_US_FILENAME,
         directoryName: CONTACT_US_DIRECTORY_NAME,
         fileContent: mockRawContactUsContent,
         sha: oldSha,
@@ -149,7 +149,7 @@ describe("ContactUs Page Service", () => {
     it("Propagates the correct error on failed update", async () => {
       mockGithubService.update.mockRejectedValueOnce(new NotFoundError(""))
       const updateReq = {
-        fileName: CONTACT_US_FILE_NAME,
+        fileName: CONTACT_US_FILENAME,
         content: mockContent,
         frontMatter: mockFrontMatter,
         sha: oldSha,
@@ -164,7 +164,7 @@ describe("ContactUs Page Service", () => {
         mockContent
       )
       expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
-        fileName: CONTACT_US_FILE_NAME,
+        fileName: CONTACT_US_FILENAME,
         directoryName: CONTACT_US_DIRECTORY_NAME,
         fileContent: mockRawContactUsContent,
         sha: oldSha,

--- a/src/services/fileServices/MdPageServices/__tests__/HomepagePageService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/HomepagePageService.spec.js
@@ -3,13 +3,12 @@ const {
   homepageSha: mockHomepageSha,
   rawHomepageContent: mockRawHomepageContent,
 } = require("@fixtures/homepage")
+const { HOMEPAGE_NAME } = require("@root/constants")
 
 describe("Homepage Page Service", () => {
   const siteName = "test-site"
   const accessToken = "test-token"
   const reqDetails = { siteName, accessToken }
-
-  const HOMEPAGE_FILE_NAME = "index.md"
 
   const mockFrontMatter = mockHomepageContent.frontMatter
   const mockContent = mockHomepageContent.pageBody
@@ -59,7 +58,7 @@ describe("Homepage Page Service", () => {
         mockRawHomepageContent
       )
       expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
-        fileName: HOMEPAGE_FILE_NAME,
+        fileName: HOMEPAGE_NAME,
       })
     })
   })
@@ -70,7 +69,7 @@ describe("Homepage Page Service", () => {
     it("Updating page content works correctly", async () => {
       await expect(
         service.update(reqDetails, {
-          fileName: HOMEPAGE_FILE_NAME,
+          fileName: HOMEPAGE_NAME,
           content: mockContent,
           frontMatter: mockFrontMatter,
           sha: oldSha,
@@ -85,7 +84,7 @@ describe("Homepage Page Service", () => {
         mockContent
       )
       expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
-        fileName: HOMEPAGE_FILE_NAME,
+        fileName: HOMEPAGE_NAME,
         fileContent: mockRawHomepageContent,
         sha: oldSha,
       })

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -7,10 +7,6 @@ import MissingResourceRoomError from "@root/errors/MissingResourceRoomError"
 import { NotFoundError } from "@root/errors/NotFoundError"
 import { MOCK_STAGING_URL_GITHUB } from "@root/fixtures/repoInfo"
 import { MOCK_USER_SESSION_DATA_ONE } from "@root/fixtures/sessionData"
-import { ResourceRoomDirectoryService } from "@root/services/directoryServices/ResourceRoomDirectoryService"
-import { CollectionPageService } from "@root/services/fileServices/MdPageServices/CollectionPageService"
-import { ContactUsPageService } from "@root/services/fileServices/MdPageServices/ContactUsPageService"
-import { UnlinkedPageService } from "@root/services/fileServices/MdPageServices/UnlinkedPageService"
 import {
   CollectionPageName,
   ContactUsPageName,
@@ -20,11 +16,15 @@ import {
   UnlinkedPageName,
 } from "@root/types/pages"
 import { Brand } from "@root/types/util"
+import { ResourceRoomDirectoryService } from "@services/directoryServices/ResourceRoomDirectoryService"
 
+import { CollectionPageService } from "../CollectionPageService"
+import { ContactUsPageService } from "../ContactUsPageService"
 import { HomepagePageService } from "../HomepagePageService"
 import { PageService } from "../PageService"
 import { ResourcePageService } from "../ResourcePageService"
 import { SubcollectionPageService } from "../SubcollectionPageService"
+import { UnlinkedPageService } from "../UnlinkedPageService"
 
 const mockContactUsService = jest.mocked<ContactUsPageService>(({
   read: jest.fn(),

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -72,7 +72,7 @@ const createMockFrontMatter = (mockPageName: string) => ({
     frontMatter: {
       permalink: `/${mockPageName}`,
     },
-    pageBody: {},
+    pageBody: "",
   },
   sha: "",
 })

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -1,6 +1,6 @@
 import { err, ok } from "neverthrow"
 
-import { CONTACT_US_FILENAME, HOMEPAGE_NAME } from "@root/constants"
+import { CONTACT_US_FILENAME, HOMEPAGE_FILENAME } from "@root/constants"
 import { BaseIsomerError } from "@root/errors/BaseError"
 import EmptyStringError from "@root/errors/EmptyStringError"
 import MissingResourceRoomError from "@root/errors/MissingResourceRoomError"
@@ -82,7 +82,7 @@ describe("PageService", () => {
     it("should only accept 'index.md' as the homepage name", async () => {
       // Arrange
       const expected = ok({
-        name: HOMEPAGE_NAME,
+        name: HOMEPAGE_FILENAME,
         kind: "Homepage",
       })
 
@@ -263,7 +263,7 @@ describe("PageService", () => {
       // Act
       const actual = await pageService.parsePageName(
         // NOTE: Extra front slash
-        `/${HOMEPAGE_NAME}`,
+        `/${HOMEPAGE_FILENAME}`,
         MOCK_USER_SESSION_DATA_ONE
       )
 
@@ -599,13 +599,13 @@ describe("PageService", () => {
     it("should call the underlying service and return the `permalink` of the homepage when successful", async () => {
       // Arrange
       const MOCK_PAGE_NAME: HomepageName = {
-        name: Brand.fromString(HOMEPAGE_NAME),
+        name: Brand.fromString(HOMEPAGE_FILENAME),
         kind: "Homepage",
       }
       mockHomepageService.read.mockResolvedValueOnce(
-        createMockFrontMatter(HOMEPAGE_NAME)
+        createMockFrontMatter(HOMEPAGE_FILENAME)
       )
-      const expected = ok(createMockStagingPermalink(HOMEPAGE_NAME))
+      const expected = ok(createMockStagingPermalink(HOMEPAGE_FILENAME))
 
       // Act
       const actual = await pageService.retrieveStagingPermalink(
@@ -624,7 +624,7 @@ describe("PageService", () => {
     it("should call the underlying service and return a `BaseIsomerError` when the homepage could not be fetched", async () => {
       // Arrange
       const MOCK_PAGE_NAME: HomepageName = {
-        name: Brand.fromString(HOMEPAGE_NAME),
+        name: Brand.fromString(HOMEPAGE_FILENAME),
         kind: "Homepage",
       }
       mockHomepageService.read.mockRejectedValueOnce({})
@@ -647,7 +647,7 @@ describe("PageService", () => {
     it("should call the underlying service and return a `BaseIsomerError` when the frontmatter of the homepage has no `permalink`", async () => {
       // Arrange
       const MOCK_PAGE_NAME: HomepageName = {
-        name: Brand.fromString(HOMEPAGE_NAME),
+        name: Brand.fromString(HOMEPAGE_FILENAME),
         kind: "Homepage",
       }
       mockHomepageService.read.mockRejectedValueOnce({})

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -182,7 +182,16 @@ describe("PageService", () => {
 
     it("should return `NotFoundError` if the `layout` of the resource item is not `post`", async () => {
       // Arrange
-      const expected = err(new NotFoundError())
+      const MOCK_RESOURCE_ITEM = `${MOCK_RESOURCE_ROOM_NAME}/${MOCK_RESOURCE_CATEGORY_NAME}/_posts/${MOCK_UNLINKED_PAGE_NAME}`
+      const expected = err(
+        new NotFoundError(
+          `Error when parsing path: 
+          ${MOCK_RESOURCE_ITEM.split("/").slice(
+            0,
+            -1
+          )}, please ensure that the file exists!`
+        )
+      )
       mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
         { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
       )
@@ -199,7 +208,7 @@ describe("PageService", () => {
 
       // Act
       const actual = await pageService.parsePageName(
-        `${MOCK_RESOURCE_ROOM_NAME}/${MOCK_RESOURCE_CATEGORY_NAME}/_posts/${MOCK_UNLINKED_PAGE_NAME}`,
+        MOCK_RESOURCE_ITEM,
         MOCK_USER_SESSION_DATA_ONE
       )
 
@@ -255,7 +264,11 @@ describe("PageService", () => {
 
     it("should parse two level filepaths including 'index.md' to `NotFoundError`", async () => {
       // Arrange
-      const expected = err(new NotFoundError())
+      const expected = err(
+        new NotFoundError(
+          `Error when parsing path: , please ensure that the file exists!`
+        )
+      )
       mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
         { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
       )
@@ -272,9 +285,9 @@ describe("PageService", () => {
       expect(mockResourcePageService.read).toBeCalled()
     })
 
-    it("should parse empty strings into `NotFoundError`", async () => {
+    it("should parse empty strings into `EmptyStringError`", async () => {
       // Arrange
-      const expected = err(new NotFoundError())
+      const expected = err(new EmptyStringError())
       mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
         { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
       )
@@ -292,7 +305,11 @@ describe("PageService", () => {
 
     it("should parse `/` into `NotFoundError`", async () => {
       // Arrange
-      const expected = err(new NotFoundError())
+      const expected = err(
+        new NotFoundError(
+          "Error when parsing path: , please ensure that the file exists!"
+        )
+      )
       mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
         { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
       )

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -390,7 +390,7 @@ describe("PageService", () => {
   })
 
   describe("extractPathInfo", () => {
-    it("should return a `PathInfo` with a valid path when the string provided is a valid filepath", async () => {
+    it("should return a `PathInfo` with a valid path when the string provided is a valid filepath", () => {
       // Arrange
       const expected = ok({
         name: MOCK_UNLINKED_PAGE_NAME,

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -1,0 +1,940 @@
+import { err, ok } from "neverthrow"
+
+import { CONTACT_US_FILENAME, HOMEPAGE_NAME } from "@root/constants"
+import { BaseIsomerError } from "@root/errors/BaseError"
+import EmptyStringError from "@root/errors/EmptyStringError"
+import MissingResourceRoomError from "@root/errors/MissingResourceRoomError"
+import { NotFoundError } from "@root/errors/NotFoundError"
+import { MOCK_STAGING_URL_GITHUB } from "@root/fixtures/repoInfo"
+import { MOCK_USER_SESSION_DATA_ONE } from "@root/fixtures/sessionData"
+import { ResourceRoomDirectoryService } from "@root/services/directoryServices/ResourceRoomDirectoryService"
+import { CollectionPageService } from "@root/services/fileServices/MdPageServices/CollectionPageService"
+import { ContactUsPageService } from "@root/services/fileServices/MdPageServices/ContactUsPageService"
+import { UnlinkedPageService } from "@root/services/fileServices/MdPageServices/UnlinkedPageService"
+import {
+  CollectionPageName,
+  ContactUsPageName,
+  HomepageName,
+  ResourceCategoryPageName,
+  SubcollectionPageName,
+  UnlinkedPageName,
+} from "@root/types/pages"
+import { Brand } from "@root/types/util"
+
+import { HomepagePageService } from "../HomepagePageService"
+import { PageService } from "../PageService"
+import { ResourcePageService } from "../ResourcePageService"
+import { SubcollectionPageService } from "../SubcollectionPageService"
+
+const mockContactUsService = jest.mocked<ContactUsPageService>(({
+  read: jest.fn(),
+} as unknown) as ContactUsPageService)
+const mockCollectionPageService = jest.mocked<CollectionPageService>(({
+  read: jest.fn(),
+} as unknown) as CollectionPageService)
+const mockSubcollectionPageService = jest.mocked<SubcollectionPageService>(({
+  read: jest.fn(),
+} as unknown) as SubcollectionPageService)
+const mockHomepageService = jest.mocked<HomepagePageService>(({
+  read: jest.fn(),
+} as unknown) as HomepagePageService)
+const mockResourcePageService = jest.mocked<ResourcePageService>(({
+  read: jest.fn(),
+} as unknown) as ResourcePageService)
+const mockUnlinkedPageService = jest.mocked<UnlinkedPageService>(({
+  read: jest.fn(),
+} as unknown) as UnlinkedPageService)
+const mockResourceRoomDirectoryService = jest.mocked<ResourceRoomDirectoryService>(
+  ({
+    getResourceRoomDirectoryName: jest.fn(),
+  } as unknown) as ResourceRoomDirectoryService
+)
+const pageService = new PageService({
+  contactUsService: mockContactUsService,
+  collectionPageService: mockCollectionPageService,
+  subCollectionPageService: mockSubcollectionPageService,
+  homepageService: mockHomepageService,
+  resourcePageService: mockResourcePageService,
+  unlinkedPageService: mockUnlinkedPageService,
+  resourceRoomDirectoryService: mockResourceRoomDirectoryService,
+})
+
+const MOCK_RESOURCE_ROOM_NAME = "resources"
+const MOCK_UNLINKED_PAGE_NAME = "some_page"
+const MOCK_COLLECTION_NAME = "a_collection"
+const MOCK_SUBCOLLECTION_NAME = "submarine"
+const MOCK_RESOURCE_CATEGORY_NAME = "meow"
+const createMockStagingPermalink = (mockPageName: string) =>
+  `${MOCK_STAGING_URL_GITHUB}/${mockPageName}`
+const createMockFrontMatter = (mockPageName: string) => ({
+  fileName: MOCK_UNLINKED_PAGE_NAME,
+  content: {
+    frontMatter: {
+      permalink: `/${mockPageName}`,
+    },
+    pageBody: {},
+  },
+  sha: "",
+})
+
+describe("PageService", () => {
+  describe("parsePageName", () => {
+    it("should only accept 'index.md' as the homepage name", async () => {
+      // Arrange
+      const expected = ok({
+        name: HOMEPAGE_NAME,
+        kind: "Homepage",
+      })
+
+      // Act
+      const actual = await pageService.parsePageName(
+        "index.md",
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+    })
+
+    it("should accept 'pages/contact-us.md' as the contact-us page name", async () => {
+      // Arrange
+      const expected = ok({
+        name: CONTACT_US_FILENAME,
+        kind: "ContactUsPage",
+      })
+
+      // Act
+      const actual = await pageService.parsePageName(
+        "pages/contact-us.md",
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+    })
+
+    it('should parse "contact-us.md" into an error', async () => {
+      // Arrange
+      const expected = err(new NotFoundError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+
+      // Act
+      const actual = await pageService.parsePageName(
+        CONTACT_US_FILENAME,
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+    })
+
+    it('should parse "pages/<page_name>" into an unlinked page name', async () => {
+      // Arrange
+      const expected = ok({
+        name: MOCK_UNLINKED_PAGE_NAME,
+        kind: "UnlinkedPage",
+      })
+
+      // Act
+      const actual = await pageService.parsePageName(
+        `pages/${MOCK_UNLINKED_PAGE_NAME}`,
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+    })
+
+    it("should parse filepaths like `<resource_room_name>/<resource_category_name>/_posts/<page_name>` into a resource category page name if the layout is `post`", async () => {
+      // Arrange
+      const expected = ok({
+        name: MOCK_UNLINKED_PAGE_NAME,
+        resourceRoom: MOCK_RESOURCE_ROOM_NAME,
+        resourceCategory: MOCK_RESOURCE_CATEGORY_NAME,
+        kind: "ResourceCategoryPage",
+      })
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+      mockResourcePageService.read.mockResolvedValueOnce({
+        content: {
+          frontMatter: {
+            layout: "post",
+          },
+          pageBody: "",
+        },
+        fileName: MOCK_UNLINKED_PAGE_NAME,
+        sha: "sha",
+      })
+
+      // Act
+      const actual = await pageService.parsePageName(
+        `${MOCK_RESOURCE_ROOM_NAME}/${MOCK_RESOURCE_CATEGORY_NAME}/_posts/${MOCK_UNLINKED_PAGE_NAME}`,
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+
+    it("should return `NotFoundError` if the `layout` of the resource item is not `post`", async () => {
+      // Arrange
+      const expected = err(new NotFoundError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+      mockResourcePageService.read.mockResolvedValueOnce({
+        content: {
+          frontMatter: {
+            layout: "file",
+          },
+          pageBody: "",
+        },
+        fileName: MOCK_UNLINKED_PAGE_NAME,
+        sha: "sha",
+      })
+
+      // Act
+      const actual = await pageService.parsePageName(
+        `${MOCK_RESOURCE_ROOM_NAME}/${MOCK_RESOURCE_CATEGORY_NAME}/_posts/${MOCK_UNLINKED_PAGE_NAME}`,
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+
+    it("should parse 2 level filepaths without 'index.md' into a collection name if there is no resource room name", async () => {
+      // Arrange
+      const expected = ok({
+        name: MOCK_UNLINKED_PAGE_NAME,
+        collection: MOCK_COLLECTION_NAME,
+        kind: "CollectionPage",
+      })
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockRejectedValueOnce(
+        null
+      )
+
+      // Act
+      const actual = await pageService.parsePageName(
+        `${MOCK_COLLECTION_NAME}/${MOCK_UNLINKED_PAGE_NAME}`,
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+
+    it("should parse 3 level filepaths without 'index.md' into a sub-collection name if there is no resource room name", async () => {
+      // Arrange
+      const expected = ok({
+        name: MOCK_UNLINKED_PAGE_NAME,
+        collection: MOCK_COLLECTION_NAME,
+        subcollection: MOCK_SUBCOLLECTION_NAME,
+        kind: "SubcollectionPage",
+      })
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockRejectedValueOnce(
+        null
+      )
+
+      // Act
+      const actual = await pageService.parsePageName(
+        `${MOCK_COLLECTION_NAME}/${MOCK_SUBCOLLECTION_NAME}/${MOCK_UNLINKED_PAGE_NAME}`,
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+
+    it("should parse two level filepaths including 'index.md' to `NotFoundError`", async () => {
+      // Arrange
+      const expected = err(new NotFoundError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+
+      // Act
+      const actual = await pageService.parsePageName(
+        // NOTE: Extra front slash
+        `/${HOMEPAGE_NAME}`,
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+
+    it("should parse empty strings into `NotFoundError`", async () => {
+      // Arrange
+      const expected = err(new NotFoundError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+
+      // Act
+      const actual = await pageService.parsePageName(
+        "",
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+
+    it("should parse `/` into `NotFoundError`", async () => {
+      // Arrange
+      const expected = err(new NotFoundError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+
+      // Act
+      const actual = await pageService.parsePageName(
+        "/",
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+
+    it("should parse single level filepaths that are not 'index.md' into `NotFoundError`", async () => {
+      // Arrange
+      const expected = err(new NotFoundError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+
+      // Act
+      const actual = await pageService.parsePageName(
+        "gibberish",
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+  })
+
+  describe("extractResourceRoomName", () => {
+    it("should call the underlying service and return a result if the promise resolves", async () => {
+      // Arrange
+      const expected = ok({
+        name: MOCK_RESOURCE_ROOM_NAME,
+        kind: "ResourceRoomName",
+      })
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+
+      // Act
+      const actual = await pageService.extractResourceRoomName(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(
+        mockResourceRoomDirectoryService.getResourceRoomDirectoryName
+      ).toBeCalledWith(MOCK_USER_SESSION_DATA_ONE)
+    })
+
+    it("should call the underlying service and return a `MissingResourceRoomError` if the promise resolves to `null`", async () => {
+      // Arrange
+      const expected = err(new MissingResourceRoomError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: null }
+      )
+
+      // Act
+      const actual = await pageService.extractResourceRoomName(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(
+        mockResourceRoomDirectoryService.getResourceRoomDirectoryName
+      ).toBeCalledWith(MOCK_USER_SESSION_DATA_ONE)
+    })
+
+    it("should call the underlying service and return a `MissingResourceRoomError` if the promise rejects", async () => {
+      // Arrange
+      const expected = err(new MissingResourceRoomError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockRejectedValueOnce(
+        null
+      )
+
+      // Act
+      const actual = await pageService.extractResourceRoomName(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(
+        mockResourceRoomDirectoryService.getResourceRoomDirectoryName
+      ).toBeCalledWith(MOCK_USER_SESSION_DATA_ONE)
+    })
+  })
+
+  describe("extractPathInfo", () => {
+    it("should return a `PathInfo` with a valid path when the string provided is a valid filepath", async () => {
+      // Arrange
+      const expected = ok({
+        name: MOCK_UNLINKED_PAGE_NAME,
+        path: ok([MOCK_RESOURCE_ROOM_NAME, MOCK_RESOURCE_CATEGORY_NAME]),
+      })
+
+      // Act
+      const actual = pageService.extractPathInfo(
+        `${MOCK_RESOURCE_ROOM_NAME}/${MOCK_RESOURCE_CATEGORY_NAME}/${MOCK_UNLINKED_PAGE_NAME}`
+      )
+
+      // Assert
+      expect(actual).toStrictEqual(expected)
+    })
+
+    it("should return a `PathInfo` with an `err` path when the string provided does not contain `/`", () => {
+      // Arrange
+      const expected = ok({
+        name: MOCK_UNLINKED_PAGE_NAME,
+        path: err([]),
+      })
+
+      // Act
+      const actual = pageService.extractPathInfo(`${MOCK_UNLINKED_PAGE_NAME}`)
+
+      // Assert
+      expect(actual).toStrictEqual(expected)
+    })
+
+    it("should return a `PathInfo` with an empty string as the name when the `/` terminates the string", () => {
+      // Arrange
+      const expected = ok({
+        name: "",
+        path: ok([MOCK_RESOURCE_ROOM_NAME]),
+      })
+
+      // Act
+      const actual = pageService.extractPathInfo(`${MOCK_RESOURCE_ROOM_NAME}/`)
+
+      // Assert
+      expect(actual).toStrictEqual(expected)
+    })
+
+    it("should return a `EmptyStringError` when an empty string is provided as input", () => {
+      // Arrange
+      const expected = err(new EmptyStringError())
+
+      // Act
+      const actual = pageService.extractPathInfo("")
+
+      // Assert
+      expect(actual).toEqual(expected)
+    })
+  })
+  describe("retrieveStagingPermalink", () => {
+    it("should call the underlying service and return the `permalink` of the unlinked page when successful", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: UnlinkedPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "UnlinkedPage",
+      }
+      mockUnlinkedPageService.read.mockResolvedValueOnce(
+        createMockFrontMatter(MOCK_UNLINKED_PAGE_NAME)
+      )
+      const expected = ok(createMockStagingPermalink(MOCK_UNLINKED_PAGE_NAME))
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockUnlinkedPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the unlinked page could not be fetched", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: UnlinkedPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "UnlinkedPage",
+      }
+      mockUnlinkedPageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockUnlinkedPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the frontmatter of the unlinked page has no `permalink`", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: UnlinkedPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "UnlinkedPage",
+      }
+      mockUnlinkedPageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockUnlinkedPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+        }
+      )
+    })
+    it("should call the underlying service and return the `permalink` of the contact us page when successful", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: ContactUsPageName = {
+        name: Brand.fromString(CONTACT_US_FILENAME),
+        kind: "ContactUsPage",
+      }
+      mockContactUsService.read.mockResolvedValueOnce(
+        createMockFrontMatter(CONTACT_US_FILENAME)
+      )
+      const expected = ok(createMockStagingPermalink(CONTACT_US_FILENAME))
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockContactUsService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the contact us page could not be fetched", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: ContactUsPageName = {
+        name: Brand.fromString(CONTACT_US_FILENAME),
+        kind: "ContactUsPage",
+      }
+      mockContactUsService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockContactUsService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the frontmatter of the contact-us page has no `permalink`", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: ContactUsPageName = {
+        name: Brand.fromString(CONTACT_US_FILENAME),
+        kind: "ContactUsPage",
+      }
+      mockContactUsService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockContactUsService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+    })
+
+    it("should call the underlying service and return the `permalink` of the homepage when successful", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: HomepageName = {
+        name: Brand.fromString(HOMEPAGE_NAME),
+        kind: "Homepage",
+      }
+      mockHomepageService.read.mockResolvedValueOnce(
+        createMockFrontMatter(HOMEPAGE_NAME)
+      )
+      const expected = ok(createMockStagingPermalink(HOMEPAGE_NAME))
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockHomepageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the homepage could not be fetched", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: HomepageName = {
+        name: Brand.fromString(HOMEPAGE_NAME),
+        kind: "Homepage",
+      }
+      mockHomepageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockHomepageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the frontmatter of the homepage has no `permalink`", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: HomepageName = {
+        name: Brand.fromString(HOMEPAGE_NAME),
+        kind: "Homepage",
+      }
+      mockHomepageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockHomepageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+    })
+
+    it("should call the underlying service and return the `permalink` of the resource category page when successful", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: ResourceCategoryPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "ResourceCategoryPage",
+        resourceCategory: MOCK_RESOURCE_CATEGORY_NAME,
+        resourceRoom: Brand.fromString(MOCK_RESOURCE_ROOM_NAME),
+      }
+      mockResourcePageService.read.mockResolvedValueOnce(
+        createMockFrontMatter(MOCK_UNLINKED_PAGE_NAME)
+      )
+      const expected = ok(createMockStagingPermalink(MOCK_UNLINKED_PAGE_NAME))
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          resourceCategoryName: MOCK_PAGE_NAME.resourceCategory,
+          resourceRoomName: MOCK_PAGE_NAME.resourceRoom,
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the resource category page could not be fetched", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: ResourceCategoryPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "ResourceCategoryPage",
+        resourceCategory: MOCK_RESOURCE_CATEGORY_NAME,
+        resourceRoom: Brand.fromString(MOCK_RESOURCE_ROOM_NAME),
+      }
+      mockResourcePageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          resourceCategoryName: MOCK_PAGE_NAME.resourceCategory,
+          resourceRoomName: MOCK_PAGE_NAME.resourceRoom,
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the frontmatter of the resource category page has no `permalink`", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: ResourceCategoryPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "ResourceCategoryPage",
+        resourceCategory: MOCK_RESOURCE_CATEGORY_NAME,
+        resourceRoom: Brand.fromString(MOCK_RESOURCE_ROOM_NAME),
+      }
+      mockResourcePageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          resourceCategoryName: MOCK_PAGE_NAME.resourceCategory,
+          resourceRoomName: MOCK_PAGE_NAME.resourceRoom,
+        }
+      )
+    })
+
+    it("should call the underlying service and return the `permalink` of the subcollection page when successful", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: SubcollectionPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "SubcollectionPage",
+        collection: MOCK_COLLECTION_NAME,
+        subcollection: Brand.fromString(MOCK_SUBCOLLECTION_NAME),
+      }
+      mockSubcollectionPageService.read.mockResolvedValueOnce(
+        createMockFrontMatter(MOCK_UNLINKED_PAGE_NAME)
+      )
+      const expected = ok(createMockStagingPermalink(MOCK_UNLINKED_PAGE_NAME))
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockSubcollectionPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          collectionName: MOCK_PAGE_NAME.collection.slice(1),
+          subcollectionName: MOCK_PAGE_NAME.subcollection,
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the subcollection page could not be fetched", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: SubcollectionPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "SubcollectionPage",
+        collection: MOCK_COLLECTION_NAME,
+        subcollection: Brand.fromString(MOCK_SUBCOLLECTION_NAME),
+      }
+      mockSubcollectionPageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockSubcollectionPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          collectionName: MOCK_PAGE_NAME.collection.slice(1),
+          subcollectionName: MOCK_PAGE_NAME.subcollection,
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the frontmatter of the subcollection page has no `permalink`", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: SubcollectionPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "SubcollectionPage",
+        collection: MOCK_COLLECTION_NAME,
+        subcollection: Brand.fromString(MOCK_SUBCOLLECTION_NAME),
+      }
+      mockSubcollectionPageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockSubcollectionPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          collectionName: MOCK_PAGE_NAME.collection.slice(1),
+          subcollectionName: MOCK_PAGE_NAME.subcollection,
+        }
+      )
+    })
+
+    it("should call the underlying service and return the `permalink` of the collection page when successful", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: CollectionPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "CollectionPage",
+        collection: MOCK_COLLECTION_NAME,
+      }
+      mockCollectionPageService.read.mockResolvedValueOnce(
+        createMockFrontMatter(MOCK_UNLINKED_PAGE_NAME)
+      )
+      const expected = ok(createMockStagingPermalink(MOCK_UNLINKED_PAGE_NAME))
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockCollectionPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          collectionName: MOCK_PAGE_NAME.collection.slice(1),
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the collection page could not be fetched", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: CollectionPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "CollectionPage",
+        collection: MOCK_COLLECTION_NAME,
+      }
+      mockCollectionPageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockCollectionPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          collectionName: MOCK_PAGE_NAME.collection.slice(1),
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the frontmatter of the collection page has no `permalink`", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: CollectionPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "CollectionPage",
+        collection: MOCK_COLLECTION_NAME,
+      }
+      mockCollectionPageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockCollectionPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          collectionName: MOCK_PAGE_NAME.collection.slice(1),
+        }
+      )
+    })
+  })
+})

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -185,8 +185,7 @@ describe("PageService", () => {
       const MOCK_RESOURCE_ITEM = `${MOCK_RESOURCE_ROOM_NAME}/${MOCK_RESOURCE_CATEGORY_NAME}/_posts/${MOCK_UNLINKED_PAGE_NAME}`
       const expected = err(
         new NotFoundError(
-          `Error when parsing path: 
-          ${MOCK_RESOURCE_ITEM.split("/").slice(
+          `Error when parsing path: ${MOCK_RESOURCE_ITEM.split("/").slice(
             0,
             -1
           )}, please ensure that the file exists!`

--- a/src/services/identity/SitesService.ts
+++ b/src/services/identity/SitesService.ts
@@ -434,7 +434,6 @@ class SitesService {
       if (this.isGitHubCommitData(possibleCommit)) {
         return okAsync(possibleCommit)
       }
-      console.log("=======", possibleCommit)
       return errAsync(
         new UnprocessableError("Unable to retrieve GitHub commit info")
       )

--- a/src/services/identity/__tests__/CollaboratorsService.spec.ts
+++ b/src/services/identity/__tests__/CollaboratorsService.spec.ts
@@ -1,3 +1,4 @@
+import { errAsync, okAsync } from "neverthrow"
 import { ModelStatic } from "sequelize"
 
 import { ForbiddenError } from "@errors/ForbiddenError"
@@ -286,7 +287,9 @@ describe("CollaboratorsService", () => {
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Admin
       ) as unknown) as () => Promise<CollaboratorRoles | null>
-      mockSitesService.getBySiteName.mockResolvedValue({ id: mockSiteId })
+      mockSitesService.getBySiteName.mockReturnValue(
+        okAsync({ id: mockSiteId })
+      )
       mockUsersService.findByEmail.mockResolvedValue({ id: mockUserId })
       mockSiteMemberRepo.findOne.mockResolvedValue(null)
       mockSiteMemberRepo.create.mockResolvedValue(mockSiteMemberRecord)
@@ -369,7 +372,7 @@ describe("CollaboratorsService", () => {
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Admin
       ) as unknown) as () => Promise<CollaboratorRoles | null>
-      mockSitesService.getBySiteName.mockResolvedValue(null)
+      mockSitesService.getBySiteName.mockResolvedValue(errAsync(null))
       mockUsersService.findByEmail.mockResolvedValue({ id: mockUserId })
       mockSiteMemberRepo.findOne.mockResolvedValue(null)
       mockSiteMemberRepo.create.mockResolvedValue(mockSiteMemberRecord)
@@ -397,7 +400,9 @@ describe("CollaboratorsService", () => {
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Admin
       ) as unknown) as () => Promise<CollaboratorRoles | null>
-      mockSitesService.getBySiteName.mockResolvedValue({ id: mockSiteId })
+      mockSitesService.getBySiteName.mockResolvedValue(
+        okAsync({ id: mockSiteId })
+      )
       mockUsersService.findByEmail.mockResolvedValue(null)
       mockSiteMemberRepo.findOne.mockResolvedValue(null)
       mockSiteMemberRepo.create.mockResolvedValue(mockSiteMemberRecord)
@@ -425,7 +430,9 @@ describe("CollaboratorsService", () => {
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Admin
       ) as unknown) as () => Promise<CollaboratorRoles | null>
-      mockSitesService.getBySiteName.mockResolvedValue({ id: mockSiteId })
+      mockSitesService.getBySiteName.mockResolvedValue(
+        okAsync({ id: mockSiteId })
+      )
       mockUsersService.findByEmail.mockResolvedValue({ id: mockUserId })
       mockSiteMemberRepo.findOne.mockResolvedValue(mockSiteMemberRecord)
       mockSiteMemberRepo.create.mockResolvedValue(mockSiteMemberRecord)
@@ -453,7 +460,9 @@ describe("CollaboratorsService", () => {
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Contributor
       ) as unknown) as () => Promise<CollaboratorRoles | null>
-      mockSitesService.getBySiteName.mockResolvedValue({ id: mockSiteId })
+      mockSitesService.getBySiteName.mockResolvedValue(
+        okAsync({ id: mockSiteId })
+      )
       mockUsersService.findByEmail.mockResolvedValue({ id: mockUserId })
       mockSiteMemberRepo.findOne.mockResolvedValue(null)
       mockSiteMemberRepo.create.mockResolvedValue(mockSiteMemberRecord)

--- a/src/services/identity/__tests__/SitesService.spec.ts
+++ b/src/services/identity/__tests__/SitesService.spec.ts
@@ -129,10 +129,7 @@ describe("SitesService", () => {
         staging: MOCK_STAGING_URL_CONFIGYML,
         prod: MOCK_PRODUCTION_URL_CONFIGYML,
       }
-      const initial: SiteUrls = {
-        staging: "",
-        prod: "",
-      }
+
       const configYmlResponse = {
         content: {
           staging: MOCK_STAGING_URL_CONFIGYML,
@@ -144,7 +141,7 @@ describe("SitesService", () => {
 
       // Act
       const actual = await SitesService.insertUrlsFromConfigYml(
-        initial,
+        {},
         mockSessionDataEmailUserWithSite
       )
 
@@ -160,7 +157,6 @@ describe("SitesService", () => {
         prod: MOCK_PRODUCTION_URL_DB,
       }
       const initial: SiteUrls = {
-        staging: "",
         prod: MOCK_PRODUCTION_URL_DB,
       }
       const configYmlResponse = {
@@ -191,7 +187,6 @@ describe("SitesService", () => {
       }
       const initial: SiteUrls = {
         staging: MOCK_STAGING_URL_DB,
-        prod: "",
       }
       const configYmlResponse = {
         content: {
@@ -238,13 +233,9 @@ describe("SitesService", () => {
     it("should not insert staging URL if it does not exist in config.yml", async () => {
       // Arrange
       const expected: SiteUrls = {
-        staging: "",
         prod: MOCK_PRODUCTION_URL_CONFIGYML,
       }
-      const initial: SiteUrls = {
-        staging: "",
-        prod: "",
-      }
+
       const configYmlResponse = {
         content: {
           prod: MOCK_PRODUCTION_URL_CONFIGYML,
@@ -255,7 +246,7 @@ describe("SitesService", () => {
 
       // Act
       const actual = await SitesService.insertUrlsFromConfigYml(
-        initial,
+        {},
         mockSessionDataEmailUserWithSite
       )
 
@@ -268,11 +259,6 @@ describe("SitesService", () => {
       // Arrange
       const expected: SiteUrls = {
         staging: MOCK_STAGING_URL_CONFIGYML,
-        prod: "",
-      }
-      const initial: SiteUrls = {
-        staging: "",
-        prod: "",
       }
       const configYmlResponse = {
         content: {
@@ -284,7 +270,7 @@ describe("SitesService", () => {
 
       // Act
       const actual = await SitesService.insertUrlsFromConfigYml(
-        initial,
+        {},
         mockSessionDataEmailUserWithSite
       )
 
@@ -295,14 +281,8 @@ describe("SitesService", () => {
 
     it("should not insert URLs if config.yml does not contain both staging and production URLs", async () => {
       // Arrange
-      const expected: SiteUrls = {
-        staging: "",
-        prod: "",
-      }
-      const initial: SiteUrls = {
-        staging: "",
-        prod: "",
-      }
+      const expected: SiteUrls = {}
+      const initial: SiteUrls = {}
       const configYmlResponse = {
         content: {},
         sha: "abc",
@@ -328,10 +308,7 @@ describe("SitesService", () => {
         staging: MOCK_STAGING_URL_GITHUB,
         prod: MOCK_PRODUCTION_URL_GITHUB,
       }
-      const initial: SiteUrls = {
-        staging: "",
-        prod: "",
-      }
+      const initial: SiteUrls = {}
       MockGithubService.getRepoInfo.mockResolvedValueOnce(repoInfo)
 
       // Act
@@ -352,7 +329,6 @@ describe("SitesService", () => {
         prod: MOCK_PRODUCTION_URL_DB,
       }
       const initial: SiteUrls = {
-        staging: "",
         prod: MOCK_PRODUCTION_URL_DB,
       }
       MockGithubService.getRepoInfo.mockResolvedValueOnce(repoInfo)
@@ -376,7 +352,6 @@ describe("SitesService", () => {
       }
       const initial: SiteUrls = {
         staging: MOCK_STAGING_URL_DB,
-        prod: "",
       }
       MockGithubService.getRepoInfo.mockResolvedValueOnce(repoInfo)
 
@@ -416,13 +391,9 @@ describe("SitesService", () => {
     it("should not insert staging URL if it does not exist in the description", async () => {
       // Arrange
       const expected: SiteUrls = {
-        staging: "",
         prod: MOCK_PRODUCTION_URL_CONFIGYML,
       }
-      const initial: SiteUrls = {
-        staging: "",
-        prod: "",
-      }
+      const initial: SiteUrls = {}
       const repoInfoWithoutStagingUrl = {
         description: `Production: ${MOCK_PRODUCTION_URL_CONFIGYML}`,
       }
@@ -445,12 +416,8 @@ describe("SitesService", () => {
       // Arrange
       const expected: SiteUrls = {
         staging: MOCK_STAGING_URL_CONFIGYML,
-        prod: "",
       }
-      const initial: SiteUrls = {
-        staging: "",
-        prod: "",
-      }
+      const initial: SiteUrls = {}
       const repoInfoWithoutProductionUrl = {
         description: `Staging: ${MOCK_STAGING_URL_CONFIGYML}`,
       }
@@ -471,14 +438,8 @@ describe("SitesService", () => {
 
     it("should not insert URLs if description is empty", async () => {
       // Arrange
-      const expected: SiteUrls = {
-        staging: "",
-        prod: "",
-      }
-      const initial: SiteUrls = {
-        staging: "",
-        prod: "",
-      }
+      const expected: SiteUrls = {}
+      const initial: SiteUrls = {}
       const repoInfoWithoutDescription = {
         description: "",
       }
@@ -499,14 +460,8 @@ describe("SitesService", () => {
 
     it("should not insert URLs if description is some gibberish", async () => {
       // Arrange
-      const expected: SiteUrls = {
-        staging: "",
-        prod: "",
-      }
-      const initial: SiteUrls = {
-        staging: "",
-        prod: "",
-      }
+      const expected: SiteUrls = {}
+      const initial: SiteUrls = {}
       const repoInfoWithGibberishDescription = {
         description: "abcdefghijklmnopqrstuvwxyz-staging and-prod",
       }
@@ -783,18 +738,12 @@ describe("SitesService", () => {
       stagingUrl: MOCK_STAGING_URL_DB,
       productionUrl: MOCK_PRODUCTION_URL_DB,
     }
-    const emptyDeployment: Partial<Deployment> = {
-      stagingUrl: "",
-      productionUrl: "",
-    }
+    const emptyDeployment: Partial<Deployment> = {}
     const configYmlData: Partial<ConfigYmlData> = {
       staging: MOCK_STAGING_URL_CONFIGYML,
       prod: MOCK_PRODUCTION_URL_CONFIGYML,
     }
-    const emptyConfigYmlData: Partial<ConfigYmlData> = {
-      staging: "",
-      prod: "",
-    }
+    const emptyConfigYmlData: Partial<ConfigYmlData> = {}
     const gitHubUrls = {
       staging: MOCK_STAGING_URL_GITHUB,
       prod: MOCK_PRODUCTION_URL_GITHUB,

--- a/src/services/identity/__tests__/SitesService.spec.ts
+++ b/src/services/identity/__tests__/SitesService.spec.ts
@@ -1,3 +1,4 @@
+import { err, errAsync, Ok, ok, okAsync } from "neverthrow"
 import { ModelStatic } from "sequelize"
 
 import { config } from "@config/config"
@@ -36,6 +37,7 @@ import {
   mockSessionDataEmailUserWithSite,
 } from "@fixtures/sessionData"
 import mockAxios from "@mocks/axios"
+import MissingSiteError from "@root/errors/MissingSiteError"
 import { NotFoundError } from "@root/errors/NotFoundError"
 import RequestNotFoundError from "@root/errors/RequestNotFoundError"
 import { UnprocessableError } from "@root/errors/UnprocessableError"
@@ -125,10 +127,10 @@ describe("SitesService", () => {
   describe("insertUrlsFromConfigYml", () => {
     it("should insert URLs if both are not already present", async () => {
       // Arrange
-      const expected: SiteUrls = {
+      const expected = ok({
         staging: MOCK_STAGING_URL_CONFIGYML,
         prod: MOCK_PRODUCTION_URL_CONFIGYML,
-      }
+      })
 
       const configYmlResponse = {
         content: {
@@ -152,10 +154,10 @@ describe("SitesService", () => {
 
     it("should only insert staging URL if it is not already present", async () => {
       // Arrange
-      const expected: SiteUrls = {
+      const expected = ok({
         staging: MOCK_STAGING_URL_CONFIGYML,
         prod: MOCK_PRODUCTION_URL_DB,
-      }
+      })
       const initial: SiteUrls = {
         prod: MOCK_PRODUCTION_URL_DB,
       }
@@ -181,10 +183,10 @@ describe("SitesService", () => {
 
     it("should only insert production URL if it is not already present", async () => {
       // Arrange
-      const expected: SiteUrls = {
+      const expected = ok({
         staging: MOCK_STAGING_URL_DB,
         prod: MOCK_PRODUCTION_URL_CONFIGYML,
-      }
+      })
       const initial: SiteUrls = {
         staging: MOCK_STAGING_URL_DB,
       }
@@ -210,10 +212,10 @@ describe("SitesService", () => {
 
     it("should not insert URLs if both are already present", async () => {
       // Arrange
-      const expected: SiteUrls = {
+      const expected = ok({
         staging: MOCK_STAGING_URL_DB,
         prod: MOCK_PRODUCTION_URL_DB,
-      }
+      })
       const initial: SiteUrls = {
         staging: MOCK_STAGING_URL_DB,
         prod: MOCK_PRODUCTION_URL_DB,
@@ -232,9 +234,9 @@ describe("SitesService", () => {
 
     it("should not insert staging URL if it does not exist in config.yml", async () => {
       // Arrange
-      const expected: SiteUrls = {
+      const expected = ok({
         prod: MOCK_PRODUCTION_URL_CONFIGYML,
-      }
+      })
 
       const configYmlResponse = {
         content: {
@@ -257,9 +259,9 @@ describe("SitesService", () => {
 
     it("should not insert production URL if it does not exist in config.yml", async () => {
       // Arrange
-      const expected: SiteUrls = {
+      const expected = ok({
         staging: MOCK_STAGING_URL_CONFIGYML,
-      }
+      })
       const configYmlResponse = {
         content: {
           staging: MOCK_STAGING_URL_CONFIGYML,
@@ -281,7 +283,7 @@ describe("SitesService", () => {
 
     it("should not insert URLs if config.yml does not contain both staging and production URLs", async () => {
       // Arrange
-      const expected: SiteUrls = {}
+      const expected = ok({})
       const initial: SiteUrls = {}
       const configYmlResponse = {
         content: {},
@@ -304,10 +306,10 @@ describe("SitesService", () => {
   describe("insertUrlsFromGitHubDescription", () => {
     it("should insert URLs if both are not already present", async () => {
       // Arrange
-      const expected: SiteUrls = {
+      const expected = ok({
         staging: MOCK_STAGING_URL_GITHUB,
         prod: MOCK_PRODUCTION_URL_GITHUB,
-      }
+      })
       const initial: SiteUrls = {}
       MockGithubService.getRepoInfo.mockResolvedValueOnce(repoInfo)
 
@@ -324,10 +326,10 @@ describe("SitesService", () => {
 
     it("should only insert staging URL if it is not already present", async () => {
       // Arrange
-      const expected: SiteUrls = {
+      const expected = ok({
         staging: MOCK_STAGING_URL_GITHUB,
         prod: MOCK_PRODUCTION_URL_DB,
-      }
+      })
       const initial: SiteUrls = {
         prod: MOCK_PRODUCTION_URL_DB,
       }
@@ -346,10 +348,10 @@ describe("SitesService", () => {
 
     it("should only insert production URL if it is not already present", async () => {
       // Arrange
-      const expected: SiteUrls = {
+      const expected = ok({
         staging: MOCK_STAGING_URL_DB,
         prod: MOCK_PRODUCTION_URL_GITHUB,
-      }
+      })
       const initial: SiteUrls = {
         staging: MOCK_STAGING_URL_DB,
       }
@@ -368,10 +370,10 @@ describe("SitesService", () => {
 
     it("should not insert URLs if both are already present", async () => {
       // Arrange
-      const expected: SiteUrls = {
+      const expected = ok({
         staging: MOCK_STAGING_URL_DB,
         prod: MOCK_PRODUCTION_URL_DB,
-      }
+      })
       const initial: SiteUrls = {
         staging: MOCK_STAGING_URL_DB,
         prod: MOCK_PRODUCTION_URL_DB,
@@ -390,9 +392,9 @@ describe("SitesService", () => {
 
     it("should not insert staging URL if it does not exist in the description", async () => {
       // Arrange
-      const expected: SiteUrls = {
+      const expected = ok({
         prod: MOCK_PRODUCTION_URL_CONFIGYML,
-      }
+      })
       const initial: SiteUrls = {}
       const repoInfoWithoutStagingUrl = {
         description: `Production: ${MOCK_PRODUCTION_URL_CONFIGYML}`,
@@ -414,9 +416,9 @@ describe("SitesService", () => {
 
     it("should not insert production URL if it does not exist in the description", async () => {
       // Arrange
-      const expected: SiteUrls = {
+      const expected = ok({
         staging: MOCK_STAGING_URL_CONFIGYML,
-      }
+      })
       const initial: SiteUrls = {}
       const repoInfoWithoutProductionUrl = {
         description: `Staging: ${MOCK_STAGING_URL_CONFIGYML}`,
@@ -438,7 +440,7 @@ describe("SitesService", () => {
 
     it("should not insert URLs if description is empty", async () => {
       // Arrange
-      const expected: SiteUrls = {}
+      const expected = ok({})
       const initial: SiteUrls = {}
       const repoInfoWithoutDescription = {
         description: "",
@@ -460,7 +462,7 @@ describe("SitesService", () => {
 
     it("should not insert URLs if description is some gibberish", async () => {
       // Arrange
-      const expected: SiteUrls = {}
+      const expected = ok({})
       const initial: SiteUrls = {}
       const repoInfoWithGibberishDescription = {
         description: "abcdefghijklmnopqrstuvwxyz-staging and-prod",
@@ -484,14 +486,14 @@ describe("SitesService", () => {
   describe("getBySiteName", () => {
     it("should call the findOne method of the db model to get the siteName", async () => {
       // Arrange
-      const expected = mockSite
+      const expected = ok(mockSite)
       MockRepository.findOne.mockResolvedValueOnce(mockSite)
 
       // Act
       const actual = await SitesService.getBySiteName(mockSiteName)
 
       // Assert
-      expect(actual).toBe(expected)
+      expect(actual).toEqual(expected)
       expect(MockRepository.findOne).toBeCalledWith({
         include: [
           {
@@ -536,7 +538,7 @@ describe("SitesService", () => {
   describe("getCommitAuthorEmail", () => {
     it("should return the email of the commit author who is an email login user", async () => {
       // Arrange
-      const expected = mockEmail
+      const expected = ok(mockEmail)
       const commit: GitHubCommitData = {
         author: {
           name: MOCK_GITHUB_NAME_ONE,
@@ -551,14 +553,14 @@ describe("SitesService", () => {
       const actual = await SitesService.getCommitAuthorEmail(commit)
 
       // Assert
-      expect(actual).toBe(expected)
+      expect(actual).toEqual(expected)
       expect(MockUsersService.findById).toHaveBeenCalledWith(mockIsomerUserId)
       expect(SpySitesService.extractAuthorEmail).not.toHaveBeenCalled()
     })
 
     it("should return the email of the commit author who is a GitHub login user", async () => {
       // Arrange
-      const expected = MOCK_GITHUB_EMAIL_ADDRESS_ONE
+      const expected = ok(MOCK_GITHUB_EMAIL_ADDRESS_ONE)
       const commit: GitHubCommitData = {
         author: {
           name: MOCK_GITHUB_NAME_ONE,
@@ -572,7 +574,7 @@ describe("SitesService", () => {
       const actual = await SitesService.getCommitAuthorEmail(commit)
 
       // Assert
-      expect(actual).toBe(expected)
+      expect(actual).toEqual(expected)
       expect(MockUsersService.findById).not.toHaveBeenCalled()
       expect(SpySitesService.extractAuthorEmail).toHaveBeenCalled()
     })
@@ -581,7 +583,7 @@ describe("SitesService", () => {
   describe("getMergeAuthorEmail", () => {
     it("should return the email of the merge commit author if it was not performed using the common access token", async () => {
       // Arrange
-      const expected = MOCK_GITHUB_EMAIL_ADDRESS_ONE
+      const expected = ok(MOCK_GITHUB_EMAIL_ADDRESS_ONE)
       const commit: GitHubCommitData = {
         author: {
           name: MOCK_GITHUB_NAME_ONE,
@@ -607,7 +609,7 @@ describe("SitesService", () => {
 
     it("should return the email of the merge commit author if the site cannot be found", async () => {
       // Arrange
-      const expected = MOCK_GITHUB_EMAIL_ADDRESS_ONE
+      const expected = ok(MOCK_GITHUB_EMAIL_ADDRESS_ONE)
       const commit: GitHubCommitData = {
         author: {
           name: MOCK_COMMON_ACCESS_TOKEN_GITHUB_NAME,
@@ -634,7 +636,7 @@ describe("SitesService", () => {
 
     it("should return the email of the merge commit author if there are no merged review requests", async () => {
       // Arrange
-      const expected = MOCK_GITHUB_EMAIL_ADDRESS_ONE
+      const expected = ok(MOCK_GITHUB_EMAIL_ADDRESS_ONE)
       const commit: GitHubCommitData = {
         author: {
           name: MOCK_COMMON_ACCESS_TOKEN_GITHUB_NAME,
@@ -645,7 +647,7 @@ describe("SitesService", () => {
       }
       MockRepository.findOne.mockResolvedValueOnce(mockSite)
       MockReviewRequestService.getLatestMergedReviewRequest.mockResolvedValueOnce(
-        new RequestNotFoundError()
+        errAsync(new RequestNotFoundError())
       )
 
       // Act
@@ -664,7 +666,7 @@ describe("SitesService", () => {
 
     it("should return the email of the requestor for the latest merged review request", async () => {
       // Arrange
-      const expected = mockEmail
+      const expected = ok(mockEmail)
       const commit: GitHubCommitData = {
         author: {
           name: MOCK_COMMON_ACCESS_TOKEN_GITHUB_NAME,
@@ -680,7 +682,7 @@ describe("SitesService", () => {
       }
       MockRepository.findOne.mockResolvedValueOnce(mockSite)
       MockReviewRequestService.getLatestMergedReviewRequest.mockResolvedValueOnce(
-        mockReviewRequest
+        okAsync(mockReviewRequest)
       )
 
       // Act
@@ -699,7 +701,7 @@ describe("SitesService", () => {
 
     it("should return the email of the merge commit author if the requestor for the latest merged review request does not have an email", async () => {
       // Arrange
-      const expected = MOCK_GITHUB_EMAIL_ADDRESS_ONE
+      const expected = ok(MOCK_GITHUB_EMAIL_ADDRESS_ONE)
       const commit: GitHubCommitData = {
         author: {
           name: MOCK_COMMON_ACCESS_TOKEN_GITHUB_NAME,
@@ -715,7 +717,7 @@ describe("SitesService", () => {
       }
       MockRepository.findOne.mockResolvedValueOnce(mockSite)
       MockReviewRequestService.getLatestMergedReviewRequest.mockResolvedValueOnce(
-        mockReviewRequest
+        okAsync(mockReviewRequest)
       )
 
       // Act
@@ -754,10 +756,10 @@ describe("SitesService", () => {
 
     it("should return the urls of the site from the deployments table", async () => {
       // Arrange
-      const expected = {
+      const expected = ok({
         staging: deployment.stagingUrl,
         prod: deployment.productionUrl,
-      }
+      })
       const mockSiteWithDeployment = {
         ...mockSite,
         deployment,
@@ -779,10 +781,10 @@ describe("SitesService", () => {
 
     it("should return the urls of the site from the _config.yml file", async () => {
       // Arrange
-      const expected = {
+      const expected = ok({
         staging: configYmlData.staging,
         prod: configYmlData.prod,
-      }
+      })
       const mockSiteWithNullDeployment = {
         ...mockSite,
         deployment: {
@@ -809,10 +811,10 @@ describe("SitesService", () => {
 
     it("should return the urls of the site from the GitHub repo description", async () => {
       // Arrange
-      const expected = {
+      const expected = ok({
         staging: gitHubUrls.staging,
         prod: gitHubUrls.prod,
-      }
+      })
       const mockSiteWithNullDeployment = {
         ...mockSite,
         deployment: {
@@ -840,7 +842,7 @@ describe("SitesService", () => {
       expect(MockGithubService.getRepoInfo).toHaveBeenCalled()
     })
 
-    it("should return a NotFoundError if all fails", async () => {
+    it("should return a MissingSiteError if all fails", async () => {
       // Arrange
       const mockSiteWithNullDeployment = {
         ...mockSite,
@@ -865,7 +867,7 @@ describe("SitesService", () => {
       )
 
       // Assert
-      expect(actual).toBeInstanceOf(NotFoundError)
+      expect(actual).toEqual(err(new MissingSiteError()))
       expect(MockRepository.findOne).toHaveBeenCalled()
       expect(MockConfigYmlService.read).toHaveBeenCalled()
       expect(MockGithubService.getRepoInfo).toHaveBeenCalled()
@@ -1060,11 +1062,11 @@ describe("SitesService", () => {
       )
 
       // Assert
-      expect(actual).toEqual(MOCK_STAGING_URL_DB)
+      expect(actual).toEqual(ok(MOCK_STAGING_URL_DB))
       expect(MockRepository.findOne).toHaveBeenCalled()
     })
 
-    it("should return an error when the staging url for a repo is not found", async () => {
+    it("should return MissingSiteError when the staging url for a repo is not found", async () => {
       // Arrange
       MockRepository.findOne.mockResolvedValueOnce(null)
       MockConfigYmlService.read.mockResolvedValueOnce({
@@ -1077,7 +1079,7 @@ describe("SitesService", () => {
       // Act
       await expect(
         SitesService.getStagingUrl(mockUserWithSiteSessionData)
-      ).resolves.toBeInstanceOf(NotFoundError)
+      ).resolves.toEqual(err(new MissingSiteError()))
 
       // Assert
       expect(MockRepository.findOne).toHaveBeenCalled()
@@ -1105,11 +1107,11 @@ describe("SitesService", () => {
       )
 
       // Assert
-      expect(actual).toEqual(MOCK_PRODUCTION_URL_DB)
+      expect(actual).toEqual(ok(MOCK_PRODUCTION_URL_DB))
       expect(MockRepository.findOne).toHaveBeenCalled()
     })
 
-    it("should return an error when the site url for a repo is not found", async () => {
+    it("should return  MissingSiteError when the site url for a repo is not found", async () => {
       // Arrange
       MockRepository.findOne.mockResolvedValueOnce(null)
       MockConfigYmlService.read.mockResolvedValueOnce({
@@ -1122,7 +1124,7 @@ describe("SitesService", () => {
       // Act
       await expect(
         SitesService.getSiteUrl(mockUserWithSiteSessionData)
-      ).resolves.toBeInstanceOf(NotFoundError)
+      ).resolves.toEqual(err(new MissingSiteError()))
 
       // Assert
       expect(MockRepository.findOne).toHaveBeenCalled()
@@ -1164,14 +1166,14 @@ describe("SitesService", () => {
       const mockProductionCommitAuthor: Partial<User> = {
         email: MOCK_GITHUB_EMAIL_ADDRESS_TWO,
       }
-      const expected: SiteInfo = {
+      const expected: Ok<SiteInfo, never> = ok({
         savedAt: new Date(MOCK_GITHUB_DATE_ONE).getTime(),
         savedBy: MOCK_GITHUB_EMAIL_ADDRESS_ONE,
         publishedAt: new Date(MOCK_GITHUB_DATE_TWO).getTime(),
         publishedBy: MOCK_GITHUB_EMAIL_ADDRESS_TWO,
         stagingUrl: MOCK_STAGING_URL_DB,
         siteUrl: MOCK_PRODUCTION_URL_DB,
-      }
+      })
 
       MockRepository.findOne.mockResolvedValueOnce(mockSiteWithDeployment)
       MockGithubService.getLatestCommitOfBranch.mockResolvedValueOnce(
@@ -1215,14 +1217,14 @@ describe("SitesService", () => {
         },
         message: MOCK_COMMIT_MESSAGE_TWO,
       }
-      const expected: SiteInfo = {
+      const expected: Ok<SiteInfo, never> = ok({
         savedAt: new Date(MOCK_GITHUB_DATE_ONE).getTime(),
         savedBy: MOCK_GITHUB_EMAIL_ADDRESS_ONE,
         publishedAt: new Date(MOCK_GITHUB_DATE_TWO).getTime(),
         publishedBy: MOCK_GITHUB_EMAIL_ADDRESS_TWO,
         stagingUrl: MOCK_STAGING_URL_DB,
         siteUrl: MOCK_PRODUCTION_URL_DB,
-      }
+      })
 
       MockRepository.findOne.mockResolvedValueOnce(mockSiteWithDeployment)
       MockGithubService.getLatestCommitOfBranch.mockResolvedValueOnce(
@@ -1244,7 +1246,7 @@ describe("SitesService", () => {
       expect(MockUsersService.findById).not.toHaveBeenCalled()
     })
 
-    it("should return UnprocessableError when the site is not found", async () => {
+    it("should return MissingSiteError when the site is not found", async () => {
       // Arrange
       MockRepository.findOne.mockResolvedValueOnce(null)
       MockConfigYmlService.read.mockResolvedValueOnce({
@@ -1253,11 +1255,27 @@ describe("SitesService", () => {
       MockGithubService.getRepoInfo.mockResolvedValueOnce({
         description: "",
       })
+      MockGithubService.getLatestCommitOfBranch.mockResolvedValueOnce({
+        author: {
+          name: MOCK_COMMON_ACCESS_TOKEN_GITHUB_NAME,
+          email: MOCK_GITHUB_EMAIL_ADDRESS_ONE,
+          date: MOCK_GITHUB_DATE_ONE,
+        },
+        message: MOCK_COMMIT_MESSAGE_ONE,
+      })
+      MockGithubService.getLatestCommitOfBranch.mockResolvedValueOnce({
+        author: {
+          name: MOCK_COMMON_ACCESS_TOKEN_GITHUB_NAME,
+          email: MOCK_GITHUB_EMAIL_ADDRESS_ONE,
+          date: MOCK_GITHUB_DATE_ONE,
+        },
+        message: MOCK_COMMIT_MESSAGE_ONE,
+      })
 
       // Act
       await expect(
         SitesService.getSiteInfo(mockSessionDataEmailUserWithSite)
-      ).resolves.toBeInstanceOf(UnprocessableError)
+      ).resolves.toEqual(err(new MissingSiteError()))
 
       // Assert
       expect(MockRepository.findOne).toHaveBeenCalled()
@@ -1268,29 +1286,32 @@ describe("SitesService", () => {
       // Arrange
       MockRepository.findOne.mockResolvedValueOnce(mockSiteWithDeployment)
       MockGithubService.getLatestCommitOfBranch.mockResolvedValueOnce(null)
-      MockGithubService.getLatestCommitOfBranch.mockResolvedValueOnce(null)
 
       // Act
       await expect(
         SitesService.getSiteInfo(mockSessionDataEmailUserWithSite)
-      ).resolves.toBeInstanceOf(UnprocessableError)
+      ).resolves.toEqual(
+        err(new UnprocessableError("Unable to retrieve GitHub commit info"))
+      )
 
       // Assert
-      expect(MockRepository.findOne).toHaveBeenCalled()
-      expect(MockGithubService.getLatestCommitOfBranch).toHaveBeenCalledTimes(2)
+      // After the first call to `staging`, if it returns `null`,
+      // it short-circuits by returning an error.
+      expect(MockRepository.findOne).not.toHaveBeenCalled()
+      expect(MockGithubService.getLatestCommitOfBranch).toHaveBeenCalledTimes(1)
       expect(MockUsersService.findById).not.toHaveBeenCalled()
     })
 
     it("should return with unknown author when the GitHub commit is empty", async () => {
       // Arrange
-      const expected: SiteInfo = {
+      const expected: Ok<SiteInfo, never> = ok({
         savedAt: 0,
         savedBy: "Unknown Author",
         publishedAt: 0,
         publishedBy: "Unknown Author",
         stagingUrl: MOCK_STAGING_URL_DB,
         siteUrl: MOCK_PRODUCTION_URL_DB,
-      }
+      })
 
       const mockEmptyCommit: GitHubCommitData = {
         author: {

--- a/src/types/pages.ts
+++ b/src/types/pages.ts
@@ -17,7 +17,7 @@ export type ResourceRoomName = {
 export type SubcollectionPageName = {
   name: string & { __kind: "SubcollectionPage" }
   collection: string
-  subCollection: string
+  subcollection: string
   kind: "SubcollectionPage"
 }
 


### PR DESCRIPTION
## Problem
Part of #585, where the specs failed due to the API changes. This PR fixes the failing tests; most of the fixes are mostly cosmetic but here are a few meaningful changes described below.

## Solution
1. rework tests to unwrap value
2. for `SitesService.spec`, the spec where `it("should return UnprocessableError when the GitHub commit is not found")` has been altered to only assert that the service is called once. This is because we now short circuit when either the prod/staging commit could not be fetched, rather than continuing on with the code flow. This is because both `staging/prod` commit contain info that we use to derive properties without which the flow isn't meaningful anymore.
