### PR TITLE
fix(usersservice): remove explicit `findOrCreate` calls

### DIFF
--- a/src/services/identity/UsersService.ts
+++ b/src/services/identity/UsersService.ts
@@ -63,20 +63,37 @@ class UsersService {
     await this.repository.update(user, { where: { githubId } })
   }
 
-  async findOrCreate(githubId: string | undefined) {
-    const [user] = await this.repository.findOrCreate({
-      where: { githubId },
+  async findOrCreate(githubId: string | undefined): Promise<User> {
+    return this.sequelize.transaction<User>(async (transaction) => {
+      const existingUser = await this.repository.findOne({
+        where: { githubId },
+        transaction,
+      })
+
+      if (existingUser) return existingUser
+
+      return this.repository.create({
+        githubId,
+        transaction,
+      })
     })
-    return user
   }
 
   async login(githubId: string): Promise<User> {
     return this.sequelize.transaction<User>(async (transaction) => {
       // NOTE: The service's findOrCreate is not being used here as this requires an explicit transaction
-      const [user] = await this.repository.findOrCreate({
+      let user = await this.repository.findOne({
         where: { githubId },
         transaction,
       })
+
+      if (!user) {
+        user = await this.repository.create({
+          githubId,
+          transaction,
+        })
+      }
+
       user.lastLoggedIn = new Date()
       return user.save({ transaction })
     })

--- a/src/services/identity/UsersService.ts
+++ b/src/services/identity/UsersService.ts
@@ -63,22 +63,6 @@ class UsersService {
     await this.repository.update(user, { where: { githubId } })
   }
 
-  async findOrCreate(githubId: string | undefined): Promise<User> {
-    return this.sequelize.transaction<User>(async (transaction) => {
-      const existingUser = await this.repository.findOne({
-        where: { githubId },
-        transaction,
-      })
-
-      if (existingUser) return existingUser
-
-      return this.repository.create({
-        githubId,
-        transaction,
-      })
-    })
-  }
-
   async login(githubId: string): Promise<User> {
     return this.sequelize.transaction<User>(async (transaction) => {
       // NOTE: The service's findOrCreate is not being used here as this requires an explicit transaction

--- a/src/services/identity/__tests__/UsersService.spec.ts
+++ b/src/services/identity/__tests__/UsersService.spec.ts
@@ -89,46 +89,6 @@ describe("User Service", () => {
     })
   })
 
-  it("should return the result of calling the `findOne` method by githubId on the db model if the user exists", async () => {
-    // Arrange
-    const expected = "user1"
-    MockRepository.findOne.mockResolvedValue(expected)
-
-    // Act
-    const actual = await UsersService.findOrCreate(mockGithubId)
-
-    // Assert
-    expect(actual).toBe(expected)
-    expect(MockRepository.findOne).toBeCalledWith({
-      where: { githubId: mockGithubId },
-      transaction: "transaction",
-    })
-    expect(MockRepository.create).not.toBeCalled()
-    expect(MockSequelize.transaction).toBeCalled()
-  })
-
-  it("should call both `findOne` and `create` with githubId on the db model if the user does not exist", async () => {
-    // Arrange
-    const expected = "user1"
-    MockRepository.findOne.mockResolvedValue(null)
-    MockRepository.create.mockResolvedValue(expected)
-
-    // Act
-    const actual = await UsersService.findOrCreate(mockGithubId)
-
-    // Assert
-    expect(actual).toBe(expected)
-    expect(MockRepository.findOne).toBeCalledWith({
-      where: { githubId: mockGithubId },
-      transaction: "transaction",
-    })
-    expect(MockRepository.create).toBeCalledWith({
-      githubId: mockGithubId,
-      transaction: "transaction",
-    })
-    expect(MockSequelize.transaction).toBeCalled()
-  })
-
   it("should return the result of calling the underlying `findOne` method on the db model when the user exists and set the lastLoggedIn", async () => {
     // Arrange
     const mockDbUser = {

--- a/src/services/identity/__tests__/UsersService.spec.ts
+++ b/src/services/identity/__tests__/UsersService.spec.ts
@@ -22,7 +22,7 @@ const MockSmsClient = {
 const MockRepository = {
   findOne: jest.fn(),
   update: jest.fn(),
-  findOrCreate: jest.fn(),
+  create: jest.fn(),
 }
 const MockSequelize = {
   transaction: jest.fn((closure) => closure("transaction")),
@@ -89,28 +89,53 @@ describe("User Service", () => {
     })
   })
 
-  it("should return the result of calling the findOrCreate method by githubId on the db model", async () => {
+  it("should return the result of calling the `findOne` method by githubId on the db model if the user exists", async () => {
     // Arrange
     const expected = "user1"
-    MockRepository.findOrCreate.mockResolvedValue([expected])
+    MockRepository.findOne.mockResolvedValue(expected)
 
     // Act
     const actual = await UsersService.findOrCreate(mockGithubId)
 
     // Assert
     expect(actual).toBe(expected)
-    expect(MockRepository.findOrCreate).toBeCalledWith({
+    expect(MockRepository.findOne).toBeCalledWith({
       where: { githubId: mockGithubId },
+      transaction: "transaction",
     })
+    expect(MockRepository.create).not.toBeCalled()
+    expect(MockSequelize.transaction).toBeCalled()
   })
 
-  it("should return the result of calling the underlying findOrCreate method on the db model and set the lastLoggedIn", async () => {
+  it("should call both `findOne` and `create` with githubId on the db model if the user does not exist", async () => {
+    // Arrange
+    const expected = "user1"
+    MockRepository.findOne.mockResolvedValue(null)
+    MockRepository.create.mockResolvedValue(expected)
+
+    // Act
+    const actual = await UsersService.findOrCreate(mockGithubId)
+
+    // Assert
+    expect(actual).toBe(expected)
+    expect(MockRepository.findOne).toBeCalledWith({
+      where: { githubId: mockGithubId },
+      transaction: "transaction",
+    })
+    expect(MockRepository.create).toBeCalledWith({
+      githubId: mockGithubId,
+      transaction: "transaction",
+    })
+    expect(MockSequelize.transaction).toBeCalled()
+  })
+
+  it("should return the result of calling the underlying `findOne` method on the db model when the user exists and set the lastLoggedIn", async () => {
     // Arrange
     const mockDbUser = {
       save: jest.fn().mockReturnThis(),
       githubId: mockGithubId,
     }
-    MockRepository.findOrCreate.mockResolvedValue([mockDbUser])
+    MockRepository.findOne.mockResolvedValue(mockDbUser)
 
     // Act
     const actual = await UsersService.login(mockGithubId)
@@ -118,6 +143,38 @@ describe("User Service", () => {
     // Assert
     expect(actual.lastLoggedIn).toBeDefined()
     expect(actual.githubId).toBe(mockGithubId)
+    expect(MockRepository.create).not.toBeCalled()
+    expect(MockRepository.findOne).toBeCalledWith({
+      where: { githubId: mockGithubId },
+      transaction: "transaction",
+    })
+    expect(MockSequelize.transaction).toBeCalled()
+  })
+
+  it("should call both `findOne` and `create` on the db model when the user does not exist and set the lastLoggedIn", async () => {
+    // Arrange
+    const mockDbUser = {
+      save: jest.fn().mockReturnThis(),
+      githubId: mockGithubId,
+    }
+    MockRepository.findOne.mockResolvedValue(null)
+    MockRepository.create.mockResolvedValue(mockDbUser)
+
+    // Act
+    const actual = await UsersService.login(mockGithubId)
+
+    // Assert
+    expect(actual.lastLoggedIn).toBeDefined()
+    expect(actual.githubId).toBe(mockGithubId)
+    expect(MockRepository.create).toBeCalledWith({
+      githubId: mockGithubId,
+      transaction: "transaction",
+    })
+    expect(MockRepository.findOne).toBeCalledWith({
+      where: { githubId: mockGithubId },
+      transaction: "transaction",
+    })
+    expect(MockSequelize.transaction).toBeCalled()
   })
 
   it("should allow whitelisted emails", async () => {


### PR DESCRIPTION
## Problem
See #592 for an overview of the issue

Closes #592

## Solution
1. remove explicit calls of `findOrCreate` on our db model. instead, this has been replaced with explicit calls to both `findOne` and `create`, which are both wrapped into a single txn to ensure atomicity + consistency
2. test cases updated to ensure that we call explicit methods + use the txn 