### PR TITLE
Chore(Site launch microservices):managing cloud environments

### DIFF
--- a/microservices/README.md
+++ b/microservices/README.md
@@ -1,0 +1,15 @@
+## Microservices
+
+This folder contain the microservices that are needed for the functionality of the site launch process.
+
+We do intend to move away from serverless soon in favour of Pullumi. In the interim, here are the prerequisites for deploying into the cloud.
+
+1. Run `npm install -g serverless`
+
+By the very nature of cloud development, everyone will have access to the same shared resource. If you seek to do develop in an isolated environment, please use:
+
+`npm run deploy:dev -- --stage <identifiable-unique-name>`
+
+After development, please clean up by using:
+
+`npm run destroy:dev -- --stage <identifiable-unique-name>`

--- a/microservices/package-lock.json
+++ b/microservices/package-lock.json
@@ -2207,6 +2207,45 @@
         "kuler": "^2.0.0"
       }
     },
+    "@hapi/address": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
+      "dev": true
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "dev": true
+    },
+    "@hapi/hoek": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
+      "dev": true
+    },
+    "@hapi/joi": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/topo": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^8.3.0"
+      }
+    },
     "@kwsites/file-exists": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
@@ -2749,6 +2788,16 @@
         "@types/responselike": "*"
       }
     },
+    "@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -2782,6 +2831,12 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
+    },
+    "@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
     },
     "@types/node": {
       "version": "18.11.7",
@@ -2977,6 +3032,35 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
+    },
+    "asl-path-validator": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.11.0.tgz",
+      "integrity": "sha512-2kfFkqNCXInc7d8hbUoXn/XpK5fFr3//0nh4jfcZWav0VR4zo2bYVlRCwOuNKJID9yM4vIo7dMb4n0fnWrc/Xw==",
+      "dev": true,
+      "requires": {
+        "jsonpath-plus": "^7.0.0"
+      }
+    },
+    "asl-validator": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.5.0.tgz",
+      "integrity": "sha512-DyIw6MwrePKutwxizPOxgaJhRT8klcWGNEC0fRpz7HtNMDysRBTCetGgjBR41CjXASd7ldvcIuzRA6CS4dbMxg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.11.0",
+        "asl-path-validator": "^0.11.0",
+        "commander": "^5.1.0",
+        "jsonpath-plus": "^7.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        }
+      }
     },
     "ast-types": {
       "version": "0.13.4",
@@ -3448,6 +3532,16 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "colorful": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/colorful/-/colorful-2.1.0.tgz",
+      "integrity": "sha512-DpDLDvi/vPzqoPX7Dw44ZZf004DCdEcCx1pf5hq5aipVHXjwgRSYGCz3m17rA2XCduW91wJUapge8/3qLvjYcg=="
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
     "colorspace": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
@@ -3567,6 +3661,11 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
       "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+    },
+    "dateformat": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.5.1.tgz",
+      "integrity": "sha512-OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q=="
     },
     "dayjs": {
       "version": "1.11.6",
@@ -5048,6 +5147,12 @@
         "universalify": "^2.0.0"
       }
     },
+    "jsonpath-plus": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
+      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
+      "dev": true
+    },
     "jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
@@ -5469,8 +5574,7 @@
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "ms": {
       "version": "2.1.3",
@@ -6230,6 +6334,75 @@
         }
       }
     },
