### PR TITLE
fix(utils): change order of ops and rec sanitization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5909,6 +5909,12 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
+        },
+        "yaml": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+          "dev": true
         }
       }
     },
@@ -15663,9 +15669,9 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "validator": "^13.6.0",
     "winston": "^3.3.3",
     "winston-cloudwatch": "^6.1.1",
-    "yaml": "^1.10.2"
+    "yaml": "^2.2.1"
   },
   "devDependencies": {
     "@octokit/types": "^6.35.0",

--- a/src/utils/yaml-utils.ts
+++ b/src/utils/yaml-utils.ts
@@ -1,12 +1,29 @@
+import _ from "lodash"
 import yaml from "yaml"
 
 import { sanitizer } from "@services/utilServices/Sanitizer"
+
+type YamlRecord = {
+  [key: string]: YamlRecord | string
+}
+
+const sanitizeYamlRecord = (yamlRec: YamlRecord): YamlRecord =>
+  _(yamlRec)
+    .mapValues((val) => {
+      if (typeof val === "string") return sanitizer.sanitize(val)
+      return sanitizeYamlRecord(val)
+    })
+    .value()
 
 // Note: `yaml.parse()` and `yaml.stringify()` should not be used anywhere
 // else in the codebase.
 export const sanitizedYamlParse = (
   unparsedContent: string
-): Record<string, unknown> => yaml.parse(sanitizer.sanitize(unparsedContent))
+): Record<string, unknown> => {
+  const parsedContent = yaml.parse(unparsedContent) as YamlRecord
+
+  return sanitizeYamlRecord(parsedContent)
+}
 
 export const sanitizedYamlStringify = (prestringifiedContent: object): string =>
   sanitizer.sanitize(yaml.stringify(prestringifiedContent))

--- a/src/utils/yaml-utils.ts
+++ b/src/utils/yaml-utils.ts
@@ -1,34 +1,17 @@
-import _ from "lodash"
 import yaml from "yaml"
 
 import { sanitizer } from "@services/utilServices/Sanitizer"
-
-type YamlRecord = {
-  [key: string]: YamlRecord | string | (YamlRecord | string)[]
-}
-
-const isArr = (t: unknown): t is Array<unknown> => !!(t as unknown[]).length
-
-const sanitizeYamlRecord = (yamlRec: YamlRecord): YamlRecord =>
-  _(yamlRec)
-    .mapValues((val) => {
-      if (typeof val === "string") return sanitizer.sanitize(val)
-      if (isArr(val))
-        return val.map((v) =>
-          typeof v === "string" ? sanitizer.sanitize(v) : sanitizeYamlRecord(v)
-        )
-      return sanitizeYamlRecord(val)
-    })
-    .value()
 
 // Note: `yaml.parse()` and `yaml.stringify()` should not be used anywhere
 // else in the codebase.
 export const sanitizedYamlParse = (
   unparsedContent: string
-): Record<string, unknown> => {
-  const parsedContent = yaml.parse(unparsedContent) as YamlRecord
-  return sanitizeYamlRecord(parsedContent)
-}
+): Record<string, unknown> =>
+  yaml.parse(unparsedContent, (key, value) =>
+    typeof value === "string" ? sanitizer.sanitize(value) : value
+  )
 
 export const sanitizedYamlStringify = (prestringifiedContent: object): string =>
-  sanitizer.sanitize(yaml.stringify(prestringifiedContent))
+  yaml.stringify(prestringifiedContent, (key, value) =>
+    typeof value === "string" ? sanitizer.sanitize(value) : value
+  )

--- a/src/utils/yaml-utils.ts
+++ b/src/utils/yaml-utils.ts
@@ -4,13 +4,16 @@ import yaml from "yaml"
 import { sanitizer } from "@services/utilServices/Sanitizer"
 
 type YamlRecord = {
-  [key: string]: YamlRecord | string
+  [key: string]: YamlRecord | string | YamlRecord[]
 }
+
+const isArr = (t: unknown): t is Array<unknown> => !!(t as unknown[]).length
 
 const sanitizeYamlRecord = (yamlRec: YamlRecord): YamlRecord =>
   _(yamlRec)
     .mapValues((val) => {
       if (typeof val === "string") return sanitizer.sanitize(val)
+      if (isArr(val)) return val.map(sanitizeYamlRecord)
       return sanitizeYamlRecord(val)
     })
     .value()
@@ -21,7 +24,6 @@ export const sanitizedYamlParse = (
   unparsedContent: string
 ): Record<string, unknown> => {
   const parsedContent = yaml.parse(unparsedContent) as YamlRecord
-
   return sanitizeYamlRecord(parsedContent)
 }
 

--- a/src/utils/yaml-utils.ts
+++ b/src/utils/yaml-utils.ts
@@ -4,7 +4,7 @@ import yaml from "yaml"
 import { sanitizer } from "@services/utilServices/Sanitizer"
 
 type YamlRecord = {
-  [key: string]: YamlRecord | string | YamlRecord[]
+  [key: string]: YamlRecord | string | (YamlRecord | string)[]
 }
 
 const isArr = (t: unknown): t is Array<unknown> => !!(t as unknown[]).length
@@ -13,7 +13,10 @@ const sanitizeYamlRecord = (yamlRec: YamlRecord): YamlRecord =>
   _(yamlRec)
     .mapValues((val) => {
       if (typeof val === "string") return sanitizer.sanitize(val)
-      if (isArr(val)) return val.map(sanitizeYamlRecord)
+      if (isArr(val))
+        return val.map((v) =>
+          typeof v === "string" ? sanitizer.sanitize(v) : sanitizeYamlRecord(v)
+        )
       return sanitizeYamlRecord(val)
     })
     .value()


### PR DESCRIPTION
## Problem
the problem is that sanitizing in special pages (homepage, contact us, nav) leads to html tags being removed. though this is expected behaviour, it destructively interferes with user edits.

an example of this is when the user uses <a href = "something" /> to direct users to their internal link; this gets removed sadly and causes errors when we do yaml.parse post sanitization.

## Solution
sanitize the values post parsing rather than treating the yaml as a raw blob

## Dependencies
Upgraded `yaml` from 1.x to 2.x in order to use the `reviver/replacer` functionality. This operates on the value post parsing, which is what we desire. See [here](https://eemeli.org/yaml/#parse-amp-stringify) for more info on this.

This is a [breaking change](https://github.com/eemeli/yaml/releases/tag/v2.0.0) but we only use `.parse` (verified by global search on codebase) so this a safe upgrade for us