### PR TITLE
Feat(site launch): support for multiple sites

### DIFF
--- a/microservices/package-lock.json
+++ b/microservices/package-lock.json
@@ -2499,13 +2499,28 @@
       }
     },
     "@octokit/request-error": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.2.tgz",
-      "integrity": "sha512-WMNOFYrSaX8zXWoJg9u/pKgWPo94JXilMLb2VManNOby9EZxrQaBe/QSC4a1TzpAlpxofg2X/jMnCyZgL6y7eg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
       "requires": {
-        "@octokit/types": "^8.0.0",
+        "@octokit/types": "^9.0.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "16.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
+          "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA=="
+        },
+        "@octokit/types": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
+          "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+          "requires": {
+            "@octokit/openapi-types": "^16.0.0"
+          }
+        }
       }
     },
     "@octokit/rest": {

--- a/microservices/package.json
+++ b/microservices/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@aws-sdk/client-amplify": "^3.290.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.276.0",
+    "@octokit/request-error": "^3.0.3",
     "@octokit/rest": "^19.0.5",
     "aws-sdk": "^2.1241.0",
     "octokit": "^2.0.10",

--- a/microservices/serverless.yml
+++ b/microservices/serverless.yml
@@ -14,6 +14,7 @@ provider:
     INCOMING_QUEUE_URL: ${env:INCOMING_QUEUE_URL}
     OUTGOING_QUEUE_URL: ${env:OUTGOING_QUEUE_URL}
     NODE_ENV: ${env:NODE_ENV}
+    SYSTEM_GITHUB_TOKEN: ${env:SYSTEM_GITHUB_TOKEN}
 
 functions:
   generalDomainValidation:

--- a/microservices/site-launch/lambda-functions/failure-notification/index.ts
+++ b/microservices/site-launch/lambda-functions/failure-notification/index.ts
@@ -3,7 +3,6 @@ import type { APIGatewayProxyResult } from "aws-lambda"
 import { SQS } from "aws-sdk"
 
 import logger from "../../shared/logger"
-import { MessageBody } from "../../shared/types"
 
 const { INCOMING_QUEUE_URL, AWS_REGION } = process.env
 

--- a/microservices/site-launch/lambda-functions/general-domain-validation/index.ts
+++ b/microservices/site-launch/lambda-functions/general-domain-validation/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/prefer-default-export */
 import {
   AmplifyClient,
   GetDomainAssociationCommand,

--- a/microservices/site-launch/lambda-functions/redirection-domain-validation/index.ts
+++ b/microservices/site-launch/lambda-functions/redirection-domain-validation/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/prefer-default-export */ // todo fix default export
 
+import { RequestError } from "@octokit/request-error"
 import { Octokit } from "@octokit/rest"
 
 import logger from "../../shared/logger"
@@ -59,11 +60,8 @@ export const redirectionDomainValidation = async (
         ref: DEFAULT_BRANCH,
       }
     )
-  } catch (error) {
-    if (
-      Object.prototype.hasOwnProperty.call(error, "status") &&
-      error.status === 404
-    ) {
+  } catch (error: unknown) {
+    if (error instanceof RequestError && error.status && error.status === 404) {
       fileExists = false
     } else {
       throw Error(

--- a/microservices/site-launch/lambda-functions/redirection-domain-validation/index.ts
+++ b/microservices/site-launch/lambda-functions/redirection-domain-validation/index.ts
@@ -63,11 +63,11 @@ export const redirectionDomainValidation = async (
   } catch (error: unknown) {
     if (error instanceof RequestError && error.status && error.status === 404) {
       fileExists = false
-    } else {
-      throw Error(
-        `Unknown error when checking for file existence of ${primaryDomainSource}.conf: ${error}`
-      )
+      return
     }
+    throw Error(
+      `Unknown error when checking for file existence of ${primaryDomainSource}.conf: ${error}`
+    )
   }
   if (fileExists) return
   await octokit.request(

--- a/microservices/site-launch/lambda-functions/redirection-domain-validation/index.ts
+++ b/microservices/site-launch/lambda-functions/redirection-domain-validation/index.ts
@@ -70,7 +70,7 @@ export const redirectionDomainValidation = async (
     }
   }
   if (fileExists) return
-  const response = await octokit.request(
+  await octokit.request(
     `PUT /repos/isomerpages/isomer-redirection/contents/letsencrypt/${primaryDomainSource}.conf`,
     {
       owner: "isomerpages",
@@ -85,7 +85,5 @@ export const redirectionDomainValidation = async (
       branch: DEFAULT_BRANCH,
     }
   )
-  logger.info(
-    `status of redirection commit for ${primaryDomainSource}:\n ${response}`
-  )
+  logger.info(`Redirection commit for ${primaryDomainSource} is successful`)
 }

--- a/microservices/site-launch/lambda-functions/step-functions-trigger/index.ts
+++ b/microservices/site-launch/lambda-functions/step-functions-trigger/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */ // todo remove this and use prefer-default-export
 
-import AWS, { Lambda, StepFunctions } from "aws-sdk"
+import { Lambda, StepFunctions } from "aws-sdk"
 
 import logger from "../../shared/logger"
 import { MessageBody } from "../../shared/types"

--- a/src/routes/formsgSiteCreation.ts
+++ b/src/routes/formsgSiteCreation.ts
@@ -82,7 +82,6 @@ export class FormsgRouter {
 
       // 3. Use service to create site
       const { deployment } = await this.infraService.createSite(
-        submissionId,
         foundUser,
         siteName,
         repoName

--- a/src/routes/formsgSiteLaunch.ts
+++ b/src/routes/formsgSiteLaunch.ts
@@ -1,6 +1,7 @@
 import { DecryptedContent } from "@opengovsg/formsg-sdk/dist/types"
 import autoBind from "auto-bind"
-import express, { RequestHandler, response } from "express"
+import express, { RequestHandler } from "express"
+import { err, ok } from "neverthrow"
 
 import logger from "@logger/logger"
 
@@ -11,16 +12,10 @@ import { getField, getFieldsFromTable } from "@utils/formsg-utils"
 import { attachFormSGHandler } from "@root/middleware"
 import { mailer } from "@root/services/utilServices/MailClient"
 import UsersService from "@services/identity/UsersService"
-import InfraService, {
-  REDIRECTION_SERVER_IP,
-} from "@services/infra/InfraService"
+import InfraService from "@services/infra/InfraService"
 
 const { SITE_LAUNCH_FORM_KEY } = process.env
 const REQUESTER_EMAIL_FIELD = "Government Email"
-const REPO_NAME_FIELD = "Repository Name"
-const PRIMARY_DOMAIN = "Primary Domain"
-const REDIRECTION_DOMAIN = "Redirection Domain"
-const AGENCY_EMAIL_FIELD = "Agency recipient"
 const SITE_LAUNCH_LIST =
   "Site Launch Details (Root Domain (eg. blah.moe.edu.sg), Redirection domain, Repo name (eg. moe-standrewsjc), Agency Email)"
 
@@ -62,8 +57,25 @@ interface RedirectionDomainObject {
   target: string
 }
 
+interface LaunchFailureEmailProps {
+  requesterEmail?: string
+  repoName?: string
+  primaryDomain?: string
+  error: string
+}
+
+interface DnsRecordsEmailProps {
+  requesterEmail: string
+  repoName: string
+  domainValidationSource: string
+  domainValidationTarget: string
+  primaryDomainSource: string
+  primaryDomainTarget: string
+  redirectionDomain?: RedirectionDomainObject
+}
+
 export class FormsgSiteLaunchRouter {
-  siteLaunch = async (formResponses: FormResponsesProps): Promise<void> => {
+  siteLaunch = async (formResponses: FormResponsesProps) => {
     const {
       submissionId,
       requesterEmail,
@@ -93,81 +105,56 @@ export class FormsgSiteLaunchRouter {
 
     // 2. Check arguments
     if (!requesterEmail) {
-      // Most errors are handled by sending an email to the requester, so we can't recover from this.
-      await this.sendLaunchError(
-        ISOMER_ADMIN_EMAIL,
-        repoName,
-        submissionId,
-        `Error: ${"Required 'Agency E-mail' input was not found"}`
-      )
-      return
+      return err({
+        ...formResponses,
+        error: "Required 'Requester E-mail' input was not found",
+      })
     }
 
     if (!agencyEmail) {
-      // Most errors are handled by sending an email to the requester, so we can't recover from this.
-      await this.sendLaunchError(
-        requesterEmail,
-        repoName,
-        submissionId,
-        `Error: ${"Required 'Agency E-mail' input was not found"}`
-      )
-      return
+      return err({
+        ...formResponses,
+        error: "Required 'Agency E-mail' input was not found",
+      })
     }
 
     if (!primaryDomain) {
-      const err = `A primary domain is required`
-      await this.sendLaunchError(requesterEmail, repoName, submissionId, err)
-      return
+      const error = `A primary domain is required`
+      return err({ error, ...formResponses })
     }
     if (!repoName) {
-      const err = `A repository name is required`
-      await this.sendLaunchError(requesterEmail, repoName, submissionId, err)
-      return
+      const error = `A repository name is required`
+      return err({ error, ...formResponses })
     }
 
     const agencyUser = await this.usersService.findByEmail(agencyEmail)
     const requesterUser = await this.usersService.findByEmail(requesterEmail)
 
     if (!agencyUser) {
-      const err = `Form submitter ${agencyEmail} is not an Isomer user. Register an account for this user and try again.`
-      await this.sendLaunchError(requesterEmail, repoName, submissionId, err)
-      return
+      const error = `Form submitter ${agencyEmail} is not an Isomer user. Register an account for this user and try again.`
+      return err({ error, ...formResponses })
     }
 
     if (!requesterUser) {
-      const err = `Form submitter ${requesterUser} is not an Isomer user. Register an account for this user and try again.`
-      await this.sendLaunchError(requesterEmail, repoName, submissionId, err)
-      return
+      const error = `Form submitter ${requesterUser} is not an Isomer user. Register an account for this user and try again.`
+      return err({ error, ...formResponses })
     }
 
     // 3. Use service to Launch site
-    // note: this function is not be async due to the timeout for http requests.
-    const launchSite = await this.infraService.launchSite(
+    const launchSiteResult = await this.infraService.launchSite(
       requesterUser,
       agencyUser,
       repoName,
       primaryDomain,
       subDomainSettings
     )
-
-    if (launchSite.isOk()) {
-      await this.sendVerificationDetails(
-        requesterEmail,
-        repoName,
-        submissionId,
-        launchSite.value.domainValidationSource,
-        launchSite.value.domainValidationTarget,
-        launchSite.value.primaryDomainTarget,
-        launchSite.value.domainValidationSource
-      )
-    } else {
-      await this.sendLaunchError(
-        requesterEmail,
-        repoName,
-        submissionId,
-        `Error: ${launchSite.error}`
-      )
+    if (launchSiteResult.isErr()) {
+      return err({
+        ...formResponses,
+        error: launchSiteResult.error,
+      })
     }
+    return ok({ ...launchSiteResult.value, repoName, requesterEmail })
   }
 
   private readonly usersService: FormsgRouterProps["usersService"]
@@ -224,52 +211,118 @@ export class FormsgSiteLaunchRouter {
       ) || []
 
     res.sendStatus(200) // we have received the form and obtained relevant field
-    formResponses.forEach((formResponse) => this.siteLaunch(formResponse))
+    await this.siteLaunchHandler(formResponses, submissionId)
   }
 
   sendLaunchError = async (
-    isomerEmail: string,
-    repoName: string | undefined,
     submissionId: string,
-    errorMessage: string
+    failureResults: LaunchFailureEmailProps[]
   ) => {
-    const displayedRepoName = repoName || "<missing repo name>"
-    const subject = `[Isomer] Launch site ${displayedRepoName} FAILURE`
-    const html = `<p>Isomer site ${displayedRepoName} was <b>not</b> launched successfully. (Form submission id [${submissionId}])</p> 
-<p>${errorMessage}</p>
-<p>This email was sent from the Isomer CMS backend.</p>`
+    if (failureResults.length === 0) return
+    const { requesterEmail } = failureResults[0]
+    const email = requesterEmail || ISOMER_ADMIN_EMAIL
+    const subject = `[Isomer] Launch site FAILURE`
+    let html = `<p>The following sites were NOT launched successfully. (Form submission id [${submissionId}])</p>
+    <table><thread><tr><th>Repo Name</th><th>Error</th></tr></thread><tbody>`
 
-    await mailer.sendMail(isomerEmail, subject, html)
+    failureResults.forEach((failureResult) => {
+      const displayedRepoName = failureResult.repoName || "<missing repo name>"
+      html += `
+      <tr>
+        <td>${displayedRepoName}</td>
+        <td>${failureResult.error}</td>
+      </tr>`
+    })
+    html += `
+    </tbody></table>
+    <p>This email was sent from the Isomer CMS backend.</p>`
+
+    await mailer.sendMail(email, subject, html)
   }
 
-  sendVerificationDetails = async (
-    requestorEmail: string,
-    repoName: string,
+  sendDNSRecords = async (
     submissionId: string,
-    domainValidationSource: string,
-    domainValidationTarget: string,
-    primaryDomainSource: string,
-    primaryDomainTarget: string,
-    redirectionDomain?: RedirectionDomainObject
+    dnsRecordsEmailProps: DnsRecordsEmailProps[]
   ): Promise<void> => {
-    const subject = `[Isomer] Launch site ${repoName} domain validation`
-    let html = `<p>Isomer site ${repoName} is in the process of launching. (Form submission id [${submissionId}])</p>
-<p>Please set the following CNAME record:</p>
-<p>Source: ${domainValidationSource}</p>
-<p>Target: ${domainValidationTarget}</p>
-<p>Source: ${primaryDomainSource}</p>
-<p>Target: ${primaryDomainTarget}</p>`
-    if (redirectionDomain) {
-      html += `<p>Source: ${redirectionDomain.source}</p>\n<p>Target: ${redirectionDomain.target}</p>\n`
-    }
+    if (dnsRecordsEmailProps.length === 0) return
+    const { requesterEmail } = dnsRecordsEmailProps[0]
+    const subject = `[Isomer] DNS records for launching websites`
 
-    html += `<p>This email was sent from the Isomer CMS backend.</p>`
-    await mailer.sendMail(requestorEmail, subject, html)
+    let html = `<p>Isomer sites are in the process of launching. (Form submission id [${submissionId}])</p>
+    <table>
+    <thead>
+      <tr>
+        <th>Repo Name</th>
+        <th>Source</th>
+        <th>Target</th>
+        <th>Type</th>
+      </tr>
+    </thead>
+    <tbody>`
+    dnsRecordsEmailProps.forEach((dnsRecords) => {
+      // check if dnsRecords.redirectionDomain is undefined
+      const isRedirection = !!dnsRecords.redirectionDomain
+      html += `
+    <tr>
+      <td>${dnsRecords.repoName}</td>
+      <td>${dnsRecords.domainValidationSource}</td>
+      <td>${dnsRecords.domainValidationTarget}</td>
+      <td>CNAME</td>
+    </tr>
+    <tr>
+      <td>${dnsRecords.repoName}</td>
+      <td>${
+        isRedirection
+          ? // if redirection, website will be hosted in the 'www' subdomain
+            `www.${dnsRecords.primaryDomainSource}`
+          : dnsRecords.primaryDomainSource
+      }</td>
+      <td>${dnsRecords.primaryDomainTarget}</td>
+      <td>CNAME</td>
+    </tr>`
+
+      if (isRedirection) {
+        html += `
+      <tr>
+        <td>${dnsRecords.repoName}</td>
+        <td>${dnsRecords.redirectionDomain?.source}</td>
+        <td>${dnsRecords.redirectionDomain?.target}</td>
+        <td>A Record</td>
+      </tr>`
+      }
+    })
+    html += `</tbody></table>
+    <p>This email was sent from the Isomer CMS backend.</p>`
+    await mailer.sendMail(requesterEmail, subject, html)
+  }
+
+  private async siteLaunchHandler(
+    formResponses: FormResponsesProps[],
+    submissionId: string
+  ) {
+    const launchResults = await Promise.all(formResponses.map(this.siteLaunch))
+    const successResults: DnsRecordsEmailProps[] = []
+    launchResults.forEach((launchResult) => {
+      if (launchResult.isOk()) {
+        successResults.push(launchResult.value)
+      }
+    })
+
+    await this.sendDNSRecords(submissionId, successResults)
+
+    const failureResults: LaunchFailureEmailProps[] = []
+
+    launchResults.forEach((launchResult) => {
+      if (launchResult.isErr() && launchResult.error) {
+        failureResults.push(launchResult.error)
+      }
+    })
+
+    await this.sendLaunchError(submissionId, failureResults)
   }
 
   getRouter() {
     const router = express.Router({ mergeParams: true })
-
     if (!SITE_LAUNCH_FORM_KEY) {
       throw new InitializationError(
         "Required SITE_LAUNCH_FORM_KEY environment variable is empty."

--- a/src/routes/formsgSiteLaunch.ts
+++ b/src/routes/formsgSiteLaunch.ts
@@ -71,7 +71,7 @@ interface DnsRecordsEmailProps {
 }
 
 export class FormsgSiteLaunchRouter {
-  siteLaunch = async (formResponses: FormResponsesProps) => {
+  launchSiteFromForm = async (formResponses: FormResponsesProps) => {
     const {
       submissionId,
       requesterEmail,
@@ -160,7 +160,7 @@ export class FormsgSiteLaunchRouter {
   getPrimaryDomain = (url: string) =>
     url.replace(/^(https?:\/\/)?(www\.)?/, "").replace(/\/$/, "")
 
-  launchSiteUsingForm: RequestHandler<
+  handleSiteLaunchFormRequest: RequestHandler<
     never,
     string,
     { data: { submissionId: string } },
@@ -206,7 +206,7 @@ export class FormsgSiteLaunchRouter {
       ) || []
 
     res.sendStatus(200) // we have received the form and obtained relevant field
-    await this.siteLaunchHandler(formResponses, submissionId)
+    await this.handleSiteLaunchResults(formResponses, submissionId)
   }
 
   sendLaunchError = async (
@@ -295,11 +295,13 @@ export class FormsgSiteLaunchRouter {
     await mailer.sendMail(requesterEmail, subject, html)
   }
 
-  private async siteLaunchHandler(
+  private async handleSiteLaunchResults(
     formResponses: FormResponsesProps[],
     submissionId: string
   ) {
-    const launchResults = await Promise.all(formResponses.map(this.siteLaunch))
+    const launchResults = await Promise.all(
+      formResponses.map(this.launchSiteFromForm)
+    )
     const successResults: DnsRecordsEmailProps[] = []
     launchResults.forEach((launchResult) => {
       if (launchResult.isOk()) {
@@ -336,7 +338,7 @@ export class FormsgSiteLaunchRouter {
     router.post(
       "/launch-site",
       attachFormSGHandler(SITE_LAUNCH_FORM_KEY),
-      this.launchSiteUsingForm
+      this.handleSiteLaunchFormRequest
     )
 
     return router

--- a/src/routes/formsgSiteLaunch.ts
+++ b/src/routes/formsgSiteLaunch.ts
@@ -314,6 +314,12 @@ export class FormsgSiteLaunchRouter {
     launchResults.forEach((launchResult) => {
       if (launchResult.isErr() && launchResult.error) {
         failureResults.push(launchResult.error)
+        return
+      }
+      if (launchResult.isErr()) {
+        failureResults.push({
+          error: "Unknown error",
+        })
       }
     })
 

--- a/src/routes/formsgSiteLaunch.ts
+++ b/src/routes/formsgSiteLaunch.ts
@@ -53,6 +53,8 @@ interface FormResponsesProps {
 }
 
 interface LaunchFailureEmailProps {
+  // The fields here are optional since a misconfiguration in our
+  // formSG can cause some or even all fields to be missing
   requesterEmail?: string
   repoName?: string
   primaryDomain?: string

--- a/src/routes/formsgSiteLaunch.ts
+++ b/src/routes/formsgSiteLaunch.ts
@@ -163,13 +163,16 @@ export class FormsgSiteLaunchRouter {
 
   getPrimaryDomain = (url: string) => {
     let domain = url
-    // remove leading https:// and www.
     if (domain.startsWith("https://")) {
       domain = domain.replace("https://", "")
     }
     if (domain.startsWith("www.")) {
       domain = domain.replace("www.", "")
     }
+    if (domain.endsWith("/")) {
+      domain = domain.slice(0, -1)
+    }
+
     return domain
   }
 

--- a/src/routes/formsgSiteLaunch.ts
+++ b/src/routes/formsgSiteLaunch.ts
@@ -88,16 +88,9 @@ export class FormsgSiteLaunchRouter {
     const subDomainSettings = [
       {
         branchName: "master",
-        prefix: "",
+        prefix: `${redirectionDomain ? "www" : ""}`,
       },
     ]
-
-    if (redirectionDomain) {
-      subDomainSettings.push({
-        branchName: "master",
-        prefix: "www",
-      })
-    }
 
     logger.info(
       `Launch site form submission [${submissionId}] (repoName '${repoName}', domain '${primaryDomain}') requested by <${requesterEmail}>`
@@ -168,6 +161,18 @@ export class FormsgSiteLaunchRouter {
     autoBind(this)
   }
 
+  getPrimaryDomain = (url: string) => {
+    let domain = url
+    // remove leading https:// and www.
+    if (domain.startsWith("https://")) {
+      domain = domain.replace("https://", "")
+    }
+    if (domain.startsWith("www.")) {
+      domain = domain.replace("www.", "")
+    }
+    return domain
+  }
+
   launchSiteUsingForm: RequestHandler<
     never,
     string,
@@ -201,8 +206,11 @@ export class FormsgSiteLaunchRouter {
           submissionId,
           requesterEmail: getField(responses, REQUESTER_EMAIL_FIELD),
           repoName: element[2],
-          primaryDomain: element[0],
-          redirectionDomain: element[1] === "WWW" ? `www.${element[0]}` : "",
+          primaryDomain: this.getPrimaryDomain(element[0]),
+          redirectionDomain:
+            element[1] === "WWW"
+              ? `www.${this.getPrimaryDomain(element[0])}`
+              : "",
           // if agency email not needed, use email from requester instead
           agencyEmail: element[3]
             ? element[3]

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -284,7 +284,7 @@ export default class InfraService {
 
       /**
        * Amplify only stores the prefix.
-       * ie: if I wanted to have a www.blah.gov.sg -> giberish.cloudfront.net,
+       * ie: if I wanted to have a www.blah.gov.sg -> gibberish.cloudfront.net,
        * amplify will store the prefix as "www". To get the entire redirectionDomainSource,
        * I would have to add the prefix ("www") with the primary domain (blah.gov.sg)
        */
@@ -300,6 +300,7 @@ export default class InfraService {
 
       if (redirectionDomainList?.length) {
         newLaunchParams.redirectionDomainSource = `www.${primaryDomain}` // we only support 'www' redirections for now
+        newLaunchParams.redirectionDomainTarget = REDIRECTION_SERVER_IP
       }
 
       // Create launches records table
@@ -326,7 +327,6 @@ export default class InfraService {
           type: RedirectionTypes.A,
         }
         message.redirectionDomain = [redirectionDomainObject]
-        newLaunchParams.redirectionDomain = redirectionDomainObject
       }
 
       this.queueService.sendMessage(message)

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -63,12 +63,7 @@ export default class InfraService {
     this.queueService = queueService
   }
 
-  createSite = async (
-    submissionId: string,
-    creator: User,
-    siteName: string,
-    repoName: string
-  ) => {
+  createSite = async (creator: User, siteName: string, repoName: string) => {
     let site: Site | undefined // For error handling
     try {
       // 1. Create a new site record in the Sites table
@@ -154,13 +149,11 @@ export default class InfraService {
     // type checking
     const sourceUrl = this.removeTrailingDot(recordsInfo[0])
 
-    // for the root domain record, Amplify records this as : ' CNAME gibberish.cloudfront.net'.
-    // in this case, sourceUrl will be an empty string, and while this is not a valid URL,
-    // this is ok, as it is just an interim representation from Amplify.
-    const isSourceUrlValid = !sourceUrl || this.isValidUrl(sourceUrl)
-    if (!isSourceUrlValid) {
-      return err(`Source url: "${sourceUrl}" was not a valid url`)
-    }
+    // For the root domain record, Amplify records this as : ' CNAME gibberish.cloudfront.net',
+    // sourceUrl is an empty string in this case.
+    // For the www record, Amplify records this as : 'www CNAME gibberish.cloudfront.net',
+    // sourceUrl is 'www' in this case.
+    // In both cases, the sourceUrl is not a valid url, so we skip the url validation.
 
     const targetUrl = this.removeTrailingDot(recordsInfo[2])
     if (!this.isValidUrl(targetUrl)) {
@@ -266,7 +259,7 @@ export default class InfraService {
       if (primaryDomainInfo.isErr()) {
         return err(
           new AmplifyError(
-            `Missing primary domain info${primaryDomainInfo.error}`,
+            `Missing primary domain info ${primaryDomainInfo.error}`,
             repoName,
             appId
           )


### PR DESCRIPTION
## Problem

The Site Launch form returns an email per site. Ie when using the form to launch 5 sites, the cms backend will return 5 different emails. This can be a hassle for Ops as they have to keep sieving through each of the email to get the site details. 
This PR modifies the site launch logic such that the DNS details of the site launches are consolidated into at most 2 emails (one for successful launches and one for unsuccessful launches) 

Other sub-issues closed: 
The current code in redirection domain lambda is wrong since 
1) The env var was not imported properly
2) The call `octokit.request()` doesn't return an 404 when a file is not found. Instead, it throws an error, which caused our redirection lambda to crash. 

## Solution

Rather than sending an email directly to Ops per site launch, now only two emails are sent back to ops. (one for success, and another for failure) 

**Breaking Changes**


- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Tests

To just test the functionality of redirection domain lambda: 

1) Go to the lambda [here]( https://ap-southeast-1.console.aws.amazon.com/lambda/home?region=ap-southeast-1#/functions/isomercms-kishore-test-redirectionDomainValidation?tab=testing). (Note: I have already deployed this version using the `npm run deploy:dev -- --stage kishore-test` command)
2) Click on the event name `testEvent`. 
3) Run test, notice the lack of any failures. 

You can change the test object to: 
`{
  "primaryDomainSource": "<some-other-url>.isomer.gov.sg",
  "redirectionDomain": [
    {
      "source": "www.<some-other-url>.isomer.gov.sg",
      "target": "18.136.36.203",
      "type": "A"
    }
  ]
}`, as long as the .conf file never existed in our branch, it should be updated [here](https://github.com/isomerpages/isomer-redirection/tree/test/redirectionLambdaTest). This branch is being used for testing anyways, feel free to test with whatever values you like. 

Here is a short video I made to show a trivial testing of the current state of site the site launch form:
 
https://user-images.githubusercontent.com/42832651/227849536-db8b5f89-bbec-4ac5-9956-6168a074e299.mp4

To replicate the example shown in the video, one would need to 
1. Change the SITE_LAUNCH_FORM_KEY  in your .env to the one in 1password for `Form Secret Key Dev Site Launch`
2. In the env OUTGOING_QUEUE_URL, replace `outgoingQueue` to `outgoingQueueKishoreTest`
3. Change NODE_ENV="LOCAL_DEV" (will be tackled in a separate [pr](https://github.com/isomerpages/isomercms-backend/issues/668))
4. Populate your local DB for `sites`, `repos` and `deployments`
5. Run `ngrok http 8081`
6. Log into formSG and modify the webhook URL to the one corresponding to ngrok's url. 
7. Populate form with relevant values, then click on submit, see the email output in your local computer
8. CLEAN UP by removing domain associations in amplify, remove any new rows created in the `launches` and `redirections` table. 

## Deploy Notes

This PR will have conflicts with the recent changes in node var, and the changes with convict PR. These will be addressed in a separate PR, when the changes in identity gets merged into develop. Issues have been raised [here](https://github.com/isomerpages/isomercms-backend/issues/667) and [here](https://github.com/isomerpages/isomercms-backend/issues/668). 

## Review Notes
I feel weird about the naming convention for this [function](https://github.com/isomerpages/isomercms-backend/pull/665/files#r1148815122), open to suggestions for this! 

