### PR TITLE
fix(site creation): make rewrites to redirects

### DIFF
--- a/src/services/identity/DeploymentClient.ts
+++ b/src/services/identity/DeploymentClient.ts
@@ -69,7 +69,7 @@ class DeploymentClient {
     environmentVariables: {
       JEKYLL_ENV: "development",
     },
-    customRules: [{ source: "/<*>", target: "/404.html", status: "404-200" }],
+    customRules: [{ source: "/<*>", target: "/404.html", status: "404" }],
   })
 
   generateCreateBranchInput = (


### PR DESCRIPTION
## Problem

CSP headers are not preserved with rewrites. 

## Solution 

New sites created will have a redirect rather than a rewrite. 