### PR TITLE
Fix wrong constant in test

### DIFF
--- a/src/services/utilServices/__tests__/AuthService.spec.js
+++ b/src/services/utilServices/__tests__/AuthService.spec.js
@@ -144,11 +144,11 @@ describe("Auth Service", () => {
     const mockOtp = "123456"
     it("should be able to verify otp, login, and return token if correct", async () => {
       mockUsersService.verifyEmailOtp.mockImplementationOnce(() => true)
-      jwtUtils.signToken.mockImplementationOnce(() => signedToken)
+      jwtUtils.signToken.mockImplementationOnce(() => signedEmailToken)
 
       await expect(
         service.verifyOtp({ email: mockEmail, otp: mockOtp })
-      ).resolves.toEqual(signedToken)
+      ).resolves.toEqual(signedEmailToken)
       expect(mockUsersService.verifyEmailOtp).toHaveBeenCalledWith(
         mockEmail,
         mockOtp


### PR DESCRIPTION
## Problem

Wrong constant (`signedToken`) used instead of `signedEmailToken` which causes test in AuthService.spec.js to fail


## Solution

Replace `signedToken` with `signedEmailToken`

## Verification

Run `npm run test --runInBand AuthService.spec.js` to ensure everything passes

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible
