### PR TITLE
Fix/frontmatter for link resources

### DIFF
--- a/src/utils/markdown-utils.js
+++ b/src/utils/markdown-utils.js
@@ -18,13 +18,12 @@ const isResourceFileOrLink = (frontMatter) => {
 
 const convertDataToMarkdown = (originalFrontMatter, pageContent) => {
   const frontMatter = _.clone(originalFrontMatter)
+  if (isResourceFileOrLink(frontMatter)) {
+    delete frontMatter.permalink
+  }
   const { permalink } = frontMatter
   if (permalink) {
-    if (isResourceFileOrLink(frontMatter)) {
-      delete frontMatter.permalink
-    } else {
-      frontMatter.permalink = getTrailingSlashWithPermalink(permalink)
-    }
+    frontMatter.permalink = getTrailingSlashWithPermalink(permalink)
   }
   const newFrontMatter = yaml.stringify(frontMatter)
   const newContent = ["---\n", newFrontMatter, "---\n", pageContent].join("")

--- a/src/utils/markdown-utils.js
+++ b/src/utils/markdown-utils.js
@@ -11,11 +11,20 @@ const retrieveDataFromMarkdown = (fileContent) => {
   return { frontMatter, pageContent: pageContent.join("---") }
 }
 
+const isResourceFileOrLink = (frontMatter) => {
+  const { layout } = frontMatter
+  return layout === "file" || layout === "link"
+}
+
 const convertDataToMarkdown = (originalFrontMatter, pageContent) => {
   const frontMatter = _.clone(originalFrontMatter)
   const { permalink } = frontMatter
   if (permalink) {
-    frontMatter.permalink = getTrailingSlashWithPermalink(permalink)
+    if (isResourceFileOrLink(frontMatter)) {
+      delete frontMatter.permalink
+    } else {
+      frontMatter.permalink = getTrailingSlashWithPermalink(permalink)
+    }
   }
   const newFrontMatter = yaml.stringify(frontMatter)
   const newContent = ["---\n", newFrontMatter, "---\n", pageContent].join("")

--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -106,6 +106,7 @@ const ResourceFrontMatterSchema = Joi.object({
   permalink: Joi.string(),
   layout: Joi.string().valid("post", "file", "link"),
   file_url: Joi.string(),
+  external: Joi.string(),
 }).unknown(true)
 
 const ResourceContentSchema = Joi.object({


### PR DESCRIPTION
This PR adds the `external` param to the front matter of link resources. Previously, as `permalink` is used by jekyll to determine the files to build, any permalinks with `#` or `?` would cause a build error with jekyll, which disallows those files. This PR also modifies the handling of resource frontmatter to delete permalinks from resources of type 'file' or 'link' to prevent unintended behaviour. To be reviewed in conjunction with https://github.com/isomerpages/isomercms-frontend/pull/1174 and https://github.com/isomerpages/isomerpages-template/pull/285