+    "serverless-plugin-typescript": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/serverless-plugin-typescript/-/serverless-plugin-typescript-2.1.4.tgz",
+      "integrity": "sha512-6+IHXlsDydwDu+3ZhJiWyaFsfAoHbXdFGk10RJjipFYW+KLIoGMAxazXeiq0YQtC7uJYOtfYtGM1PtNjxOXAJg==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^7.0.1",
+        "globby": "^10.0.2",
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "globby": {
+          "version": "10.0.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+          "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.0.3",
+            "glob": "^7.1.3",
+            "ignore": "^5.1.1",
+            "merge2": "^1.2.3",
+            "slash": "^3.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        }
+      }
+    },
+    "serverless-step-functions": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/serverless-step-functions/-/serverless-step-functions-3.13.0.tgz",
+      "integrity": "sha512-lJOedjdKShJW3bemwhvTUAMqKu/uWJYFNKEtBxgOsw/BuWxCFvL6esKY+WA3QR7jeHtBknI5U/SStI4j3a+x+w==",
+      "dev": true,
+      "requires": {
+        "@hapi/joi": "^15.0.2",
+        "@serverless/utils": "^6.7.0",
+        "asl-validator": "^3.1.0",
+        "bluebird": "^3.4.0",
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.11"
+      }
+    },
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -6578,6 +6751,11 @@
         "next-tick": "1"
       }
     },
+    "tinytim": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tinytim/-/tinytim-0.1.1.tgz",
+      "integrity": "sha512-NIpsp9lBIxPNzB++HnMmUd4byzJSVbbO4F+As1Gb1IG/YQT5QvmBDjpx8SpDS8fhGC+t+Qw8ldQgbcAIaU+2cA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -6629,6 +6807,17 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "tracer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/tracer/-/tracer-1.1.6.tgz",
+      "integrity": "sha512-VKEIQRNgzSgti18whs+8l7e2y/gWcklw+C/xZtFH/AGvaN6GDlvhkQTFEsy448Gxb5MtbNbzJiG0L1TJEQnqcA==",
+      "requires": {
+        "colors": "1.4.0",
+        "dateformat": "4.5.1",
+        "mkdirp": "^1.0.4",
+        "tinytim": "0.1.1"
+      }
     },
     "traverse": {
       "version": "0.6.7",
@@ -6791,6 +6980,22 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "utilx": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/utilx/-/utilx-0.0.5.tgz",
+      "integrity": "sha512-lsNsH9TmfMMOPzoqM/Sai5DU4PwWDfHHUjEhGqQ+SB+Zngn+x3+UICj08QhZfc59rlykcD0lAShtgrtoGANsMQ==",
+      "requires": {
+        "colorful": "2.1.0",
+        "iconv-lite": "0.2.11"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.2.11",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "integrity": "sha512-KhmFWgaQZY83Cbhi+ADInoUQ8Etn6BG5fikM9syeOjQltvR45h7cRKJ/9uvQEuD61I3Uju77yYce0/LhKVClQw=="
+        }
+      }
+    },
     "uuid": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
@@ -6803,6 +7008,24 @@
       "dev": true,
       "requires": {
         "builtins": "^1.0.3"
+      }
+    },
+    "velocity": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/velocity/-/velocity-0.7.3.tgz",
+      "integrity": "sha512-x3BlBWsdWr2L/73YKsx0nw3Y40ayZs+GoFP1jRBRU/cowph8LSLvqPmXyt3E604WfNr9xf485KgjHIWFZQ5Hug==",
+      "requires": {
+        "colorful": "~2.1.0",
+        "commander": "~2.3.0",
+        "tracer": "~1.1.4",
+        "utilx": "0.0.5"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "integrity": "sha512-CD452fnk0jQyk3NfnK+KkR/hUPoHt5pVaKHogtyyv3N0U4QfAal9W0/rXLOg/vVZgQKa7jdtXypKs1YAip11uQ=="
+        }
       }
     },
     "vm2": {

--- a/microservices/package.json
+++ b/microservices/package.json
@@ -4,7 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "deploy:dev": "source ../.env && sls deploy",
+    "deploy:staging": "source ../.env && sls deploy --stage staging",
+    "deploy:prod": "source ../.env && sls deploy --stage prod",
+    "destroy:dev": "source ../.env && sls remove"
   },
   "author": "",
   "license": "ISC",
@@ -14,12 +17,15 @@
     "@octokit/rest": "^19.0.5",
     "aws-sdk": "^2.1241.0",
     "octokit": "^2.0.10",
