### PR TITLE
feat: add webp to allowed images

### DIFF
--- a/src/utils/file-upload-utils.js
+++ b/src/utils/file-upload-utils.js
@@ -14,6 +14,7 @@ const ALLOWED_FILE_EXTENSIONS = [
   "tif",
   "bmp",
   "ico",
+  "webp",
 ]
 
 const validateAndSanitizeFileUpload = async (data) => {


### PR DESCRIPTION
This PR adds in webp as an allowed format for images that can be uploaded in Isomer. To be reviewed in conjunction with PR [#1180](https://github.com/isomerpages/isomercms-frontend/pull/1180) on the isomercms-frontend repo.