### PR TITLE
test(pageservice): add tests for page service

### DIFF
--- a/src/classes/Settings.js
+++ b/src/classes/Settings.js
@@ -14,7 +14,7 @@ const {
 // Constants
 const FOOTER_PATH = "footer.yml"
 const NAVIGATION_PATH = "navigation.yml"
-const HOMEPAGE_INDEX_PATH = "index.md" // Empty string
+const { HOMEPAGE_NAME } = require("@root/constants")
 
 const retrieveSettingsFiles = async (
   accessToken,
@@ -42,7 +42,7 @@ const retrieveSettingsFiles = async (
 
   // Retrieve homepage only if flag is set to true
   if (shouldRetrieveHomepage) {
-    fileRetrievalObj.homepage = HomepageFile.read(HOMEPAGE_INDEX_PATH)
+    fileRetrievalObj.homepage = HomepageFile.read(HOMEPAGE_NAME)
   }
 
   const fileContentsArr = await Bluebird.map(
@@ -233,7 +233,7 @@ class Settings {
         const homepageContent = ["---\n", homepageFrontMatter, "---"].join("")
         const newHomepageContent = Base64.encode(homepageContent)
 
-        await HomepageFile.update(HOMEPAGE_INDEX_PATH, newHomepageContent, sha)
+        await HomepageFile.update(HOMEPAGE_NAME, newHomepageContent, sha)
       }
     }
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,2 @@
 export * from "./constants"
+export * from "./pages"

--- a/src/constants/pages.ts
+++ b/src/constants/pages.ts
@@ -1,0 +1,1 @@
+export const HOMEPAGE_NAME = "index.md"

--- a/src/constants/pages.ts
+++ b/src/constants/pages.ts
@@ -1,1 +1,3 @@
 export const HOMEPAGE_NAME = "index.md"
+
+export const CONTACT_US_FILENAME = "contact-us.md"

--- a/src/constants/pages.ts
+++ b/src/constants/pages.ts
@@ -1,3 +1,3 @@
-export const HOMEPAGE_NAME = "index.md"
+export const HOMEPAGE_FILENAME = "index.md"
 
 export const CONTACT_US_FILENAME = "contact-us.md"

--- a/src/fixtures/github.ts
+++ b/src/fixtures/github.ts
@@ -137,3 +137,13 @@ export const MOCK_GITHUB_RAWCOMMENT_TWO: RawComment = {
   body: JSON.stringify(MOCK_GITHUB_COMMENT_OBJECT_TWO),
   created_at: MOCK_GITHUB_COMMIT_DATE_THREE,
 }
+
+export const MOCK_PAGE_PERMALINK = "/department/english"
+
+export const MOCK_GITHUB_FRONTMATTER = Buffer.from(
+  `---
+permalink: ${MOCK_PAGE_PERMALINK}
+---
+`,
+  "binary"
+).toString("base64")

--- a/src/fixtures/sites.ts
+++ b/src/fixtures/sites.ts
@@ -75,7 +75,7 @@ export const MOCK_REPO_DBENTRY_TWO: Attributes<Repo> = {
   updatedAt: MOCK_SITE_DATE_TWO,
 }
 
-export const MOCK_DEPLOYMENT_DBENTRY_ONE: Attributes<Deployment> = {
+export const MOCK_DEPLOYMENT_DBENTRY_ONE = {
   id: 1,
   siteId: MOCK_SITE_ID_ONE,
   productionUrl: MOCK_DEPLOYMENT_PROD_URL_ONE,

--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -23,6 +23,17 @@ import {
   mockIsomerUserId,
   mockSiteName,
 } from "@fixtures/sessionData"
+import { BaseDirectoryService } from "@root/services/directoryServices/BaseDirectoryService"
+import { ResourceRoomDirectoryService } from "@root/services/directoryServices/ResourceRoomDirectoryService"
+import { CollectionPageService } from "@root/services/fileServices/MdPageServices/CollectionPageService"
+import { ContactUsPageService } from "@root/services/fileServices/MdPageServices/ContactUsPageService"
+import { HomepagePageService } from "@root/services/fileServices/MdPageServices/HomepagePageService"
+import { PageService } from "@root/services/fileServices/MdPageServices/PageService"
+import { ResourcePageService } from "@root/services/fileServices/MdPageServices/ResourcePageService"
+import { SubcollectionPageService } from "@root/services/fileServices/MdPageServices/SubcollectionPageService"
+import { UnlinkedPageService } from "@root/services/fileServices/MdPageServices/UnlinkedPageService"
+import { CollectionYmlService } from "@root/services/fileServices/YmlFileServices/CollectionYmlService"
+import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/FooterYmlService"
 import { GitHubService } from "@services/db/GitHubService"
 import * as ReviewApi from "@services/db/review"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
@@ -41,13 +52,62 @@ const mockGithubService = {
   getComments: jest.fn(),
 }
 const usersService = getUsersService(sequelize)
+const footerYmlService = new FooterYmlService({
+  gitHubService: mockGithubService,
+})
+const collectionYmlService = new CollectionYmlService({
+  gitHubService: mockGithubService,
+})
+const baseDirectoryService = new BaseDirectoryService({
+  gitHubService: mockGithubService,
+})
+
+const contactUsService = new ContactUsPageService({
+  gitHubService: mockGithubService,
+  footerYmlService,
+})
+const collectionPageService = new CollectionPageService({
+  gitHubService: mockGithubService,
+  collectionYmlService,
+})
+const subCollectionPageService = new SubcollectionPageService({
+  gitHubService: mockGithubService,
+  collectionYmlService,
+})
+const homepageService = new HomepagePageService({
+  gitHubService: mockGithubService,
+})
+const resourcePageService = new ResourcePageService({
+  gitHubService: mockGithubService,
+})
+const unlinkedPageService = new UnlinkedPageService({
+  gitHubService: mockGithubService,
+})
+const configYmlService = new ConfigYmlService({
+  gitHubService: mockGithubService,
+})
+const resourceRoomDirectoryService = new ResourceRoomDirectoryService({
+  baseDirectoryService,
+  configYmlService,
+  gitHubService: mockGithubService,
+})
+const pageService = new PageService({
+  collectionPageService,
+  contactUsService,
+  subCollectionPageService,
+  homepageService,
+  resourcePageService,
+  unlinkedPageService,
+  resourceRoomDirectoryService,
+})
 const reviewRequestService = new ReviewRequestService(
   (mockGithubService as unknown) as typeof ReviewApi,
   User,
   ReviewRequest,
   Reviewer,
   ReviewMeta,
-  ReviewRequestView
+  ReviewRequestView,
+  pageService
 )
 const sitesService = new SitesService({
   siteRepository: Site,

--- a/src/integration/Notifications.spec.ts
+++ b/src/integration/Notifications.spec.ts
@@ -13,9 +13,8 @@ import {
   User,
   Whitelist,
 } from "@database/models"
-import { generateRouter, generateRouterForUserWithSite } from "@fixtures/app"
+import { generateRouterForUserWithSite } from "@fixtures/app"
 import UserSessionData from "@root/classes/UserSessionData"
-import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import {
   formatNotification,
   highPriorityOldReadNotification,
@@ -35,7 +34,18 @@ import { NotificationsRouter as _NotificationsRouter } from "@root/routes/v2/aut
 import { SitesRouter as _SitesRouter } from "@root/routes/v2/authenticated/sites"
 import { genericGitHubAxiosInstance } from "@root/services/api/AxiosInstance"
 import { GitHubService } from "@root/services/db/GitHubService"
+import { BaseDirectoryService } from "@root/services/directoryServices/BaseDirectoryService"
+import { ResourceRoomDirectoryService } from "@root/services/directoryServices/ResourceRoomDirectoryService"
+import { CollectionPageService } from "@root/services/fileServices/MdPageServices/CollectionPageService"
+import { ContactUsPageService } from "@root/services/fileServices/MdPageServices/ContactUsPageService"
+import { HomepagePageService } from "@root/services/fileServices/MdPageServices/HomepagePageService"
+import { PageService } from "@root/services/fileServices/MdPageServices/PageService"
+import { ResourcePageService } from "@root/services/fileServices/MdPageServices/ResourcePageService"
+import { SubcollectionPageService } from "@root/services/fileServices/MdPageServices/SubcollectionPageService"
+import { UnlinkedPageService } from "@root/services/fileServices/MdPageServices/UnlinkedPageService"
+import { CollectionYmlService } from "@root/services/fileServices/YmlFileServices/CollectionYmlService"
 import { ConfigYmlService } from "@root/services/fileServices/YmlFileServices/ConfigYmlService"
+import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/FooterYmlService"
 import CollaboratorsService from "@root/services/identity/CollaboratorsService"
 import SitesService from "@root/services/identity/SitesService"
 import ReviewRequestService from "@root/services/review/ReviewRequestService"
@@ -58,13 +68,47 @@ const gitHubService = new GitHubService({
 const identityAuthService = getIdentityAuthService(gitHubService)
 const usersService = getUsersService(sequelize)
 const configYmlService = new ConfigYmlService({ gitHubService })
+const footerYmlService = new FooterYmlService({ gitHubService })
+const collectionYmlService = new CollectionYmlService({ gitHubService })
+const baseDirectoryService = new BaseDirectoryService({ gitHubService })
+
+const contactUsService = new ContactUsPageService({
+  gitHubService,
+  footerYmlService,
+})
+const collectionPageService = new CollectionPageService({
+  gitHubService,
+  collectionYmlService,
+})
+const subCollectionPageService = new SubcollectionPageService({
+  gitHubService,
+  collectionYmlService,
+})
+const homepageService = new HomepagePageService({ gitHubService })
+const resourcePageService = new ResourcePageService({ gitHubService })
+const unlinkedPageService = new UnlinkedPageService({ gitHubService })
+const resourceRoomDirectoryService = new ResourceRoomDirectoryService({
+  baseDirectoryService,
+  configYmlService,
+  gitHubService,
+})
+const pageService = new PageService({
+  collectionPageService,
+  contactUsService,
+  subCollectionPageService,
+  homepageService,
+  resourcePageService,
+  unlinkedPageService,
+  resourceRoomDirectoryService,
+})
 const reviewRequestService = new ReviewRequestService(
   (gitHubService as unknown) as typeof ReviewApi,
   User,
   ReviewRequest,
   Reviewer,
   ReviewMeta,
-  ReviewRequestView
+  ReviewRequestView,
+  pageService
 )
 const sitesService = new SitesService({
   siteRepository: Site,

--- a/src/routes/v1/authenticatedSites/homepage.js
+++ b/src/routes/v1/authenticatedSites/homepage.js
@@ -12,7 +12,7 @@ const {
 const { File, HomepageType } = require("@classes/File")
 
 // Constants
-const HOMEPAGE_INDEX_PATH = "index.md" // Empty string
+const { HOMEPAGE_NAME } = require("@root/constants")
 
 // Read homepage index file
 async function readHomepage(req, res) {
@@ -24,9 +24,7 @@ async function readHomepage(req, res) {
   const IsomerFile = new File(accessToken, siteName)
   const homepageType = new HomepageType()
   IsomerFile.setFileType(homepageType)
-  const { sha, content: encodedContent } = await IsomerFile.read(
-    HOMEPAGE_INDEX_PATH
-  )
+  const { sha, content: encodedContent } = await IsomerFile.read(HOMEPAGE_NAME)
   const content = Base64.decode(encodedContent)
 
   // TO-DO:
@@ -50,7 +48,7 @@ async function updateHomepage(req, res) {
   const homepageType = new HomepageType()
   IsomerFile.setFileType(homepageType)
   const { newSha } = await IsomerFile.update(
-    HOMEPAGE_INDEX_PATH,
+    HOMEPAGE_NAME,
     Base64.encode(content),
     sha
   )

--- a/src/routes/v2/authenticated/__tests__/review.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/review.spec.ts
@@ -151,7 +151,8 @@ describe("Review Requests Router", () => {
       mockReviewRequestService.compareDiff.mockResolvedValueOnce(
         mockFilesChanged
       )
-      mockSitesService.getBySiteName.mockResolvedValueOnce(true)
+      mockSitesService.getBySiteName.mockResolvedValueOnce(ok(true))
+
       // Act
       const response = await request(app).get("/mockSite/review/compare")
 
@@ -165,7 +166,7 @@ describe("Review Requests Router", () => {
     it("should return 404 if user is not a site member", async () => {
       // Arrange
       mockIdentityUsersService.getSiteMember.mockResolvedValueOnce(null)
-      mockSitesService.getBySiteName.mockResolvedValueOnce(true)
+      mockSitesService.getBySiteName.mockResolvedValueOnce(ok(true))
 
       // Act
       const response = await request(app).get("/mockSite/review/compare")
@@ -531,7 +532,6 @@ describe("Review Requests Router", () => {
     it("should return 200 with the full review request", async () => {
       // Arrange
       const mockReviewRequest = "review request"
-
       mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
       mockReviewRequestService.getFullReviewRequest.mockReturnValueOnce(
         okAsync(mockReviewRequest)
@@ -552,10 +552,10 @@ describe("Review Requests Router", () => {
 
     it("should return 404 if the site does not exist", async () => {
       // Arrange
-      mockSitesService.getBySiteName.mockResolvedValueOnce(null)
       mockSitesService.getBySiteName.mockReturnValueOnce(
         errAsync(new MissingSiteError("site"))
       )
+      mockGithubService.getRepoInfo.mockRejectedValueOnce(null)
 
       // Act
       const response = await request(app).get(`/mockSite/review/12345`)

--- a/src/services/fileServices/MdPageServices/ContactUsPageService.js
+++ b/src/services/fileServices/MdPageServices/ContactUsPageService.js
@@ -3,7 +3,8 @@ const {
   convertDataToMarkdown,
 } = require("@utils/markdown-utils")
 
-const CONTACT_US_FILE_NAME = "contact-us.md"
+const { CONTACT_US_FILENAME } = require("@root/constants/pages")
+
 const CONTACT_US_DIRECTORY_NAME = "pages"
 
 class ContactUsPageService {
@@ -18,7 +19,7 @@ class ContactUsPageService {
     const { content: rawContent, sha } = await this.gitHubService.read(
       sessionData,
       {
-        fileName: CONTACT_US_FILE_NAME,
+        fileName: CONTACT_US_FILENAME,
         directoryName: CONTACT_US_DIRECTORY_NAME,
       }
     )
@@ -37,7 +38,7 @@ class ContactUsPageService {
     const { newSha } = await this.gitHubService.update(sessionData, {
       fileContent: newContent,
       sha,
-      fileName: CONTACT_US_FILE_NAME,
+      fileName: CONTACT_US_FILENAME,
       directoryName: CONTACT_US_DIRECTORY_NAME,
     })
     const {

--- a/src/services/fileServices/MdPageServices/HomepagePageService.js
+++ b/src/services/fileServices/MdPageServices/HomepagePageService.js
@@ -3,7 +3,7 @@ const {
   convertDataToMarkdown,
 } = require("@utils/markdown-utils")
 
-const HOMEPAGE_FILE_NAME = "index.md"
+const { HOMEPAGE_NAME } = require("@root/constants")
 
 class HomepagePageService {
   constructor({ gitHubService }) {
@@ -14,7 +14,7 @@ class HomepagePageService {
     const { content: rawContent, sha } = await this.gitHubService.read(
       sessionData,
       {
-        fileName: HOMEPAGE_FILE_NAME,
+        fileName: HOMEPAGE_NAME,
       }
     )
     const { frontMatter, pageContent } = retrieveDataFromMarkdown(rawContent)
@@ -26,7 +26,7 @@ class HomepagePageService {
     const { newSha } = await this.gitHubService.update(sessionData, {
       fileContent: newContent,
       sha,
-      fileName: HOMEPAGE_FILE_NAME,
+      fileName: HOMEPAGE_NAME,
     })
     return {
       content: { frontMatter, pageBody: content },

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -141,10 +141,6 @@ export class PageService {
           CollectionPageName | SubcollectionPageName,
           NotFoundError
         >((rawPath) => {
-          // NOTE: Only 2 levels of nesting
-          if (rawPath.length > 2) {
-            return errAsync(new NotFoundError())
-          }
           if (rawPath.length === 1 && !!rawPath[0]) {
             return okAsync({
               name: Brand.fromString(name),

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -145,19 +145,22 @@ export class PageService {
           if (rawPath.length > 2) {
             return errAsync(new NotFoundError())
           }
-          if (rawPath.length === 1) {
+          if (rawPath.length === 1 && !!rawPath[0]) {
             return okAsync({
               name: Brand.fromString(name),
               collection: rawPath[0],
               kind: "CollectionPage",
             })
           }
-          return okAsync({
-            name: Brand.fromString(name),
-            collection: rawPath[0],
-            subCollection: rawPath[1],
-            kind: "SubcollectionPage",
-          })
+          if (rawPath.length === 2 && !!rawPath[0] && !!rawPath[1]) {
+            return okAsync({
+              name: Brand.fromString(name),
+              collection: rawPath[0],
+              subCollection: rawPath[1],
+              kind: "SubcollectionPage",
+            })
+          }
+          return errAsync(new NotFoundError())
         })
       )
       .mapErr(() => new NotFoundError())

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -1,7 +1,7 @@
 import { ok, err, Result, ResultAsync, okAsync, errAsync } from "neverthrow"
 
 import UserSessionData from "@root/classes/UserSessionData"
-import { CONTACT_US_FILENAME, HOMEPAGE_NAME } from "@root/constants"
+import { CONTACT_US_FILENAME, HOMEPAGE_FILENAME } from "@root/constants"
 import { BaseIsomerError } from "@root/errors/BaseError"
 import EmptyStringError from "@root/errors/EmptyStringError"
 import MissingResourceRoomError from "@root/errors/MissingResourceRoomError"
@@ -170,7 +170,7 @@ export class PageService {
   ): Result<HomepageName, NotFoundError> =>
     this.extractPathInfo(pageName).andThen<HomepageName, NotFoundError>(
       ({ name, path }) => {
-        if (path.isErr() && name === HOMEPAGE_NAME) {
+        if (path.isErr() && name === HOMEPAGE_FILENAME) {
           return ok({ name: Brand.fromString(name), kind: "Homepage" })
         }
         return err(new NotFoundError())

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -1,7 +1,7 @@
-import _ from "lodash"
 import { ok, err, Result, ResultAsync, okAsync, errAsync } from "neverthrow"
 
 import UserSessionData from "@root/classes/UserSessionData"
+import { HOMEPAGE_NAME } from "@root/constants"
 import { BaseIsomerError } from "@root/errors/BaseError"
 import EmptyStringError from "@root/errors/EmptyStringError"
 import MissingResourceRoomError from "@root/errors/MissingResourceRoomError"
@@ -167,7 +167,7 @@ export class PageService {
   ): Result<HomepageName, NotFoundError> =>
     this.extractPathInfo(pageName).andThen<HomepageName, NotFoundError>(
       ({ name, path }) => {
-        if (path.isErr() && name === "index.md") {
+        if (path.isErr() && name === HOMEPAGE_NAME) {
           return ok({ name: Brand.fromString(name), kind: "Homepage" })
         }
         return err(new NotFoundError())

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -1,7 +1,7 @@
 import { ok, err, Result, ResultAsync, okAsync, errAsync } from "neverthrow"
 
 import UserSessionData from "@root/classes/UserSessionData"
-import { HOMEPAGE_NAME } from "@root/constants"
+import { CONTACT_US_FILENAME, HOMEPAGE_NAME } from "@root/constants"
 import { BaseIsomerError } from "@root/errors/BaseError"
 import EmptyStringError from "@root/errors/EmptyStringError"
 import MissingResourceRoomError from "@root/errors/MissingResourceRoomError"
@@ -187,7 +187,7 @@ export class PageService {
         if (
           path.isOk() &&
           path.value.pop() === "pages" &&
-          name === "contact-us.md"
+          name === CONTACT_US_FILENAME
         ) {
           return ok({ name: Brand.fromString(name), kind: "ContactUsPage" })
         }

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -159,7 +159,7 @@ export class PageService {
           }
           return errAsync(
             new NotFoundError(
-              `Error when parsig path: ${rawPath}, please ensure that the file exists!`
+              `Error when parsing path: ${rawPath}, please ensure that the file exists!`
             )
           )
         })

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -156,7 +156,7 @@ export class PageService {
             return okAsync({
               name: Brand.fromString(name),
               collection: rawPath[0],
-              subCollection: rawPath[1],
+              subcollection: rawPath[1],
               kind: "SubcollectionPage",
             })
           }
@@ -346,7 +346,7 @@ export class PageService {
             .read(sessionData, {
               fileName: pageName.name,
               collectionName: pageName.collection.slice(1),
-              subcollectionName: pageName.subCollection,
+              subcollectionName: pageName.subcollection,
             })
             .then((subcollectionPage) => subcollectionPage as SubcollectionPage)
         ).map(withPermalink)

--- a/src/services/fileServices/MdPageServices/__tests__/ContactUsPageService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/ContactUsPageService.spec.js
@@ -7,6 +7,7 @@ const {
   footerContent: mockFooterContent,
   footerSha: mockFooterSha,
 } = require("@fixtures/footer")
+const { CONTACT_US_FILENAME } = require("@root/constants/pages")
 const { NotFoundError } = require("@root/errors/NotFoundError")
 
 describe("ContactUs Page Service", () => {
@@ -14,7 +15,6 @@ describe("ContactUs Page Service", () => {
   const accessToken = "test-token"
   const reqDetails = { siteName, accessToken }
 
-  const CONTACT_US_FILE_NAME = "contact-us.md"
   const CONTACT_US_DIRECTORY_NAME = "pages"
 
   const mockFrontMatter = {
@@ -80,7 +80,7 @@ describe("ContactUs Page Service", () => {
         mockRawContactUsContent
       )
       expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
-        fileName: CONTACT_US_FILE_NAME,
+        fileName: CONTACT_US_FILENAME,
         directoryName: CONTACT_US_DIRECTORY_NAME,
       })
       expect(mockFooterYmlService.read).toHaveBeenCalledWith(reqDetails)
@@ -95,7 +95,7 @@ describe("ContactUs Page Service", () => {
         mockRawContactUsContent
       )
       expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
-        fileName: CONTACT_US_FILE_NAME,
+        fileName: CONTACT_US_FILENAME,
         directoryName: CONTACT_US_DIRECTORY_NAME,
       })
       expect(mockFooterYmlService.read).toHaveBeenCalledWith(reqDetails)
@@ -112,7 +112,7 @@ describe("ContactUs Page Service", () => {
         feedback: updatedFeedback,
       }
       const updateReq = {
-        fileName: CONTACT_US_FILE_NAME,
+        fileName: CONTACT_US_FILENAME,
         content: mockContent,
         frontMatter: mockUpdatedFrontMatter,
         sha: oldSha,
@@ -132,7 +132,7 @@ describe("ContactUs Page Service", () => {
         mockContent
       )
       expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
-        fileName: CONTACT_US_FILE_NAME,
+        fileName: CONTACT_US_FILENAME,
         directoryName: CONTACT_US_DIRECTORY_NAME,
         fileContent: mockRawContactUsContent,
         sha: oldSha,
@@ -149,7 +149,7 @@ describe("ContactUs Page Service", () => {
     it("Propagates the correct error on failed update", async () => {
       mockGithubService.update.mockRejectedValueOnce(new NotFoundError(""))
       const updateReq = {
-        fileName: CONTACT_US_FILE_NAME,
+        fileName: CONTACT_US_FILENAME,
         content: mockContent,
         frontMatter: mockFrontMatter,
         sha: oldSha,
@@ -164,7 +164,7 @@ describe("ContactUs Page Service", () => {
         mockContent
       )
       expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
-        fileName: CONTACT_US_FILE_NAME,
+        fileName: CONTACT_US_FILENAME,
         directoryName: CONTACT_US_DIRECTORY_NAME,
         fileContent: mockRawContactUsContent,
         sha: oldSha,

--- a/src/services/fileServices/MdPageServices/__tests__/HomepagePageService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/HomepagePageService.spec.js
@@ -3,13 +3,12 @@ const {
   homepageSha: mockHomepageSha,
   rawHomepageContent: mockRawHomepageContent,
 } = require("@fixtures/homepage")
+const { HOMEPAGE_NAME } = require("@root/constants")
 
 describe("Homepage Page Service", () => {
   const siteName = "test-site"
   const accessToken = "test-token"
   const reqDetails = { siteName, accessToken }
-
-  const HOMEPAGE_FILE_NAME = "index.md"
 
   const mockFrontMatter = mockHomepageContent.frontMatter
   const mockContent = mockHomepageContent.pageBody
@@ -59,7 +58,7 @@ describe("Homepage Page Service", () => {
         mockRawHomepageContent
       )
       expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
-        fileName: HOMEPAGE_FILE_NAME,
+        fileName: HOMEPAGE_NAME,
       })
     })
   })
@@ -70,7 +69,7 @@ describe("Homepage Page Service", () => {
     it("Updating page content works correctly", async () => {
       await expect(
         service.update(reqDetails, {
-          fileName: HOMEPAGE_FILE_NAME,
+          fileName: HOMEPAGE_NAME,
           content: mockContent,
           frontMatter: mockFrontMatter,
           sha: oldSha,
@@ -85,7 +84,7 @@ describe("Homepage Page Service", () => {
         mockContent
       )
       expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
-        fileName: HOMEPAGE_FILE_NAME,
+        fileName: HOMEPAGE_NAME,
         fileContent: mockRawHomepageContent,
         sha: oldSha,
       })

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -7,10 +7,6 @@ import MissingResourceRoomError from "@root/errors/MissingResourceRoomError"
 import { NotFoundError } from "@root/errors/NotFoundError"
 import { MOCK_STAGING_URL_GITHUB } from "@root/fixtures/repoInfo"
 import { MOCK_USER_SESSION_DATA_ONE } from "@root/fixtures/sessionData"
-import { ResourceRoomDirectoryService } from "@root/services/directoryServices/ResourceRoomDirectoryService"
-import { CollectionPageService } from "@root/services/fileServices/MdPageServices/CollectionPageService"
-import { ContactUsPageService } from "@root/services/fileServices/MdPageServices/ContactUsPageService"
-import { UnlinkedPageService } from "@root/services/fileServices/MdPageServices/UnlinkedPageService"
 import {
   CollectionPageName,
   ContactUsPageName,
@@ -20,11 +16,15 @@ import {
   UnlinkedPageName,
 } from "@root/types/pages"
 import { Brand } from "@root/types/util"
+import { ResourceRoomDirectoryService } from "@services/directoryServices/ResourceRoomDirectoryService"
 
+import { CollectionPageService } from "../CollectionPageService"
+import { ContactUsPageService } from "../ContactUsPageService"
 import { HomepagePageService } from "../HomepagePageService"
 import { PageService } from "../PageService"
 import { ResourcePageService } from "../ResourcePageService"
 import { SubcollectionPageService } from "../SubcollectionPageService"
+import { UnlinkedPageService } from "../UnlinkedPageService"
 
 const mockContactUsService = jest.mocked<ContactUsPageService>(({
   read: jest.fn(),

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -72,7 +72,7 @@ const createMockFrontMatter = (mockPageName: string) => ({
     frontMatter: {
       permalink: `/${mockPageName}`,
     },
-    pageBody: {},
+    pageBody: "",
   },
   sha: "",
 })

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -1,6 +1,6 @@
 import { err, ok } from "neverthrow"
 
-import { CONTACT_US_FILENAME, HOMEPAGE_NAME } from "@root/constants"
+import { CONTACT_US_FILENAME, HOMEPAGE_FILENAME } from "@root/constants"
 import { BaseIsomerError } from "@root/errors/BaseError"
 import EmptyStringError from "@root/errors/EmptyStringError"
 import MissingResourceRoomError from "@root/errors/MissingResourceRoomError"
@@ -82,7 +82,7 @@ describe("PageService", () => {
     it("should only accept 'index.md' as the homepage name", async () => {
       // Arrange
       const expected = ok({
-        name: HOMEPAGE_NAME,
+        name: HOMEPAGE_FILENAME,
         kind: "Homepage",
       })
 
@@ -263,7 +263,7 @@ describe("PageService", () => {
       // Act
       const actual = await pageService.parsePageName(
         // NOTE: Extra front slash
-        `/${HOMEPAGE_NAME}`,
+        `/${HOMEPAGE_FILENAME}`,
         MOCK_USER_SESSION_DATA_ONE
       )
 
@@ -599,13 +599,13 @@ describe("PageService", () => {
     it("should call the underlying service and return the `permalink` of the homepage when successful", async () => {
       // Arrange
       const MOCK_PAGE_NAME: HomepageName = {
-        name: Brand.fromString(HOMEPAGE_NAME),
+        name: Brand.fromString(HOMEPAGE_FILENAME),
         kind: "Homepage",
       }
       mockHomepageService.read.mockResolvedValueOnce(
-        createMockFrontMatter(HOMEPAGE_NAME)
+        createMockFrontMatter(HOMEPAGE_FILENAME)
       )
-      const expected = ok(createMockStagingPermalink(HOMEPAGE_NAME))
+      const expected = ok(createMockStagingPermalink(HOMEPAGE_FILENAME))
 
       // Act
       const actual = await pageService.retrieveStagingPermalink(
@@ -624,7 +624,7 @@ describe("PageService", () => {
     it("should call the underlying service and return a `BaseIsomerError` when the homepage could not be fetched", async () => {
       // Arrange
       const MOCK_PAGE_NAME: HomepageName = {
-        name: Brand.fromString(HOMEPAGE_NAME),
+        name: Brand.fromString(HOMEPAGE_FILENAME),
         kind: "Homepage",
       }
       mockHomepageService.read.mockRejectedValueOnce({})
@@ -647,7 +647,7 @@ describe("PageService", () => {
     it("should call the underlying service and return a `BaseIsomerError` when the frontmatter of the homepage has no `permalink`", async () => {
       // Arrange
       const MOCK_PAGE_NAME: HomepageName = {
-        name: Brand.fromString(HOMEPAGE_NAME),
+        name: Brand.fromString(HOMEPAGE_FILENAME),
         kind: "Homepage",
       }
       mockHomepageService.read.mockRejectedValueOnce({})

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -182,7 +182,16 @@ describe("PageService", () => {
 
     it("should return `NotFoundError` if the `layout` of the resource item is not `post`", async () => {
       // Arrange
-      const expected = err(new NotFoundError())
+      const MOCK_RESOURCE_ITEM = `${MOCK_RESOURCE_ROOM_NAME}/${MOCK_RESOURCE_CATEGORY_NAME}/_posts/${MOCK_UNLINKED_PAGE_NAME}`
+      const expected = err(
+        new NotFoundError(
+          `Error when parsing path: 
+          ${MOCK_RESOURCE_ITEM.split("/").slice(
+            0,
+            -1
+          )}, please ensure that the file exists!`
+        )
+      )
       mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
         { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
       )
@@ -199,7 +208,7 @@ describe("PageService", () => {
 
       // Act
       const actual = await pageService.parsePageName(
-        `${MOCK_RESOURCE_ROOM_NAME}/${MOCK_RESOURCE_CATEGORY_NAME}/_posts/${MOCK_UNLINKED_PAGE_NAME}`,
+        MOCK_RESOURCE_ITEM,
         MOCK_USER_SESSION_DATA_ONE
       )
 
@@ -255,7 +264,11 @@ describe("PageService", () => {
 
     it("should parse two level filepaths including 'index.md' to `NotFoundError`", async () => {
       // Arrange
-      const expected = err(new NotFoundError())
+      const expected = err(
+        new NotFoundError(
+          `Error when parsing path: , please ensure that the file exists!`
+        )
+      )
       mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
         { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
       )
@@ -272,9 +285,9 @@ describe("PageService", () => {
       expect(mockResourcePageService.read).toBeCalled()
     })
 
-    it("should parse empty strings into `NotFoundError`", async () => {
+    it("should parse empty strings into `EmptyStringError`", async () => {
       // Arrange
-      const expected = err(new NotFoundError())
+      const expected = err(new EmptyStringError())
       mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
         { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
       )
@@ -292,7 +305,11 @@ describe("PageService", () => {
 
     it("should parse `/` into `NotFoundError`", async () => {
       // Arrange
-      const expected = err(new NotFoundError())
+      const expected = err(
+        new NotFoundError(
+          "Error when parsing path: , please ensure that the file exists!"
+        )
+      )
       mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
         { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
       )

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -390,7 +390,7 @@ describe("PageService", () => {
   })
 
   describe("extractPathInfo", () => {
-    it("should return a `PathInfo` with a valid path when the string provided is a valid filepath", async () => {
+    it("should return a `PathInfo` with a valid path when the string provided is a valid filepath", () => {
       // Arrange
       const expected = ok({
         name: MOCK_UNLINKED_PAGE_NAME,

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -1,0 +1,940 @@
+import { err, ok } from "neverthrow"
+
+import { CONTACT_US_FILENAME, HOMEPAGE_NAME } from "@root/constants"
+import { BaseIsomerError } from "@root/errors/BaseError"
+import EmptyStringError from "@root/errors/EmptyStringError"
+import MissingResourceRoomError from "@root/errors/MissingResourceRoomError"
+import { NotFoundError } from "@root/errors/NotFoundError"
+import { MOCK_STAGING_URL_GITHUB } from "@root/fixtures/repoInfo"
+import { MOCK_USER_SESSION_DATA_ONE } from "@root/fixtures/sessionData"
+import { ResourceRoomDirectoryService } from "@root/services/directoryServices/ResourceRoomDirectoryService"
+import { CollectionPageService } from "@root/services/fileServices/MdPageServices/CollectionPageService"
+import { ContactUsPageService } from "@root/services/fileServices/MdPageServices/ContactUsPageService"
+import { UnlinkedPageService } from "@root/services/fileServices/MdPageServices/UnlinkedPageService"
+import {
+  CollectionPageName,
+  ContactUsPageName,
+  HomepageName,
+  ResourceCategoryPageName,
+  SubcollectionPageName,
+  UnlinkedPageName,
+} from "@root/types/pages"
+import { Brand } from "@root/types/util"
+
+import { HomepagePageService } from "../HomepagePageService"
+import { PageService } from "../PageService"
+import { ResourcePageService } from "../ResourcePageService"
+import { SubcollectionPageService } from "../SubcollectionPageService"
+
+const mockContactUsService = jest.mocked<ContactUsPageService>(({
+  read: jest.fn(),
+} as unknown) as ContactUsPageService)
+const mockCollectionPageService = jest.mocked<CollectionPageService>(({
+  read: jest.fn(),
+} as unknown) as CollectionPageService)
+const mockSubcollectionPageService = jest.mocked<SubcollectionPageService>(({
+  read: jest.fn(),
+} as unknown) as SubcollectionPageService)
+const mockHomepageService = jest.mocked<HomepagePageService>(({
+  read: jest.fn(),
+} as unknown) as HomepagePageService)
+const mockResourcePageService = jest.mocked<ResourcePageService>(({
+  read: jest.fn(),
+} as unknown) as ResourcePageService)
+const mockUnlinkedPageService = jest.mocked<UnlinkedPageService>(({
+  read: jest.fn(),
+} as unknown) as UnlinkedPageService)
+const mockResourceRoomDirectoryService = jest.mocked<ResourceRoomDirectoryService>(
+  ({
+    getResourceRoomDirectoryName: jest.fn(),
+  } as unknown) as ResourceRoomDirectoryService
+)
+const pageService = new PageService({
+  contactUsService: mockContactUsService,
+  collectionPageService: mockCollectionPageService,
+  subCollectionPageService: mockSubcollectionPageService,
+  homepageService: mockHomepageService,
+  resourcePageService: mockResourcePageService,
+  unlinkedPageService: mockUnlinkedPageService,
+  resourceRoomDirectoryService: mockResourceRoomDirectoryService,
+})
+
+const MOCK_RESOURCE_ROOM_NAME = "resources"
+const MOCK_UNLINKED_PAGE_NAME = "some_page"
+const MOCK_COLLECTION_NAME = "a_collection"
+const MOCK_SUBCOLLECTION_NAME = "submarine"
+const MOCK_RESOURCE_CATEGORY_NAME = "meow"
+const createMockStagingPermalink = (mockPageName: string) =>
+  `${MOCK_STAGING_URL_GITHUB}/${mockPageName}`
+const createMockFrontMatter = (mockPageName: string) => ({
+  fileName: MOCK_UNLINKED_PAGE_NAME,
+  content: {
+    frontMatter: {
+      permalink: `/${mockPageName}`,
+    },
+    pageBody: {},
+  },
+  sha: "",
+})
+
+describe("PageService", () => {
+  describe("parsePageName", () => {
+    it("should only accept 'index.md' as the homepage name", async () => {
+      // Arrange
+      const expected = ok({
+        name: HOMEPAGE_NAME,
+        kind: "Homepage",
+      })
+
+      // Act
+      const actual = await pageService.parsePageName(
+        "index.md",
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+    })
+
+    it("should accept 'pages/contact-us.md' as the contact-us page name", async () => {
+      // Arrange
+      const expected = ok({
+        name: CONTACT_US_FILENAME,
+        kind: "ContactUsPage",
+      })
+
+      // Act
+      const actual = await pageService.parsePageName(
+        "pages/contact-us.md",
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+    })
+
+    it('should parse "contact-us.md" into an error', async () => {
+      // Arrange
+      const expected = err(new NotFoundError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+
+      // Act
+      const actual = await pageService.parsePageName(
+        CONTACT_US_FILENAME,
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+    })
+
+    it('should parse "pages/<page_name>" into an unlinked page name', async () => {
+      // Arrange
+      const expected = ok({
+        name: MOCK_UNLINKED_PAGE_NAME,
+        kind: "UnlinkedPage",
+      })
+
+      // Act
+      const actual = await pageService.parsePageName(
+        `pages/${MOCK_UNLINKED_PAGE_NAME}`,
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+    })
+
+    it("should parse filepaths like `<resource_room_name>/<resource_category_name>/_posts/<page_name>` into a resource category page name if the layout is `post`", async () => {
+      // Arrange
+      const expected = ok({
+        name: MOCK_UNLINKED_PAGE_NAME,
+        resourceRoom: MOCK_RESOURCE_ROOM_NAME,
+        resourceCategory: MOCK_RESOURCE_CATEGORY_NAME,
+        kind: "ResourceCategoryPage",
+      })
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+      mockResourcePageService.read.mockResolvedValueOnce({
+        content: {
+          frontMatter: {
+            layout: "post",
+          },
+          pageBody: "",
+        },
+        fileName: MOCK_UNLINKED_PAGE_NAME,
+        sha: "sha",
+      })
+
+      // Act
+      const actual = await pageService.parsePageName(
+        `${MOCK_RESOURCE_ROOM_NAME}/${MOCK_RESOURCE_CATEGORY_NAME}/_posts/${MOCK_UNLINKED_PAGE_NAME}`,
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+
+    it("should return `NotFoundError` if the `layout` of the resource item is not `post`", async () => {
+      // Arrange
+      const expected = err(new NotFoundError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+      mockResourcePageService.read.mockResolvedValueOnce({
+        content: {
+          frontMatter: {
+            layout: "file",
+          },
+          pageBody: "",
+        },
+        fileName: MOCK_UNLINKED_PAGE_NAME,
+        sha: "sha",
+      })
+
+      // Act
+      const actual = await pageService.parsePageName(
+        `${MOCK_RESOURCE_ROOM_NAME}/${MOCK_RESOURCE_CATEGORY_NAME}/_posts/${MOCK_UNLINKED_PAGE_NAME}`,
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+
+    it("should parse 2 level filepaths without 'index.md' into a collection name if there is no resource room name", async () => {
+      // Arrange
+      const expected = ok({
+        name: MOCK_UNLINKED_PAGE_NAME,
+        collection: MOCK_COLLECTION_NAME,
+        kind: "CollectionPage",
+      })
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockRejectedValueOnce(
+        null
+      )
+
+      // Act
+      const actual = await pageService.parsePageName(
+        `${MOCK_COLLECTION_NAME}/${MOCK_UNLINKED_PAGE_NAME}`,
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+
+    it("should parse 3 level filepaths without 'index.md' into a sub-collection name if there is no resource room name", async () => {
+      // Arrange
+      const expected = ok({
+        name: MOCK_UNLINKED_PAGE_NAME,
+        collection: MOCK_COLLECTION_NAME,
+        subcollection: MOCK_SUBCOLLECTION_NAME,
+        kind: "SubcollectionPage",
+      })
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockRejectedValueOnce(
+        null
+      )
+
+      // Act
+      const actual = await pageService.parsePageName(
+        `${MOCK_COLLECTION_NAME}/${MOCK_SUBCOLLECTION_NAME}/${MOCK_UNLINKED_PAGE_NAME}`,
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+
+    it("should parse two level filepaths including 'index.md' to `NotFoundError`", async () => {
+      // Arrange
+      const expected = err(new NotFoundError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+
+      // Act
+      const actual = await pageService.parsePageName(
+        // NOTE: Extra front slash
+        `/${HOMEPAGE_NAME}`,
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+
+    it("should parse empty strings into `NotFoundError`", async () => {
+      // Arrange
+      const expected = err(new NotFoundError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+
+      // Act
+      const actual = await pageService.parsePageName(
+        "",
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+
+    it("should parse `/` into `NotFoundError`", async () => {
+      // Arrange
+      const expected = err(new NotFoundError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+
+      // Act
+      const actual = await pageService.parsePageName(
+        "/",
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+
+    it("should parse single level filepaths that are not 'index.md' into `NotFoundError`", async () => {
+      // Arrange
+      const expected = err(new NotFoundError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+
+      // Act
+      const actual = await pageService.parsePageName(
+        "gibberish",
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toBeCalled()
+    })
+  })
+
+  describe("extractResourceRoomName", () => {
+    it("should call the underlying service and return a result if the promise resolves", async () => {
+      // Arrange
+      const expected = ok({
+        name: MOCK_RESOURCE_ROOM_NAME,
+        kind: "ResourceRoomName",
+      })
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: MOCK_RESOURCE_ROOM_NAME }
+      )
+
+      // Act
+      const actual = await pageService.extractResourceRoomName(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(
+        mockResourceRoomDirectoryService.getResourceRoomDirectoryName
+      ).toBeCalledWith(MOCK_USER_SESSION_DATA_ONE)
+    })
+
+    it("should call the underlying service and return a `MissingResourceRoomError` if the promise resolves to `null`", async () => {
+      // Arrange
+      const expected = err(new MissingResourceRoomError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockResolvedValueOnce(
+        { resourceRoomName: null }
+      )
+
+      // Act
+      const actual = await pageService.extractResourceRoomName(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(
+        mockResourceRoomDirectoryService.getResourceRoomDirectoryName
+      ).toBeCalledWith(MOCK_USER_SESSION_DATA_ONE)
+    })
+
+    it("should call the underlying service and return a `MissingResourceRoomError` if the promise rejects", async () => {
+      // Arrange
+      const expected = err(new MissingResourceRoomError())
+      mockResourceRoomDirectoryService.getResourceRoomDirectoryName.mockRejectedValueOnce(
+        null
+      )
+
+      // Act
+      const actual = await pageService.extractResourceRoomName(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(
+        mockResourceRoomDirectoryService.getResourceRoomDirectoryName
+      ).toBeCalledWith(MOCK_USER_SESSION_DATA_ONE)
+    })
+  })
+
+  describe("extractPathInfo", () => {
+    it("should return a `PathInfo` with a valid path when the string provided is a valid filepath", async () => {
+      // Arrange
+      const expected = ok({
+        name: MOCK_UNLINKED_PAGE_NAME,
+        path: ok([MOCK_RESOURCE_ROOM_NAME, MOCK_RESOURCE_CATEGORY_NAME]),
+      })
+
+      // Act
+      const actual = pageService.extractPathInfo(
+        `${MOCK_RESOURCE_ROOM_NAME}/${MOCK_RESOURCE_CATEGORY_NAME}/${MOCK_UNLINKED_PAGE_NAME}`
+      )
+
+      // Assert
+      expect(actual).toStrictEqual(expected)
+    })
+
+    it("should return a `PathInfo` with an `err` path when the string provided does not contain `/`", () => {
+      // Arrange
+      const expected = ok({
+        name: MOCK_UNLINKED_PAGE_NAME,
+        path: err([]),
+      })
+
+      // Act
+      const actual = pageService.extractPathInfo(`${MOCK_UNLINKED_PAGE_NAME}`)
+
+      // Assert
+      expect(actual).toStrictEqual(expected)
+    })
+
+    it("should return a `PathInfo` with an empty string as the name when the `/` terminates the string", () => {
+      // Arrange
+      const expected = ok({
+        name: "",
+        path: ok([MOCK_RESOURCE_ROOM_NAME]),
+      })
+
+      // Act
+      const actual = pageService.extractPathInfo(`${MOCK_RESOURCE_ROOM_NAME}/`)
+
+      // Assert
+      expect(actual).toStrictEqual(expected)
+    })
+
+    it("should return a `EmptyStringError` when an empty string is provided as input", () => {
+      // Arrange
+      const expected = err(new EmptyStringError())
+
+      // Act
+      const actual = pageService.extractPathInfo("")
+
+      // Assert
+      expect(actual).toEqual(expected)
+    })
+  })
+  describe("retrieveStagingPermalink", () => {
+    it("should call the underlying service and return the `permalink` of the unlinked page when successful", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: UnlinkedPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "UnlinkedPage",
+      }
+      mockUnlinkedPageService.read.mockResolvedValueOnce(
+        createMockFrontMatter(MOCK_UNLINKED_PAGE_NAME)
+      )
+      const expected = ok(createMockStagingPermalink(MOCK_UNLINKED_PAGE_NAME))
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockUnlinkedPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the unlinked page could not be fetched", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: UnlinkedPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "UnlinkedPage",
+      }
+      mockUnlinkedPageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockUnlinkedPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the frontmatter of the unlinked page has no `permalink`", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: UnlinkedPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "UnlinkedPage",
+      }
+      mockUnlinkedPageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockUnlinkedPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+        }
+      )
+    })
+    it("should call the underlying service and return the `permalink` of the contact us page when successful", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: ContactUsPageName = {
+        name: Brand.fromString(CONTACT_US_FILENAME),
+        kind: "ContactUsPage",
+      }
+      mockContactUsService.read.mockResolvedValueOnce(
+        createMockFrontMatter(CONTACT_US_FILENAME)
+      )
+      const expected = ok(createMockStagingPermalink(CONTACT_US_FILENAME))
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockContactUsService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the contact us page could not be fetched", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: ContactUsPageName = {
+        name: Brand.fromString(CONTACT_US_FILENAME),
+        kind: "ContactUsPage",
+      }
+      mockContactUsService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockContactUsService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the frontmatter of the contact-us page has no `permalink`", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: ContactUsPageName = {
+        name: Brand.fromString(CONTACT_US_FILENAME),
+        kind: "ContactUsPage",
+      }
+      mockContactUsService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockContactUsService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+    })
+
+    it("should call the underlying service and return the `permalink` of the homepage when successful", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: HomepageName = {
+        name: Brand.fromString(HOMEPAGE_NAME),
+        kind: "Homepage",
+      }
+      mockHomepageService.read.mockResolvedValueOnce(
+        createMockFrontMatter(HOMEPAGE_NAME)
+      )
+      const expected = ok(createMockStagingPermalink(HOMEPAGE_NAME))
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockHomepageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the homepage could not be fetched", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: HomepageName = {
+        name: Brand.fromString(HOMEPAGE_NAME),
+        kind: "Homepage",
+      }
+      mockHomepageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockHomepageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the frontmatter of the homepage has no `permalink`", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: HomepageName = {
+        name: Brand.fromString(HOMEPAGE_NAME),
+        kind: "Homepage",
+      }
+      mockHomepageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockHomepageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE
+      )
+    })
+
+    it("should call the underlying service and return the `permalink` of the resource category page when successful", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: ResourceCategoryPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "ResourceCategoryPage",
+        resourceCategory: MOCK_RESOURCE_CATEGORY_NAME,
+        resourceRoom: Brand.fromString(MOCK_RESOURCE_ROOM_NAME),
+      }
+      mockResourcePageService.read.mockResolvedValueOnce(
+        createMockFrontMatter(MOCK_UNLINKED_PAGE_NAME)
+      )
+      const expected = ok(createMockStagingPermalink(MOCK_UNLINKED_PAGE_NAME))
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          resourceCategoryName: MOCK_PAGE_NAME.resourceCategory,
+          resourceRoomName: MOCK_PAGE_NAME.resourceRoom,
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the resource category page could not be fetched", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: ResourceCategoryPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "ResourceCategoryPage",
+        resourceCategory: MOCK_RESOURCE_CATEGORY_NAME,
+        resourceRoom: Brand.fromString(MOCK_RESOURCE_ROOM_NAME),
+      }
+      mockResourcePageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          resourceCategoryName: MOCK_PAGE_NAME.resourceCategory,
+          resourceRoomName: MOCK_PAGE_NAME.resourceRoom,
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the frontmatter of the resource category page has no `permalink`", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: ResourceCategoryPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "ResourceCategoryPage",
+        resourceCategory: MOCK_RESOURCE_CATEGORY_NAME,
+        resourceRoom: Brand.fromString(MOCK_RESOURCE_ROOM_NAME),
+      }
+      mockResourcePageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockResourcePageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          resourceCategoryName: MOCK_PAGE_NAME.resourceCategory,
+          resourceRoomName: MOCK_PAGE_NAME.resourceRoom,
+        }
+      )
+    })
+
+    it("should call the underlying service and return the `permalink` of the subcollection page when successful", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: SubcollectionPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "SubcollectionPage",
+        collection: MOCK_COLLECTION_NAME,
+        subcollection: Brand.fromString(MOCK_SUBCOLLECTION_NAME),
+      }
+      mockSubcollectionPageService.read.mockResolvedValueOnce(
+        createMockFrontMatter(MOCK_UNLINKED_PAGE_NAME)
+      )
+      const expected = ok(createMockStagingPermalink(MOCK_UNLINKED_PAGE_NAME))
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockSubcollectionPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          collectionName: MOCK_PAGE_NAME.collection.slice(1),
+          subcollectionName: MOCK_PAGE_NAME.subcollection,
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the subcollection page could not be fetched", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: SubcollectionPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "SubcollectionPage",
+        collection: MOCK_COLLECTION_NAME,
+        subcollection: Brand.fromString(MOCK_SUBCOLLECTION_NAME),
+      }
+      mockSubcollectionPageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockSubcollectionPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          collectionName: MOCK_PAGE_NAME.collection.slice(1),
+          subcollectionName: MOCK_PAGE_NAME.subcollection,
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the frontmatter of the subcollection page has no `permalink`", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: SubcollectionPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "SubcollectionPage",
+        collection: MOCK_COLLECTION_NAME,
+        subcollection: Brand.fromString(MOCK_SUBCOLLECTION_NAME),
+      }
+      mockSubcollectionPageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockSubcollectionPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          collectionName: MOCK_PAGE_NAME.collection.slice(1),
+          subcollectionName: MOCK_PAGE_NAME.subcollection,
+        }
+      )
+    })
+
+    it("should call the underlying service and return the `permalink` of the collection page when successful", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: CollectionPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "CollectionPage",
+        collection: MOCK_COLLECTION_NAME,
+      }
+      mockCollectionPageService.read.mockResolvedValueOnce(
+        createMockFrontMatter(MOCK_UNLINKED_PAGE_NAME)
+      )
+      const expected = ok(createMockStagingPermalink(MOCK_UNLINKED_PAGE_NAME))
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockCollectionPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          collectionName: MOCK_PAGE_NAME.collection.slice(1),
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the collection page could not be fetched", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: CollectionPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "CollectionPage",
+        collection: MOCK_COLLECTION_NAME,
+      }
+      mockCollectionPageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockCollectionPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          collectionName: MOCK_PAGE_NAME.collection.slice(1),
+        }
+      )
+    })
+
+    it("should call the underlying service and return a `BaseIsomerError` when the frontmatter of the collection page has no `permalink`", async () => {
+      // Arrange
+      const MOCK_PAGE_NAME: CollectionPageName = {
+        name: Brand.fromString(MOCK_UNLINKED_PAGE_NAME),
+        kind: "CollectionPage",
+        collection: MOCK_COLLECTION_NAME,
+      }
+      mockCollectionPageService.read.mockRejectedValueOnce({})
+      const expected = err(new BaseIsomerError())
+
+      // Act
+      const actual = await pageService.retrieveStagingPermalink(
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_STAGING_URL_GITHUB,
+        MOCK_PAGE_NAME
+      )
+
+      // Assert
+      expect(actual).toEqual(expected)
+      expect(mockCollectionPageService.read).toHaveBeenCalledWith(
+        MOCK_USER_SESSION_DATA_ONE,
+        {
+          fileName: MOCK_PAGE_NAME.name,
+          collectionName: MOCK_PAGE_NAME.collection.slice(1),
+        }
+      )
+    })
+  })
+})

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -185,8 +185,7 @@ describe("PageService", () => {
       const MOCK_RESOURCE_ITEM = `${MOCK_RESOURCE_ROOM_NAME}/${MOCK_RESOURCE_CATEGORY_NAME}/_posts/${MOCK_UNLINKED_PAGE_NAME}`
       const expected = err(
         new NotFoundError(
-          `Error when parsing path: 
-          ${MOCK_RESOURCE_ITEM.split("/").slice(
+          `Error when parsing path: ${MOCK_RESOURCE_ITEM.split("/").slice(
             0,
             -1
           )}, please ensure that the file exists!`

--- a/src/types/pages.ts
+++ b/src/types/pages.ts
@@ -17,7 +17,7 @@ export type ResourceRoomName = {
 export type SubcollectionPageName = {
   name: string & { __kind: "SubcollectionPage" }
   collection: string
-  subCollection: string
+  subcollection: string
   kind: "SubcollectionPage"
 }
 


### PR DESCRIPTION
## Problem
previously, `PageService` had no associated tests; this PR add the tests in. 

## Solution
1. write unit tests for `pageService`
    - the unit tests are centered around `parsePageName` together with `retrieveStagingPermalink`; the invariants that we want to guarantee will be briefly outlined below
    - for static pages (pages whose name are **always fixed**), maintain the invariant that only that specified filepath can be parsed into that name
    - guarantee that for resource rooms, we will only get permalink for posts 
    - recursive descent (ie, the order in which we attempt to parse is fixed) 
    - note that filepaths terminating in `/` will **not** have a name property - consistent w/ how directories behave; we could extend our model to also parse directories but this is not done at present. this should also not be possible if we are receiving from the fe