### PR TITLE
Fix: query for site through repo

### DIFF
--- a/src/services/identity/CollaboratorsService.ts
+++ b/src/services/identity/CollaboratorsService.ts
@@ -11,7 +11,7 @@ import {
   INACTIVE_USER_THRESHOLD_DAYS,
 } from "@constants/constants"
 
-import { Whitelist, User, Site, SiteMember } from "@database/models"
+import { Whitelist, User, Site, SiteMember, Repo } from "@database/models"
 import { BadRequestError } from "@root/errors/BadRequestError"
 import { ConflictError } from "@root/errors/ConflictError"
 import logger from "@root/logger/logger"
@@ -86,7 +86,6 @@ class CollaboratorsService {
     // However, the converse is possible, i.e. we can query the Sites table and retrieve joined
     // records from the Users table, along with the SiteMember records.
     const site = await this.siteRepository.findOne({
-      where: { name: siteName },
       include: [
         {
           model: User,
@@ -94,6 +93,12 @@ class CollaboratorsService {
           attributes: {
             // Hide PII such as contactNumber
             exclude: ["contactNumber"],
+          },
+        },
+        {
+          model: Repo,
+          where: {
+            name: siteName,
           },
         },
       ],
@@ -183,11 +188,16 @@ class CollaboratorsService {
 
   delete = async (siteName: string, userId: string) => {
     const site = await this.siteRepository.findOne({
-      where: { name: siteName },
       include: [
         {
           model: User,
           as: "site_members",
+        },
+        {
+          model: Repo,
+          where: {
+            name: siteName,
+          },
         },
       ],
     })
@@ -220,13 +230,18 @@ class CollaboratorsService {
     userId: string
   ): Promise<CollaboratorRoles | null> => {
     const site = await this.siteRepository.findOne({
-      where: { name: siteName },
       include: [
         {
           model: User,
           as: "site_members",
           where: {
             id: userId,
+          },
+        },
+        {
+          model: Repo,
+          where: {
+            name: siteName,
           },
         },
       ],
@@ -241,11 +256,16 @@ class CollaboratorsService {
       inactiveLimit.getDate() - INACTIVE_USER_THRESHOLD_DAYS
     )
     const site = await this.siteRepository.findOne({
-      where: { name: siteName },
       include: [
         {
           model: User,
           as: "site_members",
+        },
+        {
+          model: Repo,
+          where: {
+            name: siteName,
+          },
         },
       ],
     })

--- a/src/services/identity/SitesService.ts
+++ b/src/services/identity/SitesService.ts
@@ -1,7 +1,7 @@
 import _ from "lodash"
 import { ModelStatic } from "sequelize"
 
-import { Deployment, Site } from "@database/models"
+import { Deployment, Repo, Site } from "@database/models"
 import type UserSessionData from "@root/classes/UserSessionData"
 import type UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import {
@@ -155,7 +155,14 @@ class SitesService {
 
   async getBySiteName(siteName: string): Promise<Site | null> {
     const site = await this.siteRepository.findOne({
-      where: { name: siteName },
+      include: [
+        {
+          model: Repo,
+          where: {
+            name: siteName,
+          },
+        },
+      ],
     })
 
     return site
@@ -245,11 +252,18 @@ class SitesService {
     const { siteName } = sessionData
 
     const site = await this.siteRepository.findOne({
-      where: { name: siteName },
-      include: {
-        model: Deployment,
-        as: "deployment",
-      },
+      include: [
+        {
+          model: Deployment,
+          as: "deployment",
+        },
+        {
+          model: Repo,
+          where: {
+            name: siteName,
+          },
+        },
+      ],
     })
 
     // Note: site may be null if the site does not exist


### PR DESCRIPTION
This PR fixes an issue where we were querying for the github repo name of a site through the `Site` table (which contains the human readable version of the name) instead of through the `Repo` table (which contains the desired string). All existing queries referencing the `Site` table for the github sitename have been changed to reference the `Repo` table instead.