### PR TITLE
fix(server): shift api logger to be initialised within each subrouter

### DIFF
--- a/src/routes/v1/authenticated/index.js
+++ b/src/routes/v1/authenticated/index.js
@@ -3,14 +3,20 @@ const express = require("express")
 const sitesRouter = require("@routes/v1/authenticated/sites")
 const { UsersRouter } = require("@routes/v2/authenticated/users")
 
-const getAuthenticatedSubrouter = ({ authMiddleware, usersService }) => {
+const getAuthenticatedSubrouter = ({
+  authMiddleware,
+  usersService,
+  apiLogger,
+}) => {
   // Workaround - no v1 users router exists
   const usersRouter = new UsersRouter({ usersService })
 
   const authenticatedSubrouter = express.Router({ mergeParams: true })
 
   authenticatedSubrouter.use(authMiddleware.verifyJwt)
-
+  // NOTE: apiLogger needs to be after `verifyJwt` as it logs the github username
+  // which is only available after verifying that the jwt is valid
+  authenticatedSubrouter.use(apiLogger)
   authenticatedSubrouter.use("/sites", sitesRouter)
   authenticatedSubrouter.use("/user", usersRouter.getRouter())
 

--- a/src/routes/v1/authenticatedSites/index.js
+++ b/src/routes/v1/authenticatedSites/index.js
@@ -16,11 +16,14 @@ const resourceRoomRouter = require("@routes/v1/authenticatedSites/resourceRoom")
 const resourcesRouter = require("@routes/v1/authenticatedSites/resources")
 const settingsRouter = require("@routes/v1/authenticatedSites/settings")
 
-const getAuthenticatedSitesSubrouter = ({ authMiddleware }) => {
+const getAuthenticatedSitesSubrouter = ({ authMiddleware, apiLogger }) => {
   const authenticatedSitesSubrouter = express.Router({ mergeParams: true })
 
   authenticatedSitesSubrouter.use(authMiddleware.verifyJwt)
   authenticatedSitesSubrouter.use(authMiddleware.useSiteAccessTokenIfAvailable)
+  // NOTE: apiLogger needs to be after `verifyJwt` as it logs the github username
+  // which is only available after verifying that the jwt is valid
+  authenticatedSitesSubrouter.use(apiLogger)
 
   authenticatedSitesSubrouter.use("/pages", pagesRouter)
   authenticatedSitesSubrouter.use("/collections", collectionsRouter)

--- a/src/routes/v2/auth.js
+++ b/src/routes/v2/auth.js
@@ -16,9 +16,10 @@ const CSRF_COOKIE_NAME = "isomer-csrf"
 const COOKIE_NAME = "isomercms"
 
 class AuthRouter {
-  constructor({ authService, authMiddleware }) {
+  constructor({ authService, authMiddleware, apiLogger }) {
     this.authService = authService
     this.authMiddleware = authMiddleware
+    this.apiLogger = apiLogger
     // We need to bind all methods because we don't invoke them from the class directly
     autoBind(this)
   }
@@ -90,6 +91,7 @@ class AuthRouter {
 
   getRouter() {
     const router = express.Router()
+    router.use(this.apiLogger)
 
     router.get(
       "/github-redirect",

--- a/src/routes/v2/authenticated/index.js
+++ b/src/routes/v2/authenticated/index.js
@@ -1,5 +1,3 @@
-import InfraService from "@services/infra/InfraService"
-
 const express = require("express")
 
 const {
@@ -16,6 +14,7 @@ const getAuthenticatedSubrouter = ({
   gitHubService,
   configYmlService,
   usersService,
+  apiLogger,
 }) => {
   const sitesService = new SitesService({ gitHubService, configYmlService })
   const netlifyTomlService = new NetlifyTomlService()
@@ -27,6 +26,9 @@ const getAuthenticatedSubrouter = ({
   const authenticatedSubrouter = express.Router({ mergeParams: true })
 
   authenticatedSubrouter.use(authMiddleware.verifyJwt)
+  // NOTE: apiLogger needs to be after `verifyJwt` as it logs the github username
+  // which is only available after verifying that the jwt is valid
+  authenticatedSubrouter.use(apiLogger)
 
   authenticatedSubrouter.use("/sites", sitesV2Router.getRouter())
   authenticatedSubrouter.use("/user", usersRouter.getRouter())

--- a/src/routes/v2/authenticatedSites/index.js
+++ b/src/routes/v2/authenticatedSites/index.js
@@ -85,6 +85,7 @@ const getAuthenticatedSitesSubrouter = ({
   authMiddleware,
   gitHubService,
   configYmlService,
+  apiLogger,
 }) => {
   const collectionYmlService = new CollectionYmlService({ gitHubService })
   const homepagePageService = new HomepagePageService({ gitHubService })
@@ -186,6 +187,9 @@ const getAuthenticatedSitesSubrouter = ({
 
   authenticatedSitesSubrouter.use(authMiddleware.verifyJwt)
   authenticatedSitesSubrouter.use(authMiddleware.useSiteAccessTokenIfAvailable)
+  // NOTE: apiLogger needs to be after `verifyJwt` as it logs the github username
+  // which is only available after verifying that the jwt is valid
+  authenticatedSitesSubrouter.use(apiLogger)
 
   authenticatedSitesSubrouter.use(
     "/collections/:collectionName",

--- a/src/server.js
+++ b/src/server.js
@@ -131,7 +131,7 @@ const authenticatedSitesSubrouterV2 = getAuthenticatedSitesSubrouter({
   configYmlService,
   apiLogger,
 })
-const authV2Router = new AuthRouter({ authMiddleware, authService })
+const authV2Router = new AuthRouter({ authMiddleware, authService, apiLogger })
 const formsgRouter = new FormsgRouter({ usersService, infraService })
 const formsgSiteLaunchRouter = new FormsgSiteLaunchRouter({
   usersService,

--- a/src/server.js
+++ b/src/server.js
@@ -28,6 +28,7 @@ import QueueService from "@services/identity/QueueService"
 import ReposService from "@services/identity/ReposService"
 import InfraService from "@services/infra/InfraService"
 
+import { apiLogger } from "./middleware/apiLogger"
 import getAuthenticatedSubrouterV1 from "./routes/v1/authenticated"
 import getAuthenticatedSitesSubrouterV1 from "./routes/v1/authenticatedSites"
 import getAuthenticatedSubrouter from "./routes/v2/authenticated"
@@ -62,7 +63,6 @@ const { FRONTEND_URL } = process.env
 // Import middleware
 
 // Import routes
-const { apiLogger } = require("@middleware/apiLogger")
 const { errorHandler } = require("@middleware/errorHandler")
 
 const { FormsgRouter } = require("@routes/formsgSiteCreation")
@@ -109,9 +109,11 @@ const authMiddleware = getAuthMiddleware({ identityAuthService })
 const authenticatedSubrouterV1 = getAuthenticatedSubrouterV1({
   authMiddleware,
   usersService,
+  apiLogger,
 })
 const authenticatedSitesSubrouterV1 = getAuthenticatedSitesSubrouterV1({
   authMiddleware,
+  apiLogger,
 })
 
 const authenticatedSubrouterV2 = getAuthenticatedSubrouter({
@@ -121,11 +123,13 @@ const authenticatedSubrouterV2 = getAuthenticatedSubrouter({
   usersService,
   reposService,
   deploymentsService,
+  apiLogger,
 })
 const authenticatedSitesSubrouterV2 = getAuthenticatedSitesSubrouter({
   authMiddleware,
   gitHubService,
   configYmlService,
+  apiLogger,
 })
 const authV2Router = new AuthRouter({ authMiddleware, authService })
 const formsgRouter = new FormsgRouter({ usersService, infraService })
@@ -147,9 +151,6 @@ app.use(express.json({ limit: "7mb" }))
 app.use(express.urlencoded({ extended: false }))
 app.use(cookieParser())
 app.use(express.static(path.join(__dirname, "public")))
-
-// Log api requests
-app.use(apiLogger)
 
 // Health endpoint
 app.use("/v2/ping", (req, res, next) => res.status(200).send("Ok"))


### PR DESCRIPTION
## Problem
Previously, our logs weren't capturing the github username of the isomer user. This led to the github id being logged as `undefined` in our logs.

Closes #620 

## Solution
Change `apiLogger` to be initialised after `verifyJwt`; this was done through making it a dependency of the required routers (rather than importing) to keep in line w/ existing code conventions