### PR TITLE
fix(utils): sanitize empty string + trim

### DIFF
--- a/src/utils/yaml-utils.ts
+++ b/src/utils/yaml-utils.ts
@@ -8,10 +8,16 @@ export const sanitizedYamlParse = (
   unparsedContent: string
 ): Record<string, unknown> =>
   yaml.parse(unparsedContent, (key, value) =>
-    typeof value === "string" ? sanitizer.sanitize(value) : value
+    typeof value === "string" && !!value
+      ? // NOTE: We call `trim` here because post-sanitization,
+        // there could be an extra space.
+        // For example: `logo: path <script />`,
+        // which will be sanitized with a trailing space.
+        sanitizer.sanitize(value).trim()
+      : value
   )
 
 export const sanitizedYamlStringify = (prestringifiedContent: object): string =>
   yaml.stringify(prestringifiedContent, (key, value) =>
-    typeof value === "string" ? sanitizer.sanitize(value) : value
+    typeof value === "string" && !!value ? sanitizer.sanitize(value) : value
   )


### PR DESCRIPTION
## Problem
sanitization on empty strings lead to empty block comment; also, there is trailing space when sanitization does occur.

## Solution
`trim` post sanitization + don't sanitize if the string is empty
