### PR TITLE
feat(rr): construct cms link for users

### DIFF
--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -749,7 +749,7 @@ describe("Review Requests Integration Tests", () => {
             type: ["page"],
             name: MOCK_GITHUB_FILENAME_ALPHA_ONE,
             path: [],
-            url: `${MOCK_DEPLOYMENT_DBENTRY_ONE.stagingUrl}${MOCK_PAGE_PERMALINK}`,
+            stagingUrl: `${MOCK_DEPLOYMENT_DBENTRY_ONE.stagingUrl}${MOCK_PAGE_PERMALINK}`,
             lastEditedBy: MOCK_USER_EMAIL_TWO, // TODO: This should be MOCK_USER_EMAIL_ONE
             lastEditedTime: new Date(MOCK_GITHUB_COMMIT_DATE_THREE).getTime(),
           },
@@ -757,7 +757,7 @@ describe("Review Requests Integration Tests", () => {
             type: ["page"],
             name: MOCK_GITHUB_FILENAME_ALPHA_TWO,
             path: MOCK_GITHUB_FILEPATH_ALPHA_TWO.split("/").filter((x) => x),
-            url: `${MOCK_DEPLOYMENT_DBENTRY_ONE.stagingUrl}${MOCK_PAGE_PERMALINK}`,
+            stagingUrl: `${MOCK_DEPLOYMENT_DBENTRY_ONE.stagingUrl}${MOCK_PAGE_PERMALINK}`,
             lastEditedBy: MOCK_USER_EMAIL_TWO,
             lastEditedTime: new Date(MOCK_GITHUB_COMMIT_DATE_THREE).getTime(),
           },

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -174,6 +174,8 @@ const migrateSpy = jest
   .spyOn(ReviewsRouter, "checkIfSiteIsUnmigrated")
   .mockResolvedValue(true)
 
+const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000"
+
 describe("Review Requests Integration Tests", () => {
   beforeAll(async () => {
     // NOTE: Because SitesService uses an axios instance,
@@ -264,7 +266,8 @@ describe("Review Requests Integration Tests", () => {
             type: ["page"],
             name: MOCK_GITHUB_FILENAME_ALPHA_ONE,
             path: [],
-            url: `${MOCK_DEPLOYMENT_DBENTRY_ONE.stagingUrl}${MOCK_PAGE_PERMALINK}`,
+            stagingUrl: `${MOCK_DEPLOYMENT_DBENTRY_ONE.stagingUrl}${MOCK_PAGE_PERMALINK}`,
+            fileUrl: `${FRONTEND_URL}/sites/${MOCK_REPO_NAME_ONE}/homepage`,
             lastEditedBy: MOCK_USER_EMAIL_TWO, // TODO: This should be MOCK_USER_EMAIL_ONE
             lastEditedTime: new Date(MOCK_GITHUB_COMMIT_DATE_THREE).getTime(),
           },
@@ -272,7 +275,8 @@ describe("Review Requests Integration Tests", () => {
             type: ["page"],
             name: MOCK_GITHUB_FILENAME_ALPHA_TWO,
             path: MOCK_GITHUB_FILEPATH_ALPHA_TWO.split("/").filter((x) => x),
-            url: `${MOCK_DEPLOYMENT_DBENTRY_ONE.stagingUrl}${MOCK_PAGE_PERMALINK}`,
+            stagingUrl: `${MOCK_DEPLOYMENT_DBENTRY_ONE.stagingUrl}${MOCK_PAGE_PERMALINK}`,
+            fileUrl: `${FRONTEND_URL}/sites/${MOCK_REPO_NAME_ONE}/editPage/${MOCK_GITHUB_FILENAME_ALPHA_TWO}`,
             lastEditedBy: MOCK_USER_EMAIL_TWO,
             lastEditedTime: new Date(MOCK_GITHUB_COMMIT_DATE_THREE).getTime(),
           },
@@ -750,6 +754,7 @@ describe("Review Requests Integration Tests", () => {
             name: MOCK_GITHUB_FILENAME_ALPHA_ONE,
             path: [],
             stagingUrl: `${MOCK_DEPLOYMENT_DBENTRY_ONE.stagingUrl}${MOCK_PAGE_PERMALINK}`,
+            fileUrl: `${FRONTEND_URL}/sites/${MOCK_REPO_NAME_ONE}/homepage`,
             lastEditedBy: MOCK_USER_EMAIL_TWO, // TODO: This should be MOCK_USER_EMAIL_ONE
             lastEditedTime: new Date(MOCK_GITHUB_COMMIT_DATE_THREE).getTime(),
           },
@@ -758,6 +763,7 @@ describe("Review Requests Integration Tests", () => {
             name: MOCK_GITHUB_FILENAME_ALPHA_TWO,
             path: MOCK_GITHUB_FILEPATH_ALPHA_TWO.split("/").filter((x) => x),
             stagingUrl: `${MOCK_DEPLOYMENT_DBENTRY_ONE.stagingUrl}${MOCK_PAGE_PERMALINK}`,
+            fileUrl: `${FRONTEND_URL}/sites/${MOCK_REPO_NAME_ONE}/editPage/${MOCK_GITHUB_FILENAME_ALPHA_TWO}`,
             lastEditedBy: MOCK_USER_EMAIL_TWO,
             lastEditedTime: new Date(MOCK_GITHUB_COMMIT_DATE_THREE).getTime(),
           },

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -349,7 +349,7 @@ export class PageService {
       case "SubcollectionPage": {
         return okAsync(
           `${baseUrl}/folders/${pageName.collection.slice(1)}/subfolders/${
-            pageName.subCollection
+            pageName.subcollection
           }/editPage/${pageName.name}`
         )
       }

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -361,7 +361,7 @@ export class PageService {
       default: {
         const unimplErr: never = pageName
         return errAsync(
-          new BaseIsomerError(500, `Unimplemented pagetype: ${unimplErr}`)
+          new BaseIsomerError(500, `Unimplemented page type: ${unimplErr}`)
         )
       }
     }

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -35,6 +35,8 @@ import { ResourcePageService } from "./ResourcePageService"
 import { SubcollectionPageService } from "./SubcollectionPageService"
 import { UnlinkedPageService } from "./UnlinkedPageService"
 
+const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000"
+
 // NOTE: This handler retrieves data from github then parses it
 // and it should handle the errors appropriately.
 // We return `BaseIsomerError` as a stop gap measure but in the future,
@@ -318,6 +320,51 @@ export class PageService {
       name,
       path: ok(fullPath),
     })
+  }
+
+  retrieveCmsPermalink = (
+    pageName: PageName,
+    siteName: string
+  ): ResultAsync<string, BaseIsomerError> => {
+    const baseUrl = `${FRONTEND_URL}/sites/${siteName}`
+    switch (pageName.kind) {
+      case "Homepage": {
+        return okAsync(`${baseUrl}/homepage`)
+      }
+      case "ContactUsPage": {
+        return okAsync(`${baseUrl}/contact-us`)
+      }
+      case "UnlinkedPage": {
+        return okAsync(`${baseUrl}/editPage/${pageName.name}`)
+      }
+      // NOTE: All collections are prefixed by `_` as a result of jekyll
+      // so we have to remove it
+      case "CollectionPage": {
+        return okAsync(
+          `${baseUrl}/folders/${pageName.collection.slice(1)}/editPage/${
+            pageName.name
+          }`
+        )
+      }
+      case "SubcollectionPage": {
+        return okAsync(
+          `${baseUrl}/folders/${pageName.collection.slice(1)}/subfolders/${
+            pageName.subCollection
+          }/editPage/${pageName.name}`
+        )
+      }
+      case "ResourceCategoryPage": {
+        return okAsync(
+          `${baseUrl}/resourceRoom/${pageName.resourceRoom}/resourceCategory/${pageName.resourceCategory}/editPage/${pageName.name}`
+        )
+      }
+      default: {
+        const unimplErr: never = pageName
+        return errAsync(
+          new BaseIsomerError(500, `Unimplemented pagetype: ${unimplErr}`)
+        )
+      }
+    }
   }
 
   retrieveStagingPermalink = (

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -97,8 +97,11 @@ export default class ReviewRequestService {
         // a checksum of the files contents.
         // And the actual commit sha is given by the ref param
         const sha = items[items.length - 1]
-        const url = await this.pageService
-          .parsePageName(filename, sessionData)
+        const pageNameRes = this.pageService.parsePageName(
+          filename,
+          sessionData
+        )
+        const stagingUrl = await pageNameRes
           .andThen((pageName) =>
             this.pageService.retrieveStagingPermalink(
               sessionData,
@@ -108,6 +111,11 @@ export default class ReviewRequestService {
           )
           // NOTE: We ignore the errors and use a placeholder
           .unwrapOr("")
+        const fileUrl = await pageNameRes
+          .andThen((pageName) =>
+            this.pageService.retrieveCmsPermalink(pageName, siteName)
+          )
+          .unwrapOr("")
 
         return {
           type: this.computeFileType(filename),
@@ -116,7 +124,8 @@ export default class ReviewRequestService {
           name: fullPath.pop()!,
           // NOTE: pop alters in place
           path: fullPath,
-          url,
+          stagingUrl,
+          fileUrl,
           lastEditedBy: mappings[sha]?.author || "Unknown user",
           lastEditedTime: mappings[sha]?.unixTime || 0,
         }

--- a/src/services/review/__tests__/ReviewRequestService.spec.ts
+++ b/src/services/review/__tests__/ReviewRequestService.spec.ts
@@ -1,4 +1,3 @@
-import { ReturnValue } from "aws-sdk/clients/dynamodb"
 import _ from "lodash"
 import { err, ok, okAsync } from "neverthrow"
 import { Attributes, ModelStatic } from "sequelize"
@@ -63,6 +62,7 @@ const MockPageService: {
   extractResourceRoomName: jest.fn(),
   parsePageName: jest.fn(),
   retrieveStagingPermalink: jest.fn(),
+  retrieveCmsPermalink: jest.fn(),
 }
 const MockReviewApi = {
   approvePullRequest: jest.fn(),
@@ -145,7 +145,8 @@ describe("ReviewRequestService", () => {
           type: ["page"],
           name: MOCK_PULL_REQUEST_FILE_FILENAME_ONE,
           path: [],
-          url: "www.google.com",
+          fileUrl: "www.google.com",
+          stagingUrl: "www.google.com",
           lastEditedBy: MOCK_GITHUB_NAME_ONE,
           lastEditedTime: new Date(MOCK_GITHUB_DATE_ONE).getTime(),
         },
@@ -153,7 +154,8 @@ describe("ReviewRequestService", () => {
           type: ["page"],
           name: MOCK_PULL_REQUEST_FILE_FILENAME_TWO,
           path: MOCK_COMMIT_FILEPATH_TWO.split("/"),
-          url: "www.google.com",
+          fileUrl: "www.google.com",
+          stagingUrl: "www.google.com",
           lastEditedBy: MOCK_GITHUB_NAME_TWO,
           lastEditedTime: new Date(MOCK_GITHUB_DATE_TWO).getTime(),
         },
@@ -161,6 +163,9 @@ describe("ReviewRequestService", () => {
       MockReviewApi.getCommitDiff.mockResolvedValueOnce(mockCommitDiff)
       MockPageService.parsePageName.mockReturnValue(okAsync("mock page name"))
       MockPageService.retrieveStagingPermalink.mockReturnValue(
+        okAsync("www.google.com")
+      )
+      MockPageService.retrieveCmsPermalink.mockReturnValue(
         okAsync("www.google.com")
       )
 

--- a/src/types/dto/review.ts
+++ b/src/types/dto/review.ts
@@ -8,7 +8,8 @@ export interface EditedItemDto {
   type: FileType[]
   name: string
   path: string[]
-  url: string
+  stagingUrl: string
+  fileUrl: string
   lastEditedBy: string
   lastEditedTime: number
 }


### PR DESCRIPTION
## Problem
Frontend requires a link to the cms for each page that was edited within the review request.. This PR adds that in. 

## Solution
After parsing the page, construct the cms link using the `kind` of the page and redirect teh users there