### PR TITLE
fix(launches service): change to primary domain source for clarity

### DIFF
--- a/src/services/identity/LaunchesService.ts
+++ b/src/services/identity/LaunchesService.ts
@@ -94,7 +94,7 @@ export class LaunchesService {
       const createRedirectionParams = {
         launchId: launch.id,
         type: RedirectionTypes.A,
-        source: createParams.redirectionDomainSource,
+        source: createParams.primaryDomainSource,
         target: createParams.primaryDomainTarget,
       }
       await this.redirectionsRepository.create(createRedirectionParams)


### PR DESCRIPTION
## Problem

Currently, the `redirections` table has example of: 
<img width="793" alt="Screenshot 2023-03-27 at 5 22 16 PM copy" src="https://user-images.githubusercontent.com/42832651/227899830-e3534689-afe9-4954-9b74-0d013b46885a.png">


Which is not really true since the website is technically being hosted in the www subdomain, and the redirection occurs at the primary domain instead. 
TLDR refresher: 
blah.gov.sg --A record-> 18.X.X.X 
18.X.X.X returns a 301 redirect to www.blah.gov.sg, where 
www.blah.gov.sg --CNAME-> blah.cloudfront.net, where the website is being hosted. 
Read more [here](https://www.notion.so/opengov/Site-Launch-8c7ee5dc910d426983f9167d3fb8fd2f?pvs=4). 

After this update, the leading ''www" will be removed for clarity. An example row would then be: 
<img width="794" alt="Screenshot 2023-03-27 at 5 20 42 PM" src="https://user-images.githubusercontent.com/42832651/227899559-02ac310a-ab44-4293-b147-8df1d0e938c0.png">

## Solution

Change the code in backend + manually changing all the values in production DB to reflect this change. 



<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

