### PR TITLE
Fix: use new resource room name when renaming

### DIFF
--- a/src/services/directoryServices/ResourceRoomDirectoryService.js
+++ b/src/services/directoryServices/ResourceRoomDirectoryService.js
@@ -105,7 +105,7 @@ class ResourceRoomDirectoryService {
       fileContent: newContent,
       sha,
       fileName: INDEX_FILE_NAME,
-      directoryName: resourceRoomName,
+      directoryName: slugifiedNewResourceRoomName,
     })
 
     const {


### PR DESCRIPTION
This PR fixes a bug in resource renaming - previously we were updating the index file in the location of the old resource room folder instead of the new resource room, which caused the old resource room directory to continue existing - this caused issues for users who attempted to rename a resource room to something they had used before. The name in the `index.html` of the new resource room directory would also be incorrect (using the old name instead). This PR fixes this issue.