### PR TITLE
chore(review): fix tests for review router

### DIFF
--- a/src/routes/v2/authenticated/__tests__/review.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/review.spec.ts
@@ -137,7 +137,8 @@ describe("Review Requests Router", () => {
 
   describe("compareDiff", () => {
     beforeEach(() => {
-      // NOTE: Skip preconditions check for unmigrated site
+      // TODO (IS-58): Skip preconditions check for unmigrated site
+      // Remove this when sites are fully migrated over to email login
       mockCollaboratorsService.list.mockResolvedValueOnce([{}])
     })
     it("should return 200 with the list of changed files", async () => {
@@ -321,7 +322,8 @@ describe("Review Requests Router", () => {
 
   describe("listReviews", () => {
     beforeEach(() => {
-      // NOTE: Skip preconditions check for unmigrated site
+      // TODO (IS-58): Skip preconditions check for unmigrated site
+      // Remove this when sites are fully migrated over to email login
       mockCollaboratorsService.list.mockResolvedValueOnce([{}])
     })
     it("should return 200 with the list of reviews", async () => {
@@ -511,7 +513,8 @@ describe("Review Requests Router", () => {
 
   describe("getReviewRequest", () => {
     beforeEach(() => {
-      // NOTE: Skip preconditions check for unmigrated site
+      // TODO (IS-58): Skip preconditions check for unmigrated site
+      // Remove this when sites are fully migrated over to email login
       mockCollaboratorsService.list.mockResolvedValueOnce([{}])
     })
 
@@ -911,7 +914,8 @@ describe("Review Requests Router", () => {
 
   describe("getComments", () => {
     beforeEach(() => {
-      // NOTE: Skip preconditions check for unmigrated site
+      // TODO (IS-58): Skip preconditions check for unmigrated site
+      // Remove this when sites are fully migrated over to email login
       mockCollaboratorsService.list.mockResolvedValueOnce([{}])
     })
     it("should return 200 with the comments for a review request", async () => {

--- a/src/routes/v2/authenticated/__tests__/review.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/review.spec.ts
@@ -136,6 +136,10 @@ describe("Review Requests Router", () => {
   })
 
   describe("compareDiff", () => {
+    beforeEach(() => {
+      // NOTE: Skip preconditions check for unmigrated site
+      mockCollaboratorsService.list.mockResolvedValueOnce([{}])
+    })
     it("should return 200 with the list of changed files", async () => {
       // Arrange
       const mockFilesChanged = ["file1", "file2"]
@@ -144,7 +148,6 @@ describe("Review Requests Router", () => {
         mockFilesChanged
       )
       mockSitesService.getBySiteName.mockResolvedValueOnce(true)
-
       // Act
       const response = await request(app).get("/mockSite/review/compare")
 
@@ -317,6 +320,10 @@ describe("Review Requests Router", () => {
   })
 
   describe("listReviews", () => {
+    beforeEach(() => {
+      // NOTE: Skip preconditions check for unmigrated site
+      mockCollaboratorsService.list.mockResolvedValueOnce([{}])
+    })
     it("should return 200 with the list of reviews", async () => {
       // Arrange
       const mockReviews = ["review1", "review2"]
@@ -343,6 +350,7 @@ describe("Review Requests Router", () => {
       // Arrange
       mockSitesService.getBySiteName.mockResolvedValueOnce(null)
       mockGithubService.getRepoInfo.mockRejectedValueOnce(false)
+      mockIdentityUsersService.getSiteMember.mockResolvedValueOnce({})
 
       // Act
       const response = await request(app).get("/mockSite/review/summary")
@@ -502,6 +510,11 @@ describe("Review Requests Router", () => {
   })
 
   describe("getReviewRequest", () => {
+    beforeEach(() => {
+      // NOTE: Skip preconditions check for unmigrated site
+      mockCollaboratorsService.list.mockResolvedValueOnce([{}])
+    })
+
     it("should return 200 with the full review request", async () => {
       // Arrange
       const mockReviewRequest = "review request"
@@ -897,6 +910,10 @@ describe("Review Requests Router", () => {
   })
 
   describe("getComments", () => {
+    beforeEach(() => {
+      // NOTE: Skip preconditions check for unmigrated site
+      mockCollaboratorsService.list.mockResolvedValueOnce([{}])
+    })
     it("should return 200 with the comments for a review request", async () => {
       // Arrange
       const mockComments = ["comment1", "comment2"]


### PR DESCRIPTION
## Problem
Last release added a bunch of checks for sites that are undergoing a migration from github into our db (but not yet completed); this clashes with our code, which expects a **fully** migrated site (sites table in db populated, site members retrieved from db etc). 

This leads to a couple of tests failing in `review.spec.ts` as the calls to calculate those pre-conditions are not mocked. This PR fixes this by mocking said calls.

## Solution
for methods that have the new checks, there is a new `beforeEach` hook added to mock the call to the precondition. This causes the check to be false (ie, that the site has underwent a full migration), and continues on with the business logic rather than short-circuiting