### PR TITLE
Feat/site creation form email

### DIFF
--- a/src/routes/formsgSiteCreation.ts
+++ b/src/routes/formsgSiteCreation.ts
@@ -77,8 +77,10 @@ export class FormsgRouter {
         await this.sendCreateError(requesterEmail, repoName, submissionId, err)
         return res.sendStatus(200)
       }
-      const foundRequester = await this.usersService.findByEmail(requesterEmail)
-      if (!foundRequester) {
+      const foundIsomerRequester = await this.usersService.findByEmail(
+        requesterEmail
+      )
+      if (!foundIsomerRequester) {
         const err = `Form submitter ${requesterEmail} is not an Isomer user. Register an account for this user and try again.`
         await this.sendCreateError(requesterEmail, repoName, submissionId, err)
         return res.sendStatus(200)
@@ -87,7 +89,7 @@ export class FormsgRouter {
 
       // 3. Use service to create site
       const { deployment } = await this.infraService.createSite(
-        foundRequester,
+        foundIsomerRequester,
         foundOwner,
         siteName,
         repoName

--- a/src/routes/formsgSiteCreation.ts
+++ b/src/routes/formsgSiteCreation.ts
@@ -52,7 +52,9 @@ export class FormsgRouter {
     const requesterEmail = getField(responses, REQUESTER_EMAIL_FIELD)
     const siteName = getField(responses, SITE_NAME_FIELD)
     const repoName = getField(responses, REPO_NAME_FIELD)
-    const ownerEmail = getField(responses, OWNER_NAME_FIELD)?.toLowerCase()
+    const ownerEmail = getField(responses, OWNER_NAME_FIELD)
+      ?.toLowerCase()
+      .trim()
 
     logger.info(
       `Create site form submission [${submissionId}] (repoName '${repoName}', siteName '${siteName}') requested by <${requesterEmail}>`

--- a/src/server.js
+++ b/src/server.js
@@ -159,16 +159,6 @@ const launchesService = new LaunchesService({
   launchClient,
 })
 const queueService = new QueueService()
-const infraService = new InfraService({
-  sitesService,
-  reposService,
-  deploymentsService,
-  launchesService,
-  queueService,
-})
-
-// poller for incoming queue
-infraService.pollQueue()
 
 const identityAuthService = getIdentityAuthService(gitHubService)
 const collaboratorsService = new CollaboratorsService({
@@ -178,6 +168,17 @@ const collaboratorsService = new CollaboratorsService({
   usersService,
   whitelist: Whitelist,
 })
+
+const infraService = new InfraService({
+  sitesService,
+  reposService,
+  deploymentsService,
+  launchesService,
+  queueService,
+  collaboratorsService,
+})
+// poller for incoming queue
+infraService.pollQueue()
 
 const authenticationMiddleware = getAuthenticationMiddleware()
 const authorizationMiddleware = getAuthorizationMiddleware({

--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -64,7 +64,6 @@ export default class ReposService {
     const repoUrl = `https://github.com/isomerpages/${repoName}`
 
     await this.createRepoOnGithub(repoName)
-    await this.createTeamOnGitHub(repoName)
     await this.generateRepoAndPublishToGitHub(repoName, repoUrl)
     return this.create({
       name: repoName,

--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -147,15 +147,6 @@ export default class ReposService {
       private: false,
     })
 
-  createTeamOnGitHub = (
-    repoName: string
-  ): Promise<octokitCreateTeamResponseType> =>
-    octokit.teams.create({
-      org: ISOMER_GITHUB_ORGANIZATION_NAME,
-      name: repoName,
-      privacy: "closed",
-    })
-
   setRepoAndTeamPermissions = async (repoName: string): Promise<void> => {
     await octokit.repos.updateBranchProtection({
       owner: ISOMER_GITHUB_ORGANIZATION_NAME,

--- a/src/services/identity/UsersService.ts
+++ b/src/services/identity/UsersService.ts
@@ -167,6 +167,13 @@ class UsersService {
     return user
   }
 
+  async findOrCreateByEmail(email: string | undefined) {
+    const [user] = await this.repository.findOrCreate({
+      where: { email },
+    })
+    return user
+  }
+
   async login(githubId: string): Promise<User> {
     return this.sequelize.transaction<User>(async (transaction) => {
       // NOTE: The service's findOrCreate is not being used here as this requires an explicit transaction

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -89,7 +89,7 @@ export default class InfraService {
       // 1. Create a new site record in the Sites table
       const newSiteParams = {
         name: siteName,
-        apiTokenName: "", // TODO: remove once DB has removed this param
+        apiTokenName: "", // TODO (IS-76): Remove once DB has removed this param
         creator,
         creatorId: creator.id,
       }

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -20,6 +20,7 @@ import ReposService from "@services/identity/ReposService"
 import SitesService from "@services/identity/SitesService"
 import { mailer } from "@services/utilServices/MailClient"
 
+import CollaboratorsService from "../identity/CollaboratorsService"
 import QueueService from "../identity/QueueService"
 
 const SITE_LAUNCH_UPDATE_INTERVAL = 30000
@@ -31,6 +32,7 @@ interface InfraServiceProps {
   deploymentsService: DeploymentsService
   launchesService: LaunchesService
   queueService: QueueService
+  collaboratorsService: CollaboratorsService
 }
 
 interface dnsRecordDto {
@@ -49,27 +51,45 @@ export default class InfraService {
 
   private readonly queueService: InfraServiceProps["queueService"]
 
+  private readonly collaboratorsService: InfraServiceProps["collaboratorsService"]
+
   constructor({
     sitesService,
     reposService,
     deploymentsService,
     launchesService,
     queueService,
+    collaboratorsService,
   }: InfraServiceProps) {
     this.sitesService = sitesService
     this.reposService = reposService
     this.deploymentsService = deploymentsService
     this.launchesService = launchesService
     this.queueService = queueService
+    this.collaboratorsService = collaboratorsService
   }
 
-  createSite = async (creator: User, siteName: string, repoName: string) => {
+  createSite = async (
+    creator: User,
+    member: User,
+    siteName: string,
+    repoName: string
+  ) => {
     let site: Site | undefined // For error handling
+    const memberEmail = member.email
+    if (!memberEmail) {
+      logger.error(
+        `createSite: initial member for ${siteName} does not have associated email`
+      )
+      throw new Error(
+        `createSite: initial member for ${siteName} does not have associated email`
+      )
+    }
     try {
       // 1. Create a new site record in the Sites table
       const newSiteParams = {
         name: siteName,
-        apiTokenName: "", // TODO: figure this out
+        apiTokenName: "", // TODO: remove once DB has removed this param
         creator,
         creatorId: creator.id,
       }
@@ -96,6 +116,7 @@ export default class InfraService {
 
       // 5. Set up permissions
       await this.reposService.setRepoAndTeamPermissions(repoName)
+      await this.collaboratorsService.create(repoName, memberEmail, true)
 
       // 6. Update status
       const updateSuccessSiteInitParams = {


### PR DESCRIPTION
This PR modifies our existing site creation form to utilise the new email login flow instead. Currently, our site creation form creates a new website, but does not assign site members to the new site - thus our creation flow currently creates an Amplify site that is accessed via Github login, with access manually granted to users via Github. This PR changes the creation flow to associate an existing isomer user to the specified site, or create a new isomer user using the specified email if no such user exists. A new form has also been created for both staging and production ([staging form link](https://form.gov.sg/642be6e0682ef3001171d860)). Note that the person filling in the form is still specified as the owner of the form.

Env var changes before merging:
- Modify `SITE_CREATE_FORM_KEY` on production - we're using a new site create form (v3) just to be safe, so the form key needs to be swapped out to the new secret key