### PR TITLE
chore(mediafileservice): prevent users from changing file ext

### DIFF
--- a/src/routes/v2/authenticatedSites/contactUs.js
+++ b/src/routes/v2/authenticatedSites/contactUs.js
@@ -22,7 +22,6 @@ class ContactUsRouter {
   async readContactUs(req, res) {
     const { siteName } = req.params
     const { accessToken } = res.locals
-    console.log(accessToken)
 
     const readResp = await this.contactUsPageService.read({
       siteName,

--- a/src/services/fileServices/MdPageServices/MediaFileService.js
+++ b/src/services/fileServices/MdPageServices/MediaFileService.js
@@ -1,6 +1,8 @@
 const { BadRequestError } = require("@errors/BadRequestError")
 const { MediaTypeError } = require("@errors/MediaTypeError")
 
+const { getFileExt } = require("@root/utils/files")
+
 const { GITHUB_ORG_NAME } = process.env
 
 const { validateAndSanitizeFileUpload } = require("@utils/file-upload-utils")
@@ -109,6 +111,14 @@ class MediaFileService {
   async rename(reqDetails, { oldFileName, newFileName, directoryName, sha }) {
     this.mediaNameChecks({ directoryName, fileName: oldFileName })
     this.mediaNameChecks({ directoryName, fileName: newFileName })
+    const oldExt = getFileExt(oldFileName)
+    const newExt = getFileExt(newFileName)
+
+    if (oldExt !== newExt) {
+      throw new BadRequestError(
+        "Please ensure that the file extension stays the same when renaming!"
+      )
+    }
 
     const gitTree = await this.gitHubService.getTree(reqDetails, {
       isRecursive: true,

--- a/src/services/fileServices/MdPageServices/MediaFileService.js
+++ b/src/services/fileServices/MdPageServices/MediaFileService.js
@@ -5,7 +5,10 @@ const { getFileExt } = require("@root/utils/files")
 
 const { GITHUB_ORG_NAME } = process.env
 
-const { validateAndSanitizeFileUpload } = require("@utils/file-upload-utils")
+const {
+  validateAndSanitizeFileUpload,
+  ALLOWED_FILE_EXTENSIONS,
+} = require("@utils/file-upload-utils")
 
 const { isMediaPathValid } = require("@validators/validators")
 
@@ -117,6 +120,12 @@ class MediaFileService {
     if (oldExt !== newExt) {
       throw new BadRequestError(
         "Please ensure that the file extension stays the same when renaming!"
+      )
+    }
+
+    if (!ALLOWED_FILE_EXTENSIONS.includes(oldExt)) {
+      throw new BadRequestError(
+        "Please ensure that the file extension chosen is valid!"
       )
     }
 

--- a/src/services/fileServices/MdPageServices/MediaFileService.js
+++ b/src/services/fileServices/MdPageServices/MediaFileService.js
@@ -1,8 +1,6 @@
 const { BadRequestError } = require("@errors/BadRequestError")
 const { MediaTypeError } = require("@errors/MediaTypeError")
 
-const { getFileExt } = require("@root/utils/files")
-
 const { GITHUB_ORG_NAME } = process.env
 
 const {
@@ -11,6 +9,8 @@ const {
 } = require("@utils/file-upload-utils")
 
 const { isMediaPathValid } = require("@validators/validators")
+
+const { getFileExt } = require("@root/utils/files")
 
 class MediaFileService {
   constructor({ gitHubService }) {

--- a/src/services/fileServices/MdPageServices/ResourcePageService.js
+++ b/src/services/fileServices/MdPageServices/ResourcePageService.js
@@ -12,7 +12,7 @@ class ResourcePageService {
     this.gitHubService = gitHubService
   }
 
-  retrieveResourceFileMetadata(fileName) {
+  validateAndRetrieveResourceFileMetadata(fileName) {
     const fileNameArray = fileName.split(".md")[0]
     const tokenArray = fileNameArray.split("-")
     const date = tokenArray.slice(0, 3).join("-")
@@ -40,7 +40,7 @@ class ResourcePageService {
     reqDetails,
     { fileName, resourceRoomName, resourceCategoryName, content, frontMatter }
   ) {
-    const { title } = this.retrieveResourceFileMetadata(fileName)
+    this.validateAndRetrieveResourceFileMetadata(fileName)
     const parsedDirectoryName = this.getResourceDirectoryPath({
       resourceRoomName,
       resourceCategoryName,
@@ -130,6 +130,7 @@ class ResourcePageService {
       sha,
     }
   ) {
+    this.validateAndRetrieveResourceFileMetadata(newFileName)
     const parsedDirectoryName = this.getResourceDirectoryPath({
       resourceRoomName,
       resourceCategoryName,

--- a/src/services/fileServices/MdPageServices/ResourcePageService.js
+++ b/src/services/fileServices/MdPageServices/ResourcePageService.js
@@ -130,7 +130,6 @@ class ResourcePageService {
       sha,
     }
   ) {
-    const { title } = this.retrieveResourceFileMetadata(newFileName)
     const parsedDirectoryName = this.getResourceDirectoryPath({
       resourceRoomName,
       resourceCategoryName,

--- a/src/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
@@ -31,10 +31,13 @@ describe("Media File Service", () => {
     validateAndSanitizeFileUpload: jest
       .fn()
       .mockReturnValue(mockSanitizedContent),
+    ALLOWED_FILE_EXTENSIONS: ["pdf"],
   }))
+
   const {
     MediaFileService,
   } = require("@services/fileServices/MdPageServices/MediaFileService")
+
   const service = new MediaFileService({
     gitHubService: mockGithubService,
   })

--- a/src/utils/file-upload-utils.js
+++ b/src/utils/file-upload-utils.js
@@ -6,7 +6,7 @@ const { JSDOM } = require("jsdom")
 const { window } = new JSDOM("")
 const DOMPurify = createDOMPurify(window)
 
-const ALLOWED_FILE_EXTENSIONS = [
+export const ALLOWED_FILE_EXTENSIONS = [
   "pdf",
   "png",
   "jpg",

--- a/src/utils/file-upload-utils.js
+++ b/src/utils/file-upload-utils.js
@@ -6,7 +6,7 @@ const { JSDOM } = require("jsdom")
 const { window } = new JSDOM("")
 const DOMPurify = createDOMPurify(window)
 
-export const ALLOWED_FILE_EXTENSIONS = [
+const ALLOWED_FILE_EXTENSIONS = [
   "pdf",
   "png",
   "jpg",
@@ -35,4 +35,4 @@ const validateAndSanitizeFileUpload = async (data) => {
   return undefined
 }
 
-module.exports = { validateAndSanitizeFileUpload }
+module.exports = { validateAndSanitizeFileUpload, ALLOWED_FILE_EXTENSIONS }

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,3 +1,3 @@
 export const getFileExt = (fileName: string): string =>
   // NOTE: will never be `undefined` as `fileName` is guaranteed to be a string
-  fileName.split(".").shift()!
+  fileName.split(".").pop()!

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,2 +1,3 @@
-export const getFileExt = (fileName: string): string | undefined =>
-  fileName.split(".").shift()
+export const getFileExt = (fileName: string): string =>
+  // NOTE: will never be `undefined` as `fileName` is guaranteed to be a string
+  fileName.split(".").shift()!

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,0 +1,2 @@
+export const getFileExt = (fileName: string): string | undefined =>
+  fileName.split(".").shift()


### PR DESCRIPTION
## Problem
See the notion [link](https://www.notion.so/opengov/VAPT-Remediation-c604c62d822e4023be266c5a293d3a1e) for an overview 

## Solution
1. prevent users from renaming unless the old extension and the new extension are the same. because we disallow creation of files unless they have certain extensions (`file-upload-utils` defines `ALLOWED_FILE_EXTENSIONS`), this means that existing files already have valid extensions. now, we force the old/new ext to be the same, which implies that we only ever go from existing valid ext -> new valid ext. 
