### PR TITLE
Fix/convict fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "debug": "~2.6.9",
     "exponential-backoff": "^3.1.0",
     "express": "~4.17.3",
-    "express-session": "^1.17.3",
     "express-rate-limit": "^6.7.0",
     "express-session": "^1.17.3",
     "file-type": "^16.5.4",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -38,8 +38,8 @@ const config = convict({
   env: {
     doc: "The application environment.",
     env: "NODE_ENV",
-    format: ["LOCAL_DEV", "DEV", "test", "prod", "staging"],
-    default: "LOCAL_DEV",
+    format: ["dev", "test", "prod", "staging"],
+    default: "dev",
   },
   port: {
     doc: "The port to bind.",
@@ -81,13 +81,6 @@ const config = convict({
       env: "ISOMERPAGES_REPO_PAGE_COUNT",
       format: "required-positive-number",
       default: 10,
-    },
-    localSiteAccessToken: {
-      doc: "Access token for local site",
-      env: "LOCAL_SITE_ACCESS_TOKEN",
-      sensitive: true,
-      format: "required-string",
-      default: "",
     },
   },
   auth: {
@@ -153,24 +146,24 @@ const config = convict({
         default: "ap-southeast-1",
       },
       accountNumber: {
-        doc: "AWS account number",
+        doc: "AWS account number (microservices)",
         env: "AWS_ACCOUNT_NUMBER",
         sensitive: true,
-        format: "required-string",
+        format: String,
         default: "",
       },
       accessKeyId: {
-        doc: "AWS access key ID",
+        doc: "AWS access key ID (microservices)",
         env: "AWS_ACCESS_KEY_ID",
         sensitive: true,
-        format: "required-string",
+        format: String,
         default: "",
       },
       secretAccessKey: {
-        doc: "AWS secret access key",
+        doc: "AWS secret access key (microservices)",
         env: "AWS_SECRET_ACCESS_KEY",
         sensitive: true,
-        format: "required-string",
+        format: String,
         default: "",
       },
     },
@@ -184,12 +177,6 @@ const config = convict({
       outgoingQueueUrl: {
         doc: "URL of the outgoing SQS queue",
         env: "OUTGOING_QUEUE_URL",
-        format: "required-string",
-        default: "",
-      },
-      siteLaunchQueueUrl: {
-        doc: "URL of the site launch SQS queue",
-        env: "SITE_LAUNCH_QUEUE_URL",
         format: "required-string",
         default: "",
       },
@@ -250,7 +237,7 @@ const config = convict({
   dataDog: {
     env: {
       doc: "The DataDog environment",
-      format: ["production", "development", "local"],
+      format: ["development", "local", "staging", "production"],
       env: "DD_ENV",
       default: "local",
     },


### PR DESCRIPTION
## Problem

There were optional env vars which are not used in CMS BE logic, but rather for microservices and site launch. 

Closes [insert issue #]

## Solution

The ones being used were made optional as it should not be made mandatory for CMS BE to work. The redundant ones have been removed.

Summary:
Removed env vars: LOCAL_SITE_ACCESS_TOKEN, SITE_LAUNCH_QUEUE_URL
Made optional: AWS_ACCOUNT_NUMBER, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible
