### PR TITLE
chore(docker compose): remove local emulation of lambdas

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,27 +21,5 @@ services:
       # use a different port to avoid blocking dev environment when running tests
       - "54321:5432"
 
-  # Runs the AWS-provided emulator for step functions
-  stepFunctionsLocal:
-    image: amazon/aws-stepfunctions-local
-    environment:
-      AWS_SECRET_KEY: blah
-      AWS_ACCESS_KEY_ID: bleh
-      AWS_ACCOUNT_ID: 101010101010
-      AWS_DEFAULT_REGION: us-east-1
-      LAMBDA_ENDPOINT: http://host.docker.internal:3002
-    ports:
-      - 8083:8083
-    
-  # Start local stack
-  localstack:
-    image: localstack/localstack
-    environment: 
-      - AWS_DEFAULT_REGION=ap-southeast-1
-      - EDGE_PORT=4566
-      - SERVICES=sqs
-    ports:
-      - "4566-4599:4566-4599"
-
 volumes:
   isomercms_data:


### PR DESCRIPTION
## Problem

we no longer use local stack/step functions