+    "velocity": "^0.7.3",
     "winston": "^3.8.2",
     "winston-cloudwatch": "^6.1.1"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.108",
     "aws-lambda": "^1.0.7",
-    "serverless": "^3.23.0"
+    "serverless": "^3.23.0",
+    "serverless-plugin-typescript": "^2.1.4",
+    "serverless-step-functions": "^3.13.0"
   }
 }

--- a/microservices/serverless.yml
+++ b/microservices/serverless.yml
@@ -3,12 +3,8 @@ useDotenv: true # to allow reading of .env file
 frameworkVersion: "3"
 
 plugins:
-  # serverless-plugin-typescript needs to precede serverless-offline
   - serverless-plugin-typescript
   - serverless-step-functions
-  - serverless-step-functions-local
-  - serverless-offline-lambda
-  - serverless-offline
 
 provider:
   name: aws
@@ -18,16 +14,6 @@ provider:
     INCOMING_QUEUE_URL: ${env:INCOMING_QUEUE_URL}
     OUTGOING_QUEUE_URL: ${env:OUTGOING_QUEUE_URL}
     NODE_ENV: ${env:NODE_ENV}
-
-custom:
-  stepFunctionsLocal:
-    accountId: ${env:AWS_ACCOUNT_NUMBER}
-    region: ${env:AWS_REGION}
-    lambdaEndpoint: http://localhost:3002
-    eventBridgeEvents:
-      enabled: true
-      endpoint: http://localhost:4010
-    sqsUrl: ${env:INCOMING_QUEUE_URL}
 
 functions:
   generalDomainValidation:
@@ -44,7 +30,11 @@ functions:
     handler: handler.stepFunctionsTrigger
     events:
       - sqs: arn:aws:sqs:${aws:region}:${aws:accountId}:outgoingQueueStaging
+
+custom:
+  stateMachineName: SiteLaunchStepFunctions-${opt:stage, 'dev'}
 stepFunctions:
   stateMachines:
     siteLaunch:
+      name: ${self:custom.stateMachineName}
       definition: ${file(./site-launch/step-function-workflows/site-launch.asl.yaml)}


### PR DESCRIPTION
## Problem

We used to have local development using serverless offline, before we deployed it into the cloud. However, due to limitations of local development, and the differences between local and the cloud environments, there was effort needed to ensure similarity between emulated local and cloud environments. 


## Solution
This PR removes lingering local emulation of our cloud services that we no longer intend to use. 
Additionally, site launch cloud infra will have staging, production environments. If you wish to develop in an isolated cloud environment, simply create your own version of the infra in the cloud. eg: `npm run deploy:dev -- --stage kishore-test`. 

### Eng Decisions made
Notice that the `package.json` has a `source ../.env` before running the `sls deploy` command. I opted to use our .env file at the project root rather than creating a separate .env file at /microservices/.env for the following reasons: 
1. Lesser overhead to maintain by keeping all of our env in one singular folder. The values used for a potential `/microservices/.env` will be a subset of the as the current .env files, so any changes to .env would need to be repeated for `/microservices/.env`.
3. Serverless framework is `smart` enough to only export the variables that are required to run in the script
4. More intuitive to have a .env in the root folder only rather than at multiple locations

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible


## Tests

1. Run `npm run deploy:dev -- --stage <your-name>-test`
5. Head to https://ap-southeast-1.console.aws.amazon.com/states/home?region=ap-southeast-1#/statemachines
6. Verify that new state machine environment has been created
7. Run `npm run destroy: dev -- --stage <your-name>-test` to destroy newly created environment

### Other notes:
Currently we have `SiteLaunchStepFunctionsStateMachine-<some-gibberish-string>`. This is currently being used for our site launch process with ops. Will be depreciated soon to directly use `SiteLaunchStepFunctions-prod` in a separate PR.  



