### PR TITLE
Fix/make login response indistinguishable

### DIFF
--- a/src/routes/v2/auth.js
+++ b/src/routes/v2/auth.js
@@ -81,7 +81,7 @@ class AuthRouter {
       await this.authService.sendOtp(email)
     } catch (err) {
       // Log, but don't return so responses are indistinguishable
-      logger.log(
+      logger.error(
         `Error occurred when attempting to login user ${email}: ${err}`
       )
     }

--- a/src/routes/v2/auth.js
+++ b/src/routes/v2/auth.js
@@ -7,6 +7,8 @@ const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
 const { FRONTEND_URL } = process.env
 const { isSecure } = require("@utils/auth-utils")
 
+const logger = require("@root/logger/logger")
+
 const AUTH_TOKEN_EXPIRY_MS = parseInt(
   process.env.AUTH_TOKEN_EXPIRY_DURATION_IN_MILLISECONDS,
   10
@@ -75,7 +77,14 @@ class AuthRouter {
   async login(req, res) {
     const { email: rawEmail } = req.body
     const email = rawEmail.toLowerCase()
-    await this.authService.sendOtp(email)
+    try {
+      await this.authService.sendOtp(email)
+    } catch (err) {
+      // Log, but don't return so responses are indistinguishable
+      logger.log(
+        `Error occurred when attempting to login user ${email}: ${err}`
+      )
+    }
     return res.sendStatus(200)
   }
 

--- a/src/services/identity/SmsClient.ts
+++ b/src/services/identity/SmsClient.ts
@@ -36,7 +36,7 @@ class SmsClient {
     try {
       await this.axiosClient.post(endpoint, sms)
     } catch (err) {
-      logger.error(err)
+      logger.error(`Failed to send SMS to ${recipient}: ${err}`)
       throw new Error("Failed to send SMS.")
     }
   }

--- a/src/services/utilServices/MailClient.ts
+++ b/src/services/utilServices/MailClient.ts
@@ -32,7 +32,7 @@ class MailClient {
         },
       })
     } catch (err) {
-      logger.error(err)
+      logger.error(`Error occurred when sending email to ${recipient}: ${err}`)
       throw new Error("Failed to send email.")
     }
   }


### PR DESCRIPTION
This PR modifies the handling of our otp endpoint to always return a 200 status - this serves to hide the validity of an email address that was previously exposed in the case of blacklisted emails, when an error was thrown. Additional logging on email failure has also been added in this PR.