### PR TITLE
Fix/rename subcollection and rename/delete resource room

### DIFF
--- a/src/routes/v2/authenticatedSites/__tests__/Collections.spec.js
+++ b/src/routes/v2/authenticatedSites/__tests__/Collections.spec.js
@@ -330,15 +330,11 @@ describe("Collections Router", () => {
         .expect(200)
       expect(
         mockSubcollectionDirectoryService.renameDirectory
-      ).toHaveBeenCalledWith(
-        mockUserWithSiteSessionData,
-        mockGithubSessionData,
-        {
-          collectionName,
-          subcollectionName,
-          newDirectoryName,
-        }
-      )
+      ).toHaveBeenCalledWith(mockUserWithSiteSessionData, {
+        collectionName,
+        subcollectionName,
+        newDirectoryName,
+      })
     })
   })
 

--- a/src/routes/v2/authenticatedSites/__tests__/ResourceRoom.spec.js
+++ b/src/routes/v2/authenticatedSites/__tests__/ResourceRoom.spec.js
@@ -4,7 +4,10 @@ const request = require("supertest")
 const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
 
 const { generateRouter } = require("@fixtures/app")
-const { mockUserWithSiteSessionData } = require("@fixtures/sessionData")
+const {
+  mockUserWithSiteSessionData,
+  mockGithubSessionData,
+} = require("@fixtures/sessionData")
 
 const { ResourceRoomRouter } = require("../resourceRoom")
 
@@ -136,10 +139,14 @@ describe("Resource Room Router", () => {
         .expect(200)
       expect(
         mockResourceRoomDirectoryService.renameResourceRoomDirectory
-      ).toHaveBeenCalledWith(mockUserWithSiteSessionData, {
-        resourceRoomName,
-        newDirectoryName,
-      })
+      ).toHaveBeenCalledWith(
+        mockUserWithSiteSessionData,
+        mockGithubSessionData,
+        {
+          resourceRoomName,
+          newDirectoryName,
+        }
+      )
     })
   })
 
@@ -150,9 +157,13 @@ describe("Resource Room Router", () => {
         .expect(200)
       expect(
         mockResourceRoomDirectoryService.deleteResourceRoomDirectory
-      ).toHaveBeenCalledWith(mockUserWithSiteSessionData, {
-        resourceRoomName,
-      })
+      ).toHaveBeenCalledWith(
+        mockUserWithSiteSessionData,
+        mockGithubSessionData,
+        {
+          resourceRoomName,
+        }
+      )
     })
   })
 })

--- a/src/routes/v2/authenticatedSites/collections.js
+++ b/src/routes/v2/authenticatedSites/collections.js
@@ -102,7 +102,6 @@ class CollectionsRouter {
     if (subcollectionName) {
       await this.subcollectionDirectoryService.renameDirectory(
         userWithSiteSessionData,
-        githubSessionData,
         {
           collectionName,
           subcollectionName,

--- a/src/routes/v2/authenticatedSites/resourceRoom.js
+++ b/src/routes/v2/authenticatedSites/resourceRoom.js
@@ -67,7 +67,7 @@ class ResourceRoomRouter {
 
   // Rename resource room
   async renameResourceRoomDirectory(req, res, next) {
-    const { userWithSiteSessionData } = res.locals
+    const { userWithSiteSessionData, githubSessionData } = res.locals
 
     const { resourceRoomName } = req.params
     const { error } = RenameResourceDirectoryRequestSchema.validate(req.body)
@@ -75,6 +75,7 @@ class ResourceRoomRouter {
     const { newDirectoryName } = req.body
     await this.resourceRoomDirectoryService.renameResourceRoomDirectory(
       userWithSiteSessionData,
+      githubSessionData,
       {
         resourceRoomName,
         newDirectoryName,
@@ -87,11 +88,12 @@ class ResourceRoomRouter {
 
   // Delete resource room
   async deleteResourceRoomDirectory(req, res) {
-    const { userWithSiteSessionData } = res.locals
+    const { userWithSiteSessionData, githubSessionData } = res.locals
 
     const { resourceRoomName } = req.params
     await this.resourceRoomDirectoryService.deleteResourceRoomDirectory(
       userWithSiteSessionData,
+      githubSessionData,
       {
         resourceRoomName,
       }

--- a/src/services/directoryServices/SubcollectionDirectoryService.js
+++ b/src/services/directoryServices/SubcollectionDirectoryService.js
@@ -21,8 +21,8 @@ class SubcollectionDirectoryService {
     this.gitHubService = gitHubService
   }
 
-  async listFiles(reqDetails, { collectionName, subcollectionName }) {
-    const files = await this.collectionYmlService.listContents(reqDetails, {
+  async listFiles(sessionData, { collectionName, subcollectionName }) {
+    const files = await this.collectionYmlService.listContents(sessionData, {
       collectionName,
     })
     const subcollectionFiles = files.filter(
@@ -39,7 +39,7 @@ class SubcollectionDirectoryService {
   }
 
   async createDirectory(
-    reqDetails,
+    sessionData,
     { collectionName, subcollectionName, objArray }
   ) {
     if (titleSpecialCharCheck({ title: subcollectionName, isFile: false }))
@@ -48,13 +48,13 @@ class SubcollectionDirectoryService {
       )
     const parsedSubcollectionName = deslugifyCollectionName(subcollectionName)
     const parsedDir = `_${collectionName}/${parsedSubcollectionName}`
-    await this.gitHubService.create(reqDetails, {
+    await this.gitHubService.create(sessionData, {
       content: "",
       fileName: PLACEHOLDER_FILE_NAME,
       directoryName: parsedDir,
     })
 
-    await this.collectionYmlService.addItemToOrder(reqDetails, {
+    await this.collectionYmlService.addItemToOrder(sessionData, {
       collectionName,
       item: `${parsedSubcollectionName}/${PLACEHOLDER_FILE_NAME}`,
     })
@@ -64,7 +64,7 @@ class SubcollectionDirectoryService {
       /* eslint-disable no-await-in-loop, no-restricted-syntax */
       for (const file of objArray) {
         const fileName = file.name
-        await this.moverService.movePage(reqDetails, {
+        await this.moverService.movePage(sessionData, {
           fileName,
           oldFileCollection: collectionName,
           newFileCollection: collectionName,
@@ -79,7 +79,7 @@ class SubcollectionDirectoryService {
   }
 
   async renameDirectory(
-    reqDetails,
+    sessionData,
     { collectionName, subcollectionName, newDirectoryName }
   ) {
     if (titleSpecialCharCheck({ title: newDirectoryName, isFile: false }))
@@ -88,7 +88,7 @@ class SubcollectionDirectoryService {
       )
     const parsedNewName = deslugifyCollectionName(newDirectoryName)
     const dir = `_${collectionName}/${subcollectionName}`
-    const files = await this.baseDirectoryService.list(reqDetails, {
+    const files = await this.baseDirectoryService.list(sessionData, {
       directoryName: dir,
     })
     // We can't perform these operations concurrently because of conflict issues
@@ -97,26 +97,26 @@ class SubcollectionDirectoryService {
       if (file.type !== "file") continue
       const fileName = file.name
       if (fileName === PLACEHOLDER_FILE_NAME) {
-        await this.gitHubService.delete(reqDetails, {
+        await this.gitHubService.delete(sessionData, {
           sha: file.sha,
           fileName,
           directoryName: dir,
         })
         continue
       }
-      await this.subcollectionPageService.updateSubcollection(reqDetails, {
+      await this.subcollectionPageService.updateSubcollection(sessionData, {
         fileName,
         collectionName,
         oldSubcollectionName: subcollectionName,
         newSubcollectionName: parsedNewName,
       })
     }
-    await this.gitHubService.create(reqDetails, {
+    await this.gitHubService.create(sessionData, {
       content: "",
       fileName: PLACEHOLDER_FILE_NAME,
       directoryName: `_${collectionName}/${parsedNewName}`,
     })
-    await this.collectionYmlService.renameSubfolderInOrder(reqDetails, {
+    await this.collectionYmlService.renameSubfolderInOrder(sessionData, {
       collectionName,
       oldSubfolder: subcollectionName,
       newSubfolder: parsedNewName,
@@ -124,29 +124,29 @@ class SubcollectionDirectoryService {
   }
 
   async deleteDirectory(
-    reqDetails,
+    sessionData,
     githubSessionData,
     { collectionName, subcollectionName }
   ) {
     const dir = `_${collectionName}/${subcollectionName}`
-    await this.baseDirectoryService.delete(reqDetails, githubSessionData, {
+    await this.baseDirectoryService.delete(sessionData, githubSessionData, {
       directoryName: dir,
       message: `Deleting subcollection ${collectionName}/${subcollectionName}`,
     })
-    await this.collectionYmlService.deleteSubfolderFromOrder(reqDetails, {
+    await this.collectionYmlService.deleteSubfolderFromOrder(sessionData, {
       collectionName,
       subfolder: subcollectionName,
     })
   }
 
   async reorderDirectory(
-    reqDetails,
+    sessionData,
     { collectionName, subcollectionName, objArray }
   ) {
     const newSubcollectionOrder = [`${subcollectionName}/.keep`].concat(
       objArray.map((obj) => `${subcollectionName}/${obj.name}`)
     )
-    const files = await this.collectionYmlService.listContents(reqDetails, {
+    const files = await this.collectionYmlService.listContents(sessionData, {
       collectionName,
     })
     const insertPos = files.findIndex((fileName) =>
@@ -158,7 +158,7 @@ class SubcollectionDirectoryService {
     )
     filteredFiles.splice(insertPos, 0, ...newSubcollectionOrder)
 
-    await this.collectionYmlService.updateOrder(reqDetails, {
+    await this.collectionYmlService.updateOrder(sessionData, {
       collectionName,
       newOrder: filteredFiles,
     })
@@ -166,7 +166,7 @@ class SubcollectionDirectoryService {
   }
 
   async movePages(
-    reqDetails,
+    sessionData,
     {
       collectionName,
       subcollectionName,
@@ -179,7 +179,7 @@ class SubcollectionDirectoryService {
     /* eslint-disable no-await-in-loop, no-restricted-syntax */
     for (const file of objArray) {
       const fileName = file.name
-      await this.moverService.movePage(reqDetails, {
+      await this.moverService.movePage(sessionData, {
         fileName,
         oldFileCollection: collectionName,
         oldFileSubcollection: subcollectionName,

--- a/src/services/directoryServices/__tests__/BaseDirectoryService.spec.js
+++ b/src/services/directoryServices/__tests__/BaseDirectoryService.spec.js
@@ -55,7 +55,7 @@ describe("Base Directory Service", () => {
     },
   ]
 
-  const reqDetails = { siteName, accessToken, currentCommitSha, treeSha }
+  const sessionData = { siteName, accessToken, currentCommitSha, treeSha }
 
   const mockGithubService = {
     readDirectory: jest.fn(),
@@ -99,13 +99,16 @@ describe("Base Directory Service", () => {
     mockGithubService.readDirectory.mockResolvedValueOnce(githubServiceResp)
     it("Listing directory contents filters and returns only relevant data", async () => {
       await expect(
-        service.list(reqDetails, {
+        service.list(sessionData, {
           directoryName,
         })
       ).resolves.toMatchObject(readDirResp)
-      expect(mockGithubService.readDirectory).toHaveBeenCalledWith(reqDetails, {
-        directoryName,
-      })
+      expect(mockGithubService.readDirectory).toHaveBeenCalledWith(
+        sessionData,
+        {
+          directoryName,
+        }
+      )
     })
   })
 
@@ -146,14 +149,14 @@ describe("Base Directory Service", () => {
     ])
     it("Renaming a directory to one with an existing name throws an error", async () => {
       await expect(
-        service.rename(reqDetails, mockGithubSessionData, {
+        service.rename(sessionData, mockGithubSessionData, {
           oldDirectoryName: directoryName,
           newDirectoryName: renamedDir,
           message,
         })
       ).rejects.toThrowError(ConflictError)
       expect(mockGithubService.getTree).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           isRecursive: true,
@@ -164,21 +167,21 @@ describe("Base Directory Service", () => {
     mockGithubService.updateTree.mockResolvedValueOnce(sha)
     it("Renaming directories works correctly", async () => {
       await expect(
-        service.rename(reqDetails, mockGithubSessionData, {
+        service.rename(sessionData, mockGithubSessionData, {
           oldDirectoryName: directoryName,
           newDirectoryName: renamedDir,
           message,
         })
       ).resolves.not.toThrow()
       expect(mockGithubService.getTree).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           isRecursive: true,
         }
       )
       expect(mockGithubService.updateTree).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           gitTree: mockedRenamedTree,
@@ -186,7 +189,7 @@ describe("Base Directory Service", () => {
         }
       )
       expect(mockGithubService.updateRepoState).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           commitSha: sha,
         }
@@ -221,20 +224,20 @@ describe("Base Directory Service", () => {
     mockGithubService.updateTree.mockResolvedValueOnce(sha)
     it("Deleting directories works correctly", async () => {
       await expect(
-        service.delete(reqDetails, mockGithubSessionData, {
+        service.delete(sessionData, mockGithubSessionData, {
           directoryName,
           message,
         })
       ).resolves.not.toThrow()
       expect(mockGithubService.getTree).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           isRecursive: true,
         }
       )
       expect(mockGithubService.updateTree).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           gitTree: mockedDeletedTree,
@@ -242,7 +245,7 @@ describe("Base Directory Service", () => {
         }
       )
       expect(mockGithubService.updateRepoState).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           commitSha: sha,
         }
@@ -281,7 +284,7 @@ describe("Base Directory Service", () => {
     ])
     it("Moving files to a directory which has a file of the same name throws an error", async () => {
       await expect(
-        service.moveFiles(reqDetails, mockGithubSessionData, {
+        service.moveFiles(sessionData, mockGithubSessionData, {
           oldDirectoryName: `${directoryName}/${subcollectionName}`,
           newDirectoryName: targetDir,
           targetFiles: ["file.md", "file2.md"],
@@ -289,7 +292,7 @@ describe("Base Directory Service", () => {
         })
       ).rejects.toThrowError(ConflictError)
       expect(mockGithubService.getTree).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           isRecursive: true,
@@ -300,7 +303,7 @@ describe("Base Directory Service", () => {
     mockGithubService.updateTree.mockResolvedValueOnce(sha)
     it("Moving files in directories works correctly", async () => {
       await expect(
-        service.moveFiles(reqDetails, mockGithubSessionData, {
+        service.moveFiles(sessionData, mockGithubSessionData, {
           oldDirectoryName: `${directoryName}/${subcollectionName}`,
           newDirectoryName: targetDir,
           targetFiles: ["file.md", "file2.md"],
@@ -308,14 +311,14 @@ describe("Base Directory Service", () => {
         })
       ).resolves.not.toThrow()
       expect(mockGithubService.getTree).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           isRecursive: true,
         }
       )
       expect(mockGithubService.updateTree).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           gitTree: mockedMovedTree,
@@ -323,7 +326,7 @@ describe("Base Directory Service", () => {
         }
       )
       expect(mockGithubService.updateRepoState).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           commitSha: sha,
         }

--- a/src/services/directoryServices/__tests__/MediaDirectoryService.spec.js
+++ b/src/services/directoryServices/__tests__/MediaDirectoryService.spec.js
@@ -26,7 +26,7 @@ describe("Media Directory Service", () => {
     },
   ]
 
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
 
   const mockBaseDirectoryService = {
     list: jest.fn(),
@@ -119,13 +119,13 @@ describe("Media Directory Service", () => {
         },
       ]
       await expect(
-        service.listFiles(reqDetails, {
+        service.listFiles(sessionData, {
           mediaType: "images",
           directoryName: imageDirectoryName,
         })
       ).resolves.toMatchObject(expectedResp)
-      expect(mockGitHubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
-      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.getRepoInfo).toHaveBeenCalledWith(sessionData)
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(sessionData, {
         directoryName: imageDirectoryName,
       })
     })
@@ -159,13 +159,13 @@ describe("Media Directory Service", () => {
         },
       ]
       await expect(
-        service.listFiles(reqDetails, {
+        service.listFiles(sessionData, {
           mediaType: "images",
           directoryName: imageDirectoryName,
         })
       ).resolves.toMatchObject(expectedResp)
-      expect(mockGitHubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
-      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.getRepoInfo).toHaveBeenCalledWith(sessionData)
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(sessionData, {
         directoryName: imageDirectoryName,
       })
     })
@@ -193,13 +193,13 @@ describe("Media Directory Service", () => {
         },
       ]
       await expect(
-        service.listFiles(reqDetails, {
+        service.listFiles(sessionData, {
           mediaType: "files",
           directoryName: fileDirectoryName,
         })
       ).resolves.toMatchObject(expectedResp)
-      expect(mockGitHubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
-      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.getRepoInfo).toHaveBeenCalledWith(sessionData)
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(sessionData, {
         directoryName: fileDirectoryName,
       })
     })
@@ -208,7 +208,7 @@ describe("Media Directory Service", () => {
   describe("CreateMediaDirectory", () => {
     it("rejects directories with special characters", async () => {
       await expect(
-        service.createMediaDirectory(reqDetails, mockGithubSessionData, {
+        service.createMediaDirectory(sessionData, mockGithubSessionData, {
           directoryName: "dir/dir",
           objArray: undefined,
         })
@@ -217,14 +217,14 @@ describe("Media Directory Service", () => {
 
     it("Creating a directory with no specified files works correctly", async () => {
       await expect(
-        service.createMediaDirectory(reqDetails, mockGithubSessionData, {
+        service.createMediaDirectory(sessionData, mockGithubSessionData, {
           directoryName: imageDirectoryName,
           objArray: undefined,
         })
       ).resolves.toMatchObject({
         newDirectoryName: `images/${imageSubdirectory}`,
       })
-      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.create).toHaveBeenCalledWith(sessionData, {
         content: "",
         fileName: PLACEHOLDER_FILE_NAME,
         directoryName: imageDirectoryName,
@@ -244,20 +244,20 @@ describe("Media Directory Service", () => {
         },
       ]
       await expect(
-        service.createMediaDirectory(reqDetails, mockGithubSessionData, {
+        service.createMediaDirectory(sessionData, mockGithubSessionData, {
           directoryName: newDirectoryName,
           objArray,
         })
       ).resolves.toMatchObject({
         newDirectoryName,
       })
-      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.create).toHaveBeenCalledWith(sessionData, {
         content: "",
         fileName: PLACEHOLDER_FILE_NAME,
         directoryName: newDirectoryName,
       })
       expect(mockBaseDirectoryService.moveFiles).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           oldDirectoryName: fileDirectoryName,
@@ -273,7 +273,7 @@ describe("Media Directory Service", () => {
     const newDirectoryName = "images/new dir"
     it("rejects names with special characters", async () => {
       await expect(
-        service.renameMediaDirectory(reqDetails, mockGithubSessionData, {
+        service.renameMediaDirectory(sessionData, mockGithubSessionData, {
           directoryName: imageDirectoryName,
           newDirectoryName: "dir/dir",
         })
@@ -282,13 +282,13 @@ describe("Media Directory Service", () => {
 
     it("Renaming a media directory works correctly", async () => {
       await expect(
-        service.renameMediaDirectory(reqDetails, mockGithubSessionData, {
+        service.renameMediaDirectory(sessionData, mockGithubSessionData, {
           directoryName: imageDirectoryName,
           newDirectoryName,
         })
       ).resolves.not.toThrowError()
       expect(mockBaseDirectoryService.rename).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           oldDirectoryName: imageDirectoryName,
@@ -302,12 +302,12 @@ describe("Media Directory Service", () => {
   describe("DeleteMediaDirectory", () => {
     it("Deleting a directory works correctly", async () => {
       await expect(
-        service.deleteMediaDirectory(reqDetails, mockGithubSessionData, {
+        service.deleteMediaDirectory(sessionData, mockGithubSessionData, {
           directoryName: imageDirectoryName,
         })
       ).resolves.not.toThrowError()
       expect(mockBaseDirectoryService.delete).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           directoryName: imageDirectoryName,
@@ -322,14 +322,14 @@ describe("Media Directory Service", () => {
     const targetFiles = objArray.map((item) => item.name)
     it("Moving media in a media directory to another media directory works correctly", async () => {
       await expect(
-        service.moveMediaFiles(reqDetails, mockGithubSessionData, {
+        service.moveMediaFiles(sessionData, mockGithubSessionData, {
           directoryName: fileDirectoryName,
           targetDirectoryName,
           objArray,
         })
       ).resolves.not.toThrowError()
       expect(mockBaseDirectoryService.moveFiles).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           oldDirectoryName: fileDirectoryName,

--- a/src/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
+++ b/src/services/directoryServices/__tests__/ResourceDirectoryService.spec.js
@@ -29,7 +29,7 @@ describe("Resource Directory Service", () => {
     },
   ]
 
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
 
   const mockBaseDirectoryService = {
     list: jest.fn(),
@@ -141,15 +141,15 @@ describe("Resource Directory Service", () => {
     mockBaseDirectoryService.list.mockResolvedValueOnce(listResp)
     it("ListFiles returns all files in the category", async () => {
       await expect(
-        service.listFiles(reqDetails, {
+        service.listFiles(sessionData, {
           resourceRoomName,
           resourceCategoryName,
         })
       ).resolves.toMatchObject(expectedResp)
-      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(sessionData, {
         directoryName: resourceRoomName,
       })
-      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(sessionData, {
         directoryName: `${directoryName}/_posts`,
       })
     })
@@ -157,27 +157,27 @@ describe("Resource Directory Service", () => {
     mockBaseDirectoryService.list.mockRejectedValueOnce(new NotFoundError(""))
     it("ListFiles returns an empty array if resource category contains no files is thrown", async () => {
       await expect(
-        service.listFiles(reqDetails, {
+        service.listFiles(sessionData, {
           resourceRoomName,
           resourceCategoryName,
         })
       ).resolves.toMatchObject([])
-      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(sessionData, {
         directoryName: resourceRoomName,
       })
-      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(sessionData, {
         directoryName: `${directoryName}/_posts`,
       })
     })
     mockBaseDirectoryService.list.mockResolvedValueOnce(listDirResp)
     it("ListFiles returns an error if resource category does not exist", async () => {
       await expect(
-        service.listFiles(reqDetails, {
+        service.listFiles(sessionData, {
           resourceRoomName,
           resourceCategoryName: "fake-category",
         })
       ).rejects.toThrowError(NotFoundError)
-      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(sessionData, {
         directoryName: resourceRoomName,
       })
     })
@@ -186,7 +186,7 @@ describe("Resource Directory Service", () => {
   describe("CreateResourceDirectory", () => {
     it("rejects resource categories with special characters", async () => {
       await expect(
-        service.createResourceDirectory(reqDetails, {
+        service.createResourceDirectory(sessionData, {
           resourceRoomName,
           resourceCategoryName: "dir/dir",
         })
@@ -195,7 +195,7 @@ describe("Resource Directory Service", () => {
 
     it("Creating a resource category works correctly", async () => {
       await expect(
-        service.createResourceDirectory(reqDetails, {
+        service.createResourceDirectory(sessionData, {
           resourceRoomName,
           resourceCategoryName,
         })
@@ -206,7 +206,7 @@ describe("Resource Directory Service", () => {
         { ...mockFrontMatter },
         mockContent
       )
-      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName: INDEX_FILE_NAME,
         directoryName,
@@ -217,7 +217,7 @@ describe("Resource Directory Service", () => {
       const originalCategoryName = "Test Category"
       const slugifiedCategoryName = "test-category"
       await expect(
-        service.createResourceDirectory(reqDetails, {
+        service.createResourceDirectory(sessionData, {
           resourceRoomName,
           resourceCategoryName: originalCategoryName,
         })
@@ -231,7 +231,7 @@ describe("Resource Directory Service", () => {
         },
         mockContent
       )
-      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName: INDEX_FILE_NAME,
         directoryName: `${resourceRoomName}/${slugifiedCategoryName}`,
@@ -243,7 +243,7 @@ describe("Resource Directory Service", () => {
     const newDirectoryName = "new-dir"
     it("rejects resource categories with special characters", async () => {
       await expect(
-        service.renameResourceDirectory(reqDetails, mockGithubSessionData, {
+        service.renameResourceDirectory(sessionData, mockGithubSessionData, {
           resourceRoomName,
           resourceCategoryName,
           newDirectoryName: "dir/dir",
@@ -256,14 +256,14 @@ describe("Resource Directory Service", () => {
     })
     it("Renaming a resource category works correctly", async () => {
       await expect(
-        service.renameResourceDirectory(reqDetails, mockGithubSessionData, {
+        service.renameResourceDirectory(sessionData, mockGithubSessionData, {
           resourceRoomName,
           resourceCategoryName,
           newDirectoryName,
         })
       ).resolves.not.toThrowError()
 
-      expect(mockGitHubService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.read).toHaveBeenCalledWith(sessionData, {
         fileName: INDEX_FILE_NAME,
         directoryName,
       })
@@ -276,7 +276,7 @@ describe("Resource Directory Service", () => {
         mockContent
       )
       expect(mockBaseDirectoryService.rename).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           oldDirectoryName: directoryName,
@@ -284,7 +284,7 @@ describe("Resource Directory Service", () => {
           message: `Renaming resource category ${resourceCategoryName} to ${newDirectoryName}`,
         }
       )
-      expect(mockGitHubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.update).toHaveBeenCalledWith(sessionData, {
         fileContent: mockMarkdownContent,
         sha,
         fileName: INDEX_FILE_NAME,
@@ -304,14 +304,14 @@ describe("Resource Directory Service", () => {
       const slugifiedResourceCategory = "test-resource"
 
       await expect(
-        service.renameResourceDirectory(reqDetails, mockGithubSessionData, {
+        service.renameResourceDirectory(sessionData, mockGithubSessionData, {
           resourceRoomName,
           resourceCategoryName,
           newDirectoryName: originalResourceCategory,
         })
       ).resolves.not.toThrowError()
 
-      expect(mockGitHubService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.read).toHaveBeenCalledWith(sessionData, {
         fileName: INDEX_FILE_NAME,
         directoryName,
       })
@@ -324,7 +324,7 @@ describe("Resource Directory Service", () => {
         mockContent
       )
       expect(mockBaseDirectoryService.rename).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           oldDirectoryName: directoryName,
@@ -332,7 +332,7 @@ describe("Resource Directory Service", () => {
           message: `Renaming resource category ${resourceCategoryName} to ${slugifiedResourceCategory}`,
         }
       )
-      expect(mockGitHubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.update).toHaveBeenCalledWith(sessionData, {
         fileContent: mockMarkdownContent,
         sha,
         fileName: INDEX_FILE_NAME,
@@ -347,13 +347,13 @@ describe("Resource Directory Service", () => {
   describe("DeleteResourceDirectory", () => {
     it("Deleting a resource category works correctly", async () => {
       await expect(
-        service.deleteResourceDirectory(reqDetails, mockGithubSessionData, {
+        service.deleteResourceDirectory(sessionData, mockGithubSessionData, {
           resourceRoomName,
           resourceCategoryName,
         })
       ).resolves.not.toThrowError()
       expect(mockBaseDirectoryService.delete).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           directoryName,
@@ -368,7 +368,7 @@ describe("Resource Directory Service", () => {
     const targetFiles = ["file.md", "file2.md"]
     it("Moving resource pages works correctly", async () => {
       await expect(
-        service.moveResourcePages(reqDetails, mockGithubSessionData, {
+        service.moveResourcePages(sessionData, mockGithubSessionData, {
           resourceRoomName,
           resourceCategoryName,
           targetResourceCategory,
@@ -376,7 +376,7 @@ describe("Resource Directory Service", () => {
         })
       ).resolves.not.toThrowError()
       expect(mockBaseDirectoryService.moveFiles).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           oldDirectoryName: `${directoryName}/_posts`,

--- a/src/services/directoryServices/__tests__/ResourceRoomDirectoryService.spec.js
+++ b/src/services/directoryServices/__tests__/ResourceRoomDirectoryService.spec.js
@@ -28,7 +28,7 @@ describe("Resource Room Directory Service", () => {
   const sha = "12345"
   const mockGithubSessionData = "mockData"
 
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
 
   const mockBaseDirectoryService = {
     list: jest.fn(),
@@ -109,9 +109,9 @@ describe("Resource Room Directory Service", () => {
     mockBaseDirectoryService.list.mockResolvedValueOnce(listResp)
     it("Listing resource categories returns the full list of resource categories", async () => {
       await expect(
-        service.listAllResourceCategories(reqDetails, { resourceRoomName })
+        service.listAllResourceCategories(sessionData, { resourceRoomName })
       ).resolves.toMatchObject(expectedResp)
-      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(sessionData, {
         directoryName: resourceRoomName,
       })
     })
@@ -124,18 +124,18 @@ describe("Resource Room Directory Service", () => {
     })
     it("Getting the resource room name works correctly", async () => {
       await expect(
-        service.getResourceRoomDirectoryName(reqDetails)
+        service.getResourceRoomDirectoryName(sessionData)
       ).resolves.toMatchObject({
         resourceRoomName: mockConfigContent.resources_name,
       })
-      expect(mockConfigYmlService.read).toHaveBeenCalledWith(reqDetails)
+      expect(mockConfigYmlService.read).toHaveBeenCalledWith(sessionData)
     })
   })
 
   describe("CreateResourceRoomDirectory", () => {
     it("rejects resource room names with special characters", async () => {
       await expect(
-        service.createResourceRoomDirectory(reqDetails, {
+        service.createResourceRoomDirectory(sessionData, {
           resourceRoomName: "dir/dir",
         })
       ).rejects.toThrowError(BadRequestError)
@@ -147,7 +147,7 @@ describe("Resource Room Directory Service", () => {
     })
     it("Creating a resource room works correctly", async () => {
       await expect(
-        service.createResourceRoomDirectory(reqDetails, {
+        service.createResourceRoomDirectory(sessionData, {
           resourceRoomName,
         })
       ).resolves.toMatchObject({
@@ -157,13 +157,13 @@ describe("Resource Room Directory Service", () => {
         { ...mockFrontMatter },
         mockContent
       )
-      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName: INDEX_FILE_NAME,
         directoryName,
       })
-      expect(mockConfigYmlService.read).toHaveBeenCalledWith(reqDetails)
-      expect(mockConfigYmlService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockConfigYmlService.read).toHaveBeenCalledWith(sessionData)
+      expect(mockConfigYmlService.update).toHaveBeenCalledWith(sessionData, {
         fileContent: {
           ...mockConfigContent,
           resources_name: resourceRoomName,
@@ -180,7 +180,7 @@ describe("Resource Room Directory Service", () => {
       const originalRoomName = "Test Room"
       const slugifiedRoomName = "test-room"
       await expect(
-        service.createResourceRoomDirectory(reqDetails, {
+        service.createResourceRoomDirectory(sessionData, {
           resourceRoomName: originalRoomName,
         })
       ).resolves.toMatchObject({
@@ -193,13 +193,13 @@ describe("Resource Room Directory Service", () => {
         },
         mockContent
       )
-      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName: INDEX_FILE_NAME,
         directoryName: slugifiedRoomName,
       })
-      expect(mockConfigYmlService.read).toHaveBeenCalledWith(reqDetails)
-      expect(mockConfigYmlService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockConfigYmlService.read).toHaveBeenCalledWith(sessionData)
+      expect(mockConfigYmlService.update).toHaveBeenCalledWith(sessionData, {
         fileContent: {
           ...mockConfigContent,
           resources_name: slugifiedRoomName,
@@ -214,11 +214,11 @@ describe("Resource Room Directory Service", () => {
     })
     it("Creating a resource room throws error if one already exists", async () => {
       await expect(
-        service.createResourceRoomDirectory(reqDetails, {
+        service.createResourceRoomDirectory(sessionData, {
           resourceRoomName,
         })
       ).rejects.toThrowError(ConflictError)
-      expect(mockConfigYmlService.read).toHaveBeenCalledWith(reqDetails)
+      expect(mockConfigYmlService.read).toHaveBeenCalledWith(sessionData)
     })
   })
 
@@ -227,10 +227,14 @@ describe("Resource Room Directory Service", () => {
     const configSha = "23456"
     it("rejects resource room names with special characters", async () => {
       await expect(
-        service.renameResourceRoomDirectory(reqDetails, mockGithubSessionData, {
-          resourceRoomName,
-          newDirectoryName: "dir/dir",
-        })
+        service.renameResourceRoomDirectory(
+          sessionData,
+          mockGithubSessionData,
+          {
+            resourceRoomName,
+            newDirectoryName: "dir/dir",
+          }
+        )
       ).rejects.toThrowError(BadRequestError)
     })
 
@@ -244,12 +248,16 @@ describe("Resource Room Directory Service", () => {
     })
     it("Renaming a resource room works correctly", async () => {
       await expect(
-        service.renameResourceRoomDirectory(reqDetails, mockGithubSessionData, {
-          resourceRoomName,
-          newDirectoryName,
-        })
+        service.renameResourceRoomDirectory(
+          sessionData,
+          mockGithubSessionData,
+          {
+            resourceRoomName,
+            newDirectoryName,
+          }
+        )
       ).resolves.not.toThrowError()
-      expect(mockGitHubService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.read).toHaveBeenCalledWith(sessionData, {
         fileName: INDEX_FILE_NAME,
         directoryName,
       })
@@ -261,14 +269,14 @@ describe("Resource Room Directory Service", () => {
         },
         mockContent
       )
-      expect(mockGitHubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.update).toHaveBeenCalledWith(sessionData, {
         fileContent: mockMarkdownContent,
         sha,
         fileName: INDEX_FILE_NAME,
         directoryName: newDirectoryName,
       })
       expect(mockBaseDirectoryService.rename).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           oldDirectoryName: directoryName,
@@ -276,8 +284,8 @@ describe("Resource Room Directory Service", () => {
           message: `Renaming resource room from ${resourceRoomName} to ${newDirectoryName}`,
         }
       )
-      expect(mockConfigYmlService.read).toHaveBeenCalledWith(reqDetails)
-      expect(mockConfigYmlService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockConfigYmlService.read).toHaveBeenCalledWith(sessionData)
+      expect(mockConfigYmlService.update).toHaveBeenCalledWith(sessionData, {
         fileContent: {
           ...mockConfigContent,
           resources_name: newDirectoryName,
@@ -297,12 +305,16 @@ describe("Resource Room Directory Service", () => {
       const originalResourceRoom = "Test Resource"
       const slugifiedResourceRoom = "test-resource"
       await expect(
-        service.renameResourceRoomDirectory(reqDetails, mockGithubSessionData, {
-          resourceRoomName,
-          newDirectoryName: originalResourceRoom,
-        })
+        service.renameResourceRoomDirectory(
+          sessionData,
+          mockGithubSessionData,
+          {
+            resourceRoomName,
+            newDirectoryName: originalResourceRoom,
+          }
+        )
       ).resolves.not.toThrowError()
-      expect(mockGitHubService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.read).toHaveBeenCalledWith(sessionData, {
         fileName: INDEX_FILE_NAME,
         directoryName,
       })
@@ -314,14 +326,14 @@ describe("Resource Room Directory Service", () => {
         },
         mockContent
       )
-      expect(mockGitHubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.update).toHaveBeenCalledWith(sessionData, {
         fileContent: mockMarkdownContent,
         sha,
         fileName: INDEX_FILE_NAME,
         directoryName: slugifiedResourceRoom,
       })
       expect(mockBaseDirectoryService.rename).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           oldDirectoryName: directoryName,
@@ -329,8 +341,8 @@ describe("Resource Room Directory Service", () => {
           message: `Renaming resource room from ${resourceRoomName} to ${slugifiedResourceRoom}`,
         }
       )
-      expect(mockConfigYmlService.read).toHaveBeenCalledWith(reqDetails)
-      expect(mockConfigYmlService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockConfigYmlService.read).toHaveBeenCalledWith(sessionData)
+      expect(mockConfigYmlService.update).toHaveBeenCalledWith(sessionData, {
         fileContent: {
           ...mockConfigContent,
           resources_name: slugifiedResourceRoom,
@@ -347,22 +359,26 @@ describe("Resource Room Directory Service", () => {
     })
     it("Deleting a resource room works correctly", async () => {
       await expect(
-        service.deleteResourceRoomDirectory(reqDetails, mockGithubSessionData, {
-          resourceRoomName,
-        })
+        service.deleteResourceRoomDirectory(
+          sessionData,
+          mockGithubSessionData,
+          {
+            resourceRoomName,
+          }
+        )
       ).resolves.not.toThrowError()
       expect(mockBaseDirectoryService.delete).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           directoryName,
           message: `Deleting resource room ${resourceRoomName}`,
         }
       )
-      expect(mockConfigYmlService.read).toHaveBeenCalledWith(reqDetails)
+      expect(mockConfigYmlService.read).toHaveBeenCalledWith(sessionData)
       const newConfigContent = { ...mockConfigContent }
       delete newConfigContent.resources_name
-      expect(mockConfigYmlService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockConfigYmlService.update).toHaveBeenCalledWith(sessionData, {
         fileContent: newConfigContent,
         sha,
       })

--- a/src/services/directoryServices/__tests__/SubcollectionDirectoryService.spec.js
+++ b/src/services/directoryServices/__tests__/SubcollectionDirectoryService.spec.js
@@ -20,7 +20,7 @@ describe("Subcollection Directory Service", () => {
     },
   ]
 
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
 
   const mockBaseDirectoryService = {
     list: jest.fn(),
@@ -85,10 +85,10 @@ describe("Subcollection Directory Service", () => {
     mockCollectionYmlService.listContents.mockResolvedValueOnce(listResp)
     it("ListFiles returns all files properly formatted", async () => {
       await expect(
-        service.listFiles(reqDetails, { collectionName, subcollectionName })
+        service.listFiles(sessionData, { collectionName, subcollectionName })
       ).resolves.toMatchObject(expectedResp)
       expect(mockCollectionYmlService.listContents).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           collectionName,
         }
@@ -100,7 +100,7 @@ describe("Subcollection Directory Service", () => {
     const parsedDir = `_${collectionName}/${subcollectionName}`
     it("rejects subcollection names with special characters", async () => {
       await expect(
-        service.createDirectory(reqDetails, {
+        service.createDirectory(sessionData, {
           collectionName,
           subcollectionName: "dir/dir",
         })
@@ -108,7 +108,7 @@ describe("Subcollection Directory Service", () => {
     })
     it("Creating a directory with no specified files works correctly", async () => {
       await expect(
-        service.createDirectory(reqDetails, {
+        service.createDirectory(sessionData, {
           collectionName,
           subcollectionName,
         })
@@ -116,13 +116,13 @@ describe("Subcollection Directory Service", () => {
         newDirectoryName: subcollectionName,
         items: [],
       })
-      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.create).toHaveBeenCalledWith(sessionData, {
         content: "",
         fileName: PLACEHOLDER_FILE_NAME,
         directoryName: parsedDir,
       })
       expect(mockCollectionYmlService.addItemToOrder).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           collectionName,
           item: `${subcollectionName}/${PLACEHOLDER_FILE_NAME}`,
@@ -132,7 +132,7 @@ describe("Subcollection Directory Service", () => {
 
     it("Creating a directory with specified files works correctly", async () => {
       await expect(
-        service.createDirectory(reqDetails, {
+        service.createDirectory(sessionData, {
           collectionName,
           subcollectionName,
           objArray,
@@ -141,20 +141,20 @@ describe("Subcollection Directory Service", () => {
         newDirectoryName: subcollectionName,
         items: objArray,
       })
-      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.create).toHaveBeenCalledWith(sessionData, {
         content: "",
         fileName: PLACEHOLDER_FILE_NAME,
         directoryName: parsedDir,
       })
       expect(mockCollectionYmlService.addItemToOrder).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           collectionName,
           item: `${subcollectionName}/${PLACEHOLDER_FILE_NAME}`,
         }
       )
       objArray.forEach((file) => {
-        expect(mockMoverService.movePage).toHaveBeenCalledWith(reqDetails, {
+        expect(mockMoverService.movePage).toHaveBeenCalledWith(sessionData, {
           fileName: file.name,
           oldFileCollection: collectionName,
           newFileCollection: collectionName,
@@ -167,7 +167,7 @@ describe("Subcollection Directory Service", () => {
       const originalTitle = `hEllo there`
       const expectedTitle = `HEllo there`
       await expect(
-        service.createDirectory(reqDetails, {
+        service.createDirectory(sessionData, {
           collectionName,
           subcollectionName: originalTitle,
           objArray,
@@ -176,20 +176,20 @@ describe("Subcollection Directory Service", () => {
         newDirectoryName: expectedTitle,
         items: objArray,
       })
-      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.create).toHaveBeenCalledWith(sessionData, {
         content: "",
         fileName: PLACEHOLDER_FILE_NAME,
         directoryName: `_${collectionName}/${expectedTitle}`,
       })
       expect(mockCollectionYmlService.addItemToOrder).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           collectionName,
           item: `${expectedTitle}/${PLACEHOLDER_FILE_NAME}`,
         }
       )
       objArray.forEach((file) => {
-        expect(mockMoverService.movePage).toHaveBeenCalledWith(reqDetails, {
+        expect(mockMoverService.movePage).toHaveBeenCalledWith(sessionData, {
           fileName: file.name,
           oldFileCollection: collectionName,
           newFileCollection: collectionName,
@@ -227,7 +227,7 @@ describe("Subcollection Directory Service", () => {
 
     it("rejects subcollection names with special characters", async () => {
       await expect(
-        service.renameDirectory(reqDetails, {
+        service.renameDirectory(sessionData, {
           collectionName,
           subcollectionName,
           newDirectoryName: "dir/dir",
@@ -239,18 +239,18 @@ describe("Subcollection Directory Service", () => {
       const newDirectoryName = "New Dir"
       mockBaseDirectoryService.list.mockResolvedValueOnce(readDirResp)
       await expect(
-        service.renameDirectory(reqDetails, {
+        service.renameDirectory(sessionData, {
           collectionName,
           subcollectionName,
           newDirectoryName,
         })
       ).resolves.not.toThrowError()
-      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(sessionData, {
         directoryName: dir,
       })
       readDirResp.forEach((file) => {
         if (file.name === PLACEHOLDER_FILE_NAME) {
-          expect(mockGitHubService.delete).toHaveBeenCalledWith(reqDetails, {
+          expect(mockGitHubService.delete).toHaveBeenCalledWith(sessionData, {
             sha: file.sha,
             fileName: file.name,
             directoryName: dir,
@@ -258,7 +258,7 @@ describe("Subcollection Directory Service", () => {
         } else {
           expect(
             mockSubcollectionPageService.updateSubcollection
-          ).toHaveBeenCalledWith(reqDetails, {
+          ).toHaveBeenCalledWith(sessionData, {
             fileName: file.name,
             collectionName,
             oldSubcollectionName: subcollectionName,
@@ -266,13 +266,13 @@ describe("Subcollection Directory Service", () => {
           })
         }
       })
-      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.create).toHaveBeenCalledWith(sessionData, {
         content: "",
         fileName: PLACEHOLDER_FILE_NAME,
         directoryName: `_${collectionName}/${newDirectoryName}`,
       })
       expect(
-        mockCollectionYmlService.renameSubfolderInOrder(reqDetails, {
+        mockCollectionYmlService.renameSubfolderInOrder(sessionData, {
           collectionName,
           oldSubfolder: subcollectionName,
           newSubfolder: newDirectoryName,
@@ -285,18 +285,18 @@ describe("Subcollection Directory Service", () => {
       const expectedTitle = `HEllo there`
       mockBaseDirectoryService.list.mockResolvedValueOnce(readDirResp)
       await expect(
-        service.renameDirectory(reqDetails, {
+        service.renameDirectory(sessionData, {
           collectionName,
           subcollectionName,
           newDirectoryName: originalTitle,
         })
       ).resolves.not.toThrowError()
-      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(sessionData, {
         directoryName: dir,
       })
       readDirResp.forEach((file) => {
         if (file.name === PLACEHOLDER_FILE_NAME) {
-          expect(mockGitHubService.delete).toHaveBeenCalledWith(reqDetails, {
+          expect(mockGitHubService.delete).toHaveBeenCalledWith(sessionData, {
             sha: file.sha,
             fileName: file.name,
             directoryName: dir,
@@ -304,7 +304,7 @@ describe("Subcollection Directory Service", () => {
         } else {
           expect(
             mockSubcollectionPageService.updateSubcollection
-          ).toHaveBeenCalledWith(reqDetails, {
+          ).toHaveBeenCalledWith(sessionData, {
             fileName: file.name,
             collectionName,
             oldSubcollectionName: subcollectionName,
@@ -312,13 +312,13 @@ describe("Subcollection Directory Service", () => {
           })
         }
       })
-      expect(mockGitHubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGitHubService.create).toHaveBeenCalledWith(sessionData, {
         content: "",
         fileName: PLACEHOLDER_FILE_NAME,
         directoryName: `_${collectionName}/${expectedTitle}`,
       })
       expect(
-        mockCollectionYmlService.renameSubfolderInOrder(reqDetails, {
+        mockCollectionYmlService.renameSubfolderInOrder(sessionData, {
           collectionName,
           oldSubfolder: subcollectionName,
           newSubfolder: expectedTitle,
@@ -330,13 +330,13 @@ describe("Subcollection Directory Service", () => {
   describe("DeleteDirectory", () => {
     it("Deleting a directory works correctly", async () => {
       await expect(
-        service.deleteDirectory(reqDetails, mockGithubSessionData, {
+        service.deleteDirectory(sessionData, mockGithubSessionData, {
           collectionName,
           subcollectionName,
         })
       ).resolves.not.toThrowError()
       expect(mockBaseDirectoryService.delete).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           directoryName: `_${collectionName}/${subcollectionName}`,
@@ -345,7 +345,7 @@ describe("Subcollection Directory Service", () => {
       )
       expect(
         mockCollectionYmlService.deleteSubfolderFromOrder
-      ).toHaveBeenCalledWith(reqDetails, {
+      ).toHaveBeenCalledWith(sessionData, {
         collectionName,
         subfolder: subcollectionName,
       })
@@ -382,14 +382,14 @@ describe("Subcollection Directory Service", () => {
     mockCollectionYmlService.listContents.mockResolvedValueOnce(listResp)
     it("Reordering a directory works correctly", async () => {
       await expect(
-        service.reorderDirectory(reqDetails, {
+        service.reorderDirectory(sessionData, {
           collectionName,
           subcollectionName,
           objArray: newObjArray,
         })
       ).resolves.toMatchObject(newObjArray)
       expect(mockCollectionYmlService.updateOrder).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           collectionName,
           newOrder: expectedNewOrder,
@@ -403,14 +403,14 @@ describe("Subcollection Directory Service", () => {
     const targetSubcollectionName = "target-subcollection"
     it("Moving pages in a subcollection to unlinked pages works correctly", async () => {
       await expect(
-        service.movePages(reqDetails, {
+        service.movePages(sessionData, {
           collectionName,
           subcollectionName,
           objArray,
         })
       ).resolves.not.toThrowError()
       objArray.forEach((file) => {
-        expect(mockMoverService.movePage).toHaveBeenCalledWith(reqDetails, {
+        expect(mockMoverService.movePage).toHaveBeenCalledWith(sessionData, {
           fileName: file.name,
           oldFileCollection: collectionName,
           oldFileSubcollection: subcollectionName,
@@ -419,7 +419,7 @@ describe("Subcollection Directory Service", () => {
     })
     it("Moving pages in a subcollection to a collection works correctly", async () => {
       await expect(
-        service.movePages(reqDetails, {
+        service.movePages(sessionData, {
           collectionName,
           subcollectionName,
           targetCollectionName,
@@ -427,7 +427,7 @@ describe("Subcollection Directory Service", () => {
         })
       ).resolves.not.toThrowError()
       objArray.forEach((file) => {
-        expect(mockMoverService.movePage).toHaveBeenCalledWith(reqDetails, {
+        expect(mockMoverService.movePage).toHaveBeenCalledWith(sessionData, {
           fileName: file.name,
           oldFileCollection: collectionName,
           oldFileSubcollection: subcollectionName,
@@ -437,7 +437,7 @@ describe("Subcollection Directory Service", () => {
     })
     it("Moving pages in a subcollection to another subcollection works correctly", async () => {
       await expect(
-        service.movePages(reqDetails, {
+        service.movePages(sessionData, {
           collectionName,
           subcollectionName,
           targetCollectionName,
@@ -446,7 +446,7 @@ describe("Subcollection Directory Service", () => {
         })
       ).resolves.not.toThrowError()
       objArray.forEach((file) => {
-        expect(mockMoverService.movePage).toHaveBeenCalledWith(reqDetails, {
+        expect(mockMoverService.movePage).toHaveBeenCalledWith(sessionData, {
           fileName: file.name,
           oldFileCollection: collectionName,
           oldFileSubcollection: subcollectionName,

--- a/src/services/directoryServices/__tests__/UnlinkedPagesDirectoryService.spec.js
+++ b/src/services/directoryServices/__tests__/UnlinkedPagesDirectoryService.spec.js
@@ -15,7 +15,7 @@ describe("Unlinked Pages Directory Service", () => {
     },
   ]
 
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
 
   const mockBaseDirectoryService = {
     list: jest.fn(),
@@ -67,9 +67,9 @@ describe("Unlinked Pages Directory Service", () => {
     mockBaseDirectoryService.list.mockResolvedValueOnce(listResp)
     it("Listing all unlinked pages works correctly", async () => {
       await expect(
-        service.listAllUnlinkedPages(reqDetails)
+        service.listAllUnlinkedPages(sessionData)
       ).resolves.toMatchObject(expectedResp)
-      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(reqDetails, {
+      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(sessionData, {
         directoryName: UNLINKED_PAGE_DIRECTORY_NAME,
       })
     })
@@ -80,13 +80,13 @@ describe("Unlinked Pages Directory Service", () => {
     const targetSubcollectionName = "target-subcollection"
     it("Moving unlinked pages to a collection works correctly", async () => {
       await expect(
-        service.movePages(reqDetails, {
+        service.movePages(sessionData, {
           targetCollectionName,
           objArray,
         })
       ).resolves.not.toThrowError()
       objArray.forEach((file) => {
-        expect(mockMoverService.movePage).toHaveBeenCalledWith(reqDetails, {
+        expect(mockMoverService.movePage).toHaveBeenCalledWith(sessionData, {
           fileName: file.name,
           newFileCollection: targetCollectionName,
         })
@@ -94,14 +94,14 @@ describe("Unlinked Pages Directory Service", () => {
     })
     it("Moving unlinked pages to a subcollection works correctly", async () => {
       await expect(
-        service.movePages(reqDetails, {
+        service.movePages(sessionData, {
           targetCollectionName,
           targetSubcollectionName,
           objArray,
         })
       ).resolves.not.toThrowError()
       objArray.forEach((file) => {
-        expect(mockMoverService.movePage).toHaveBeenCalledWith(reqDetails, {
+        expect(mockMoverService.movePage).toHaveBeenCalledWith(sessionData, {
           fileName: file.name,
           newFileCollection: targetCollectionName,
           newFileSubcollection: targetSubcollectionName,

--- a/src/services/fileServices/MdPageServices/__tests__/CollectionPageService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/CollectionPageService.spec.js
@@ -14,7 +14,7 @@ describe("Collection Page Service", () => {
   }
   const sha = "12345"
 
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
   const collectionYmlObj = { collectionName, item: fileName }
 
   const mockGithubService = {
@@ -58,7 +58,7 @@ describe("Collection Page Service", () => {
 
     it("rejects page names with special characters", async () => {
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName: "file/file.md",
           collectionName,
           content: mockContent,
@@ -68,7 +68,7 @@ describe("Collection Page Service", () => {
     })
     it("Creating pages works correctly", async () => {
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName,
           collectionName,
           content: mockContent,
@@ -84,10 +84,10 @@ describe("Collection Page Service", () => {
         mockContent
       )
       expect(mockCollectionYmlService.addItemToOrder).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         collectionYmlObj
       )
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName,
         directoryName,
@@ -97,7 +97,7 @@ describe("Collection Page Service", () => {
     it("Creating pages skips the check for special characters if specified", async () => {
       const specialName = "test-name.md"
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName: specialName,
           collectionName,
           content: mockContent,
@@ -114,13 +114,13 @@ describe("Collection Page Service", () => {
         mockContent
       )
       expect(mockCollectionYmlService.addItemToOrder).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           ...collectionYmlObj,
           item: specialName,
         }
       )
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName: specialName,
         directoryName,
@@ -132,7 +132,7 @@ describe("Collection Page Service", () => {
         third_nav_title: "mock-third-nav",
       }
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName,
           collectionName,
           content: mockContent,
@@ -148,10 +148,10 @@ describe("Collection Page Service", () => {
         mockContent
       )
       expect(mockCollectionYmlService.addItemToOrder).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         collectionYmlObj
       )
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName,
         directoryName,
@@ -166,7 +166,7 @@ describe("Collection Page Service", () => {
     }),
       it("Reading pages works correctly", async () => {
         await expect(
-          service.read(reqDetails, { fileName, collectionName })
+          service.read(sessionData, { fileName, collectionName })
         ).resolves.toMatchObject({
           fileName,
           content: { frontMatter: mockFrontMatter, pageBody: mockContent },
@@ -175,7 +175,7 @@ describe("Collection Page Service", () => {
         expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(
           mockMarkdownContent
         )
-        expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+        expect(mockGithubService.read).toHaveBeenCalledWith(sessionData, {
           fileName,
           directoryName,
         })
@@ -187,7 +187,7 @@ describe("Collection Page Service", () => {
     mockGithubService.update.mockResolvedValue({ newSha: sha })
     it("Updating page content works correctly", async () => {
       await expect(
-        service.update(reqDetails, {
+        service.update(sessionData, {
           fileName,
           collectionName,
           content: mockContent,
@@ -204,7 +204,7 @@ describe("Collection Page Service", () => {
         mockFrontMatter,
         mockContent
       )
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
         fileContent: mockMarkdownContent,
@@ -216,15 +216,15 @@ describe("Collection Page Service", () => {
   describe("Delete", () => {
     it("Deleting pages works correctly", async () => {
       await expect(
-        service.delete(reqDetails, { fileName, collectionName, sha })
+        service.delete(sessionData, { fileName, collectionName, sha })
       ).resolves.not.toThrow()
-      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.delete).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
         sha,
       })
       expect(mockCollectionYmlService.deleteItemFromOrder).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           collectionName,
           item: fileName,
@@ -240,7 +240,7 @@ describe("Collection Page Service", () => {
 
     it("rejects renaming to page names with special characters", async () => {
       await expect(
-        service.rename(reqDetails, {
+        service.rename(sessionData, {
           oldFileName,
           newFileName: "file/file.md",
           collectionName,
@@ -251,7 +251,7 @@ describe("Collection Page Service", () => {
     })
     it("Renaming pages works correctly", async () => {
       await expect(
-        service.rename(reqDetails, {
+        service.rename(sessionData, {
           oldFileName,
           newFileName: fileName,
           collectionName,
@@ -266,19 +266,19 @@ describe("Collection Page Service", () => {
         newSha: sha,
       })
       expect(mockCollectionYmlService.updateItemInOrder).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           collectionName,
           oldItem: oldFileName,
           newItem: fileName,
         }
       )
-      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.delete).toHaveBeenCalledWith(sessionData, {
         fileName: oldFileName,
         directoryName,
         sha: oldSha,
       })
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName,
         directoryName,

--- a/src/services/fileServices/MdPageServices/__tests__/ContactUsPageService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/ContactUsPageService.spec.js
@@ -13,7 +13,7 @@ const { NotFoundError } = require("@root/errors/NotFoundError")
 describe("ContactUs Page Service", () => {
   const siteName = "test-site"
   const accessToken = "test-token"
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
 
   const CONTACT_US_DIRECTORY_NAME = "pages"
 
@@ -71,7 +71,7 @@ describe("ContactUs Page Service", () => {
     })
 
     it("Reading the contact us page works correctly", async () => {
-      await expect(service.read(reqDetails)).resolves.toMatchObject({
+      await expect(service.read(sessionData)).resolves.toMatchObject({
         content: { frontMatter: mockFrontMatter, pageBody: mockContent },
         sha: mockContactUsSha,
       })
@@ -79,26 +79,28 @@ describe("ContactUs Page Service", () => {
       expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(
         mockRawContactUsContent
       )
-      expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.read).toHaveBeenCalledWith(sessionData, {
         fileName: CONTACT_US_FILENAME,
         directoryName: CONTACT_US_DIRECTORY_NAME,
       })
-      expect(mockFooterYmlService.read).toHaveBeenCalledWith(reqDetails)
+      expect(mockFooterYmlService.read).toHaveBeenCalledWith(sessionData)
     })
 
     it("Propagates the correct error on failed retrieval", async () => {
       mockFooterYmlService.read.mockRejectedValueOnce(new NotFoundError(""))
 
-      await expect(service.read(reqDetails)).rejects.toThrowError(NotFoundError)
+      await expect(service.read(sessionData)).rejects.toThrowError(
+        NotFoundError
+      )
 
       expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(
         mockRawContactUsContent
       )
-      expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.read).toHaveBeenCalledWith(sessionData, {
         fileName: CONTACT_US_FILENAME,
         directoryName: CONTACT_US_DIRECTORY_NAME,
       })
-      expect(mockFooterYmlService.read).toHaveBeenCalledWith(reqDetails)
+      expect(mockFooterYmlService.read).toHaveBeenCalledWith(sessionData)
     })
   })
 
@@ -124,21 +126,21 @@ describe("ContactUs Page Service", () => {
       }
 
       await expect(
-        service.update(reqDetails, updateReq)
+        service.update(sessionData, updateReq)
       ).resolves.toMatchObject(expectedResp)
 
       expect(convertDataToMarkdown).toHaveBeenCalledWith(
         mockUpdatedFrontMatter,
         mockContent
       )
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: CONTACT_US_FILENAME,
         directoryName: CONTACT_US_DIRECTORY_NAME,
         fileContent: mockRawContactUsContent,
         sha: oldSha,
       })
-      expect(mockFooterYmlService.read).toHaveBeenCalledWith(reqDetails)
-      expect(mockFooterYmlService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockFooterYmlService.read).toHaveBeenCalledWith(sessionData)
+      expect(mockFooterYmlService.update).toHaveBeenCalledWith(sessionData, {
         fileContent: {
           ...mockFooterContent,
           feedback: updatedFeedback,
@@ -155,7 +157,7 @@ describe("ContactUs Page Service", () => {
         sha: oldSha,
       }
 
-      await expect(service.update(reqDetails, updateReq)).rejects.toThrowError(
+      await expect(service.update(sessionData, updateReq)).rejects.toThrowError(
         NotFoundError
       )
 
@@ -163,7 +165,7 @@ describe("ContactUs Page Service", () => {
         mockFrontMatter,
         mockContent
       )
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: CONTACT_US_FILENAME,
         directoryName: CONTACT_US_DIRECTORY_NAME,
         fileContent: mockRawContactUsContent,

--- a/src/services/fileServices/MdPageServices/__tests__/HomepagePageService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/HomepagePageService.spec.js
@@ -8,7 +8,7 @@ const { HOMEPAGE_FILENAME } = require("@root/constants")
 describe("Homepage Page Service", () => {
   const siteName = "test-site"
   const accessToken = "test-token"
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
 
   const mockFrontMatter = mockHomepageContent.frontMatter
   const mockContent = mockHomepageContent.pageBody
@@ -50,14 +50,14 @@ describe("Homepage Page Service", () => {
       sha: mockHomepageSha,
     })
     it("Reading the homepage works correctly", async () => {
-      await expect(service.read(reqDetails)).resolves.toMatchObject({
+      await expect(service.read(sessionData)).resolves.toMatchObject({
         content: { frontMatter: mockFrontMatter, pageBody: mockContent },
         sha: mockHomepageSha,
       })
       expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(
         mockRawHomepageContent
       )
-      expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.read).toHaveBeenCalledWith(sessionData, {
         fileName: HOMEPAGE_FILENAME,
       })
     })
@@ -68,7 +68,7 @@ describe("Homepage Page Service", () => {
     mockGithubService.update.mockResolvedValue({ newSha: mockHomepageSha })
     it("Updating page content works correctly", async () => {
       await expect(
-        service.update(reqDetails, {
+        service.update(sessionData, {
           fileName: HOMEPAGE_FILENAME,
           content: mockContent,
           frontMatter: mockFrontMatter,
@@ -83,7 +83,7 @@ describe("Homepage Page Service", () => {
         mockFrontMatter,
         mockContent
       )
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: HOMEPAGE_FILENAME,
         fileContent: mockRawHomepageContent,
         sha: oldSha,

--- a/src/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
@@ -15,7 +15,7 @@ describe("Media File Service", () => {
   const sha = "12345"
   const mockGithubSessionData = "githubData"
 
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
 
   const mockGithubService = {
     create: jest.fn(),
@@ -54,7 +54,7 @@ describe("Media File Service", () => {
   describe("Create", () => {
     it("rejects page names with special characters", async () => {
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName: "file/file.pdf",
           directoryName,
           content: mockContent,
@@ -65,7 +65,7 @@ describe("Media File Service", () => {
     mockGithubService.create.mockResolvedValueOnce({ sha })
     it("Creating pages works correctly", async () => {
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName,
           directoryName,
           content: mockContent,
@@ -75,7 +75,7 @@ describe("Media File Service", () => {
         content: mockContent,
         sha,
       })
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockSanitizedContent,
         fileName,
         directoryName,
@@ -121,15 +121,18 @@ describe("Media File Service", () => {
         sha,
       }
       await expect(
-        service.read(reqDetails, {
+        service.read(sessionData, {
           fileName: imageName,
           directoryName,
         })
       ).resolves.toMatchObject(expectedResp)
-      expect(mockGithubService.readDirectory).toHaveBeenCalledWith(reqDetails, {
-        directoryName,
-      })
-      expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
+      expect(mockGithubService.readDirectory).toHaveBeenCalledWith(
+        sessionData,
+        {
+          directoryName,
+        }
+      )
+      expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(sessionData)
     })
     const svgName = "image.svg"
     mockGithubService.readDirectory.mockResolvedValueOnce([
@@ -149,16 +152,19 @@ describe("Media File Service", () => {
         sha,
       }
       await expect(
-        service.read(reqDetails, {
+        service.read(sessionData, {
           fileName: svgName,
           directoryName,
           mediaType: "images",
         })
       ).resolves.toMatchObject(expectedResp)
-      expect(mockGithubService.readDirectory).toHaveBeenCalledWith(reqDetails, {
-        directoryName,
-      })
-      expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
+      expect(mockGithubService.readDirectory).toHaveBeenCalledWith(
+        sessionData,
+        {
+          directoryName,
+        }
+      )
+      expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(sessionData)
     })
     mockGithubService.readDirectory.mockResolvedValueOnce(imageDirResp)
     mockGithubService.getRepoInfo.mockResolvedValueOnce({
@@ -171,17 +177,20 @@ describe("Media File Service", () => {
         sha,
       }
       await expect(
-        service.read(reqDetails, {
+        service.read(sessionData, {
           fileName: imageName,
           directoryName,
           mediaType: "images",
         })
       ).resolves.toMatchObject(expectedResp)
-      expect(mockGithubService.readDirectory).toHaveBeenCalledWith(reqDetails, {
-        directoryName,
-      })
-      expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
-      expect(mockGithubService.readMedia).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.readDirectory).toHaveBeenCalledWith(
+        sessionData,
+        {
+          directoryName,
+        }
+      )
+      expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(sessionData)
+      expect(mockGithubService.readMedia).toHaveBeenCalledWith(sessionData, {
         fileSha: sha,
       })
     })
@@ -199,16 +208,19 @@ describe("Media File Service", () => {
         sha,
       }
       await expect(
-        service.read(reqDetails, {
+        service.read(sessionData, {
           fileName,
           directoryName,
           mediaType: "files",
         })
       ).resolves.toMatchObject(expectedResp)
-      expect(mockGithubService.readDirectory).toHaveBeenCalledWith(reqDetails, {
-        directoryName,
-      })
-      expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(reqDetails)
+      expect(mockGithubService.readDirectory).toHaveBeenCalledWith(
+        sessionData,
+        {
+          directoryName,
+        }
+      )
+      expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(sessionData)
     })
   })
 
@@ -217,7 +229,7 @@ describe("Media File Service", () => {
     mockGithubService.create.mockResolvedValueOnce({ sha })
     it("Updating media file content works correctly", async () => {
       await expect(
-        service.update(reqDetails, {
+        service.update(sessionData, {
           fileName,
           directoryName,
           content: mockContent,
@@ -229,12 +241,12 @@ describe("Media File Service", () => {
         oldSha,
         newSha: sha,
       })
-      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.delete).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
         sha: oldSha,
       })
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockSanitizedContent,
         fileName,
         directoryName,
@@ -247,9 +259,9 @@ describe("Media File Service", () => {
   describe("Delete", () => {
     it("Deleting pages works correctly", async () => {
       await expect(
-        service.delete(reqDetails, { fileName, directoryName, sha })
+        service.delete(sessionData, { fileName, directoryName, sha })
       ).resolves.not.toThrow()
-      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.delete).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
         sha,
@@ -289,7 +301,7 @@ describe("Media File Service", () => {
 
     it("rejects renaming to page names with special characters", async () => {
       await expect(
-        service.rename(reqDetails, mockGithubSessionData, {
+        service.rename(sessionData, mockGithubSessionData, {
           oldFileName,
           newFileName: "file/file.pdf",
           directoryName,
@@ -299,7 +311,7 @@ describe("Media File Service", () => {
     })
     it("Renaming pages works correctly", async () => {
       await expect(
-        service.rename(reqDetails, mockGithubSessionData, {
+        service.rename(sessionData, mockGithubSessionData, {
           oldFileName,
           newFileName: fileName,
           directoryName,
@@ -312,14 +324,14 @@ describe("Media File Service", () => {
         sha,
       })
       expect(mockGithubService.getTree).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           isRecursive: true,
         }
       )
       expect(mockGithubService.updateTree).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         mockGithubSessionData,
         {
           gitTree: mockedMovedTree,
@@ -327,7 +339,7 @@ describe("Media File Service", () => {
         }
       )
       expect(mockGithubService.updateRepoState).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           commitSha: treeSha,
         }

--- a/src/services/fileServices/MdPageServices/__tests__/ResourcePageService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/ResourcePageService.spec.js
@@ -15,7 +15,7 @@ describe("Resource Page Service", () => {
   }
   const sha = "12345"
 
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
 
   const mockGithubService = {
     create: jest.fn(),
@@ -50,7 +50,7 @@ describe("Resource Page Service", () => {
     mockGithubService.create.mockResolvedValue({ sha })
     it("rejects page names with special characters", async () => {
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName: "file/file.md",
           resourceRoomName,
           resourceCategoryName,
@@ -61,7 +61,7 @@ describe("Resource Page Service", () => {
     })
     it("Creating pages works correctly", async () => {
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName,
           resourceRoomName,
           resourceCategoryName,
@@ -77,7 +77,7 @@ describe("Resource Page Service", () => {
         { ...mockFrontMatter },
         mockContent
       )
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName,
         directoryName,
@@ -92,7 +92,7 @@ describe("Resource Page Service", () => {
     }),
       it("Reading pages works correctly", async () => {
         await expect(
-          service.read(reqDetails, {
+          service.read(sessionData, {
             fileName,
             resourceRoomName,
             resourceCategoryName,
@@ -105,7 +105,7 @@ describe("Resource Page Service", () => {
         expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(
           mockMarkdownContent
         )
-        expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+        expect(mockGithubService.read).toHaveBeenCalledWith(sessionData, {
           fileName,
           directoryName,
         })
@@ -117,7 +117,7 @@ describe("Resource Page Service", () => {
     mockGithubService.update.mockResolvedValue({ newSha: sha })
     it("Updating page content works correctly", async () => {
       await expect(
-        service.update(reqDetails, {
+        service.update(sessionData, {
           fileName,
           resourceRoomName,
           resourceCategoryName,
@@ -135,7 +135,7 @@ describe("Resource Page Service", () => {
         mockFrontMatter,
         mockContent
       )
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
         fileContent: mockMarkdownContent,
@@ -147,14 +147,14 @@ describe("Resource Page Service", () => {
   describe("Delete", () => {
     it("Deleting pages works correctly", async () => {
       await expect(
-        service.delete(reqDetails, {
+        service.delete(sessionData, {
           fileName,
           resourceRoomName,
           resourceCategoryName,
           sha,
         })
       ).resolves.not.toThrow()
-      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.delete).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
         sha,
@@ -168,7 +168,7 @@ describe("Resource Page Service", () => {
     mockGithubService.create.mockResolvedValue({ sha })
     it("rejects renaming to page names with special characters", async () => {
       await expect(
-        service.rename(reqDetails, {
+        service.rename(sessionData, {
           oldFileName,
           newFileName: "file/file.md",
           resourceRoomName,
@@ -180,7 +180,7 @@ describe("Resource Page Service", () => {
     })
     it("Renaming pages works correctly", async () => {
       await expect(
-        service.rename(reqDetails, {
+        service.rename(sessionData, {
           oldFileName,
           newFileName: fileName,
           resourceRoomName,
@@ -195,12 +195,12 @@ describe("Resource Page Service", () => {
         oldSha,
         newSha: sha,
       })
-      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.delete).toHaveBeenCalledWith(sessionData, {
         fileName: oldFileName,
         directoryName,
         sha: oldSha,
       })
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName,
         directoryName,

--- a/src/services/fileServices/MdPageServices/__tests__/SubcollectionPageService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/SubcollectionPageService.spec.js
@@ -17,7 +17,7 @@ describe("Subcollection Page Service", () => {
   }
   const sha = "12345"
 
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
   const collectionYmlObj = {
     collectionName,
     item: `${subcollectionName}/${fileName}`,
@@ -62,7 +62,7 @@ describe("Subcollection Page Service", () => {
   describe("Create", () => {
     it("rejects page names with special characters", async () => {
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName: "file/file.md",
           collectionName,
           subcollectionName,
@@ -74,7 +74,7 @@ describe("Subcollection Page Service", () => {
     it("Creating a page with no third nav title in the front matter correctly adds it in", async () => {
       mockGithubService.create.mockResolvedValueOnce({ sha })
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName,
           collectionName,
           subcollectionName,
@@ -94,10 +94,10 @@ describe("Subcollection Page Service", () => {
         mockContent
       )
       expect(mockCollectionYmlService.addItemToOrder).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         collectionYmlObj
       )
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName,
         directoryName,
@@ -110,7 +110,7 @@ describe("Subcollection Page Service", () => {
         third_nav_title: "mock-third-nav",
       }
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName,
           collectionName,
           subcollectionName,
@@ -130,10 +130,10 @@ describe("Subcollection Page Service", () => {
         mockContent
       )
       expect(mockCollectionYmlService.addItemToOrder).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         collectionYmlObj
       )
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName,
         directoryName,
@@ -144,7 +144,7 @@ describe("Subcollection Page Service", () => {
       mockGithubService.create.mockResolvedValueOnce({ sha })
       const specialName = "test-name.md"
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName: specialName,
           collectionName,
           subcollectionName,
@@ -165,13 +165,13 @@ describe("Subcollection Page Service", () => {
         mockContent
       )
       expect(mockCollectionYmlService.addItemToOrder).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           ...collectionYmlObj,
           item: `${subcollectionName}/${specialName}`,
         }
       )
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName: specialName,
         directoryName,
@@ -186,7 +186,7 @@ describe("Subcollection Page Service", () => {
     }),
       it("Reading pages works correctly", async () => {
         await expect(
-          service.read(reqDetails, {
+          service.read(sessionData, {
             fileName,
             collectionName,
             subcollectionName,
@@ -199,7 +199,7 @@ describe("Subcollection Page Service", () => {
         expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(
           mockMarkdownContent
         )
-        expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+        expect(mockGithubService.read).toHaveBeenCalledWith(sessionData, {
           fileName,
           directoryName,
         })
@@ -211,7 +211,7 @@ describe("Subcollection Page Service", () => {
     mockGithubService.update.mockResolvedValueOnce({ newSha: sha })
     it("Updating page content works correctly", async () => {
       await expect(
-        service.update(reqDetails, {
+        service.update(sessionData, {
           fileName,
           collectionName,
           subcollectionName,
@@ -229,7 +229,7 @@ describe("Subcollection Page Service", () => {
         mockFrontMatter,
         mockContent
       )
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
         fileContent: mockMarkdownContent,
@@ -241,20 +241,20 @@ describe("Subcollection Page Service", () => {
   describe("Delete", () => {
     it("Deleting pages works correctly", async () => {
       await expect(
-        service.delete(reqDetails, {
+        service.delete(sessionData, {
           fileName,
           collectionName,
           subcollectionName,
           sha,
         })
       ).resolves.not.toThrow()
-      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.delete).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
         sha,
       })
       expect(mockCollectionYmlService.deleteItemFromOrder).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           collectionName,
           item: `${subcollectionName}/${fileName}`,
@@ -270,7 +270,7 @@ describe("Subcollection Page Service", () => {
 
     it("rejects renaming to page names with special characters", async () => {
       await expect(
-        service.rename(reqDetails, {
+        service.rename(sessionData, {
           oldFileName,
           newFileName: "file/file.md",
           collectionName,
@@ -282,7 +282,7 @@ describe("Subcollection Page Service", () => {
     })
     it("Renaming pages works correctly", async () => {
       await expect(
-        service.rename(reqDetails, {
+        service.rename(sessionData, {
           oldFileName,
           newFileName: fileName,
           collectionName,
@@ -298,19 +298,19 @@ describe("Subcollection Page Service", () => {
         newSha: sha,
       })
       expect(mockCollectionYmlService.updateItemInOrder).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           collectionName,
           oldItem: `${subcollectionName}/${oldFileName}`,
           newItem: `${subcollectionName}/${fileName}`,
         }
       )
-      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.delete).toHaveBeenCalledWith(sessionData, {
         fileName: oldFileName,
         directoryName,
         sha: oldSha,
       })
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName,
         directoryName,
@@ -333,7 +333,7 @@ describe("Subcollection Page Service", () => {
     })
     it("Updating the subcollection of a page works correctly", async () => {
       await expect(
-        service.updateSubcollection(reqDetails, {
+        service.updateSubcollection(sessionData, {
           fileName,
           collectionName,
           oldSubcollectionName: subcollectionName,
@@ -349,12 +349,12 @@ describe("Subcollection Page Service", () => {
         },
         mockContent
       )
-      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.delete).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
         sha: oldSha,
       })
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName,
         directoryName: newDirectory,

--- a/src/services/fileServices/MdPageServices/__tests__/UnlinkedPageService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/UnlinkedPageService.spec.js
@@ -13,7 +13,7 @@ describe("Unlinked Page Service", () => {
   }
   const sha = "12345"
 
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
 
   const mockGithubService = {
     create: jest.fn(),
@@ -48,7 +48,7 @@ describe("Unlinked Page Service", () => {
     mockGithubService.create.mockResolvedValue({ sha })
     it("rejects page names with special characters", async () => {
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName: "file/file.md",
           content: mockContent,
           frontMatter: { ...mockFrontMatter },
@@ -57,7 +57,7 @@ describe("Unlinked Page Service", () => {
     })
     it("Creating pages works correctly", async () => {
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName,
           content: mockContent,
           frontMatter: mockFrontMatter,
@@ -71,7 +71,7 @@ describe("Unlinked Page Service", () => {
         mockFrontMatter,
         mockContent
       )
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName,
         directoryName,
@@ -81,7 +81,7 @@ describe("Unlinked Page Service", () => {
     it("Creating pages skips the check for special characters if specified", async () => {
       const specialName = "test-name.md"
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           fileName: specialName,
           content: mockContent,
           frontMatter: { ...mockFrontMatter },
@@ -96,7 +96,7 @@ describe("Unlinked Page Service", () => {
         { ...mockFrontMatter },
         mockContent
       )
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName: specialName,
         directoryName,
@@ -111,7 +111,7 @@ describe("Unlinked Page Service", () => {
     }),
       it("Reading pages works correctly", async () => {
         await expect(
-          service.read(reqDetails, { fileName })
+          service.read(sessionData, { fileName })
         ).resolves.toMatchObject({
           fileName,
           content: { frontMatter: mockFrontMatter, pageBody: mockContent },
@@ -120,7 +120,7 @@ describe("Unlinked Page Service", () => {
         expect(retrieveDataFromMarkdown).toHaveBeenCalledWith(
           mockMarkdownContent
         )
-        expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+        expect(mockGithubService.read).toHaveBeenCalledWith(sessionData, {
           fileName,
           directoryName,
         })
@@ -132,7 +132,7 @@ describe("Unlinked Page Service", () => {
     mockGithubService.update.mockResolvedValue({ newSha: sha })
     it("Updating page content works correctly", async () => {
       await expect(
-        service.update(reqDetails, {
+        service.update(sessionData, {
           fileName,
           content: mockContent,
           frontMatter: mockFrontMatter,
@@ -148,7 +148,7 @@ describe("Unlinked Page Service", () => {
         mockFrontMatter,
         mockContent
       )
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
         fileContent: mockMarkdownContent,
@@ -160,9 +160,9 @@ describe("Unlinked Page Service", () => {
   describe("Delete", () => {
     it("Deleting pages works correctly", async () => {
       await expect(
-        service.delete(reqDetails, { fileName, sha })
+        service.delete(sessionData, { fileName, sha })
       ).resolves.not.toThrow()
-      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.delete).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
         sha,
@@ -176,7 +176,7 @@ describe("Unlinked Page Service", () => {
     mockGithubService.create.mockResolvedValue({ sha })
     it("rejects renaming to page names with special characters", async () => {
       await expect(
-        service.rename(reqDetails, {
+        service.rename(sessionData, {
           oldFileName,
           newFileName: "file/file.md",
           content: mockContent,
@@ -186,7 +186,7 @@ describe("Unlinked Page Service", () => {
     })
     it("Renaming pages works correctly", async () => {
       await expect(
-        service.rename(reqDetails, {
+        service.rename(sessionData, {
           oldFileName,
           newFileName: fileName,
           content: mockContent,
@@ -199,12 +199,12 @@ describe("Unlinked Page Service", () => {
         oldSha,
         newSha: sha,
       })
-      expect(mockGithubService.delete).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.delete).toHaveBeenCalledWith(sessionData, {
         fileName: oldFileName,
         directoryName,
         sha: oldSha,
       })
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content: mockMarkdownContent,
         fileName,
         directoryName,

--- a/src/services/fileServices/YmlFileServices/ConfigYmlService.js
+++ b/src/services/fileServices/YmlFileServices/ConfigYmlService.js
@@ -21,9 +21,9 @@ class ConfigYmlService {
     return { content, sha }
   }
 
-  async update(reqDetails, { fileContent, sha }) {
+  async update(sessionData, { fileContent, sha }) {
     const stringifiedContent = sanitizedYamlStringify(fileContent)
-    const { newSha } = await this.gitHubService.update(reqDetails, {
+    const { newSha } = await this.gitHubService.update(sessionData, {
       fileContent: stringifiedContent,
       sha,
       fileName: CONFIG_FILE_NAME,

--- a/src/services/fileServices/YmlFileServices/__tests__/CollectionYmlService.spec.js
+++ b/src/services/fileServices/YmlFileServices/__tests__/CollectionYmlService.spec.js
@@ -17,7 +17,7 @@ describe("Collection Yml Service", () => {
   const directoryName = `_${collectionName}`
   const sha = "12345"
 
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
   const orderArray = [
     `${fileName}.md`,
     `${subcollectionName}/.keep`,
@@ -57,9 +57,9 @@ describe("Collection Yml Service", () => {
     }),
       it("Reading a collection.yml file works correctly", async () => {
         await expect(
-          service.read(reqDetails, { collectionName })
+          service.read(sessionData, { collectionName })
         ).resolves.toMatchObject({ content: mockParsedContent, sha })
-        expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+        expect(mockGithubService.read).toHaveBeenCalledWith(sessionData, {
           fileName: COLLECTION_FILE_NAME,
           directoryName,
         })
@@ -71,7 +71,7 @@ describe("Collection Yml Service", () => {
     mockGithubService.update.mockResolvedValueOnce({ newSha: sha })
     it("Updating raw content works correctly", async () => {
       await expect(
-        service.update(reqDetails, {
+        service.update(sessionData, {
           collectionName,
           fileContent: mockParsedContent,
           sha: oldSha,
@@ -79,7 +79,7 @@ describe("Collection Yml Service", () => {
       ).resolves.toMatchObject({
         newSha: sha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: COLLECTION_FILE_NAME,
         directoryName,
         fileContent: mockRawContent,
@@ -102,13 +102,13 @@ describe("Collection Yml Service", () => {
         },
       })
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           collectionName,
         })
       ).resolves.toMatchObject({
         sha,
       })
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content,
         fileName: COLLECTION_FILE_NAME,
         directoryName,
@@ -124,14 +124,14 @@ describe("Collection Yml Service", () => {
         },
       })
       await expect(
-        service.create(reqDetails, {
+        service.create(sessionData, {
           collectionName,
           orderArray,
         })
       ).resolves.toMatchObject({
         sha,
       })
-      expect(mockGithubService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.create).toHaveBeenCalledWith(sessionData, {
         content,
         fileName: COLLECTION_FILE_NAME,
         directoryName,
@@ -146,7 +146,7 @@ describe("Collection Yml Service", () => {
     })
     it("Parses the collection.yml file and returns an array of files", async () => {
       await expect(
-        service.listContents(reqDetails, {
+        service.listContents(sessionData, {
           collectionName,
         })
       ).resolves.toMatchObject(orderArray)
@@ -170,14 +170,14 @@ describe("Collection Yml Service", () => {
       modifiedParsedContent.collections[collectionName].order = expectedArray
       const modifiedRawContent = sanitizedYamlStringify(modifiedParsedContent)
       await expect(
-        service.addItemToOrder(reqDetails, {
+        service.addItemToOrder(sessionData, {
           collectionName,
           item: newFileName,
         })
       ).resolves.toMatchObject({
         newSha: sha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: COLLECTION_FILE_NAME,
         directoryName,
         fileContent: modifiedRawContent,
@@ -192,14 +192,14 @@ describe("Collection Yml Service", () => {
       modifiedParsedContent.collections[collectionName].order = expectedArray
       const modifiedRawContent = sanitizedYamlStringify(modifiedParsedContent)
       await expect(
-        service.addItemToOrder(reqDetails, {
+        service.addItemToOrder(sessionData, {
           collectionName,
           item: newFileName,
         })
       ).resolves.toMatchObject({
         newSha: sha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: COLLECTION_FILE_NAME,
         directoryName,
         fileContent: modifiedRawContent,
@@ -215,14 +215,14 @@ describe("Collection Yml Service", () => {
       modifiedParsedContent.collections[collectionName].order = expectedArray
       const modifiedRawContent = sanitizedYamlStringify(modifiedParsedContent)
       await expect(
-        service.addItemToOrder(reqDetails, {
+        service.addItemToOrder(sessionData, {
           collectionName,
           item: newFileName,
         })
       ).resolves.toMatchObject({
         newSha: sha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: COLLECTION_FILE_NAME,
         directoryName,
         fileContent: modifiedRawContent,
@@ -239,7 +239,7 @@ describe("Collection Yml Service", () => {
       modifiedParsedContent.collections[collectionName].order = expectedArray
       const modifiedRawContent = sanitizedYamlStringify(modifiedParsedContent)
       await expect(
-        service.addItemToOrder(reqDetails, {
+        service.addItemToOrder(sessionData, {
           collectionName,
           item: newFileName,
           index: addedIndex,
@@ -247,7 +247,7 @@ describe("Collection Yml Service", () => {
       ).resolves.toMatchObject({
         newSha: sha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: COLLECTION_FILE_NAME,
         directoryName,
         fileContent: modifiedRawContent,
@@ -264,7 +264,7 @@ describe("Collection Yml Service", () => {
       modifiedParsedContent.collections[collectionName].order = expectedArray
       const modifiedRawContent = sanitizedYamlStringify(modifiedParsedContent)
       await expect(
-        service.addItemToOrder(reqDetails, {
+        service.addItemToOrder(sessionData, {
           collectionName,
           item: newFileName,
           index: addedIndex,
@@ -272,7 +272,7 @@ describe("Collection Yml Service", () => {
       ).resolves.toMatchObject({
         newSha: sha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: COLLECTION_FILE_NAME,
         directoryName,
         fileContent: modifiedRawContent,
@@ -299,14 +299,14 @@ describe("Collection Yml Service", () => {
       modifiedParsedContent.collections[collectionName].order = expectedArray
       const modifiedRawContent = sanitizedYamlStringify(modifiedParsedContent)
       await expect(
-        service.deleteItemFromOrder(reqDetails, {
+        service.deleteItemFromOrder(sessionData, {
           collectionName,
           item: `${fileName}.md`,
         })
       ).resolves.toMatchObject({
         newSha: sha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: COLLECTION_FILE_NAME,
         directoryName,
         fileContent: modifiedRawContent,
@@ -321,14 +321,14 @@ describe("Collection Yml Service", () => {
       modifiedParsedContent.collections[collectionName].order = expectedArray
       const modifiedRawContent = sanitizedYamlStringify(modifiedParsedContent)
       await expect(
-        service.deleteItemFromOrder(reqDetails, {
+        service.deleteItemFromOrder(sessionData, {
           collectionName,
           item: itemName,
         })
       ).resolves.toMatchObject({
         newSha: sha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: COLLECTION_FILE_NAME,
         directoryName,
         fileContent: modifiedRawContent,
@@ -342,7 +342,7 @@ describe("Collection Yml Service", () => {
       const modifiedParsedContent = _.cloneDeep(mockParsedContent)
       modifiedParsedContent.collections[collectionName].order = expectedArray
       await expect(
-        service.deleteItemFromOrder(reqDetails, {
+        service.deleteItemFromOrder(sessionData, {
           collectionName,
           item: itemName,
         })
@@ -369,7 +369,7 @@ describe("Collection Yml Service", () => {
       modifiedParsedContent.collections[collectionName].order = expectedArray
       const modifiedRawContent = sanitizedYamlStringify(modifiedParsedContent)
       await expect(
-        service.updateItemInOrder(reqDetails, {
+        service.updateItemInOrder(sessionData, {
           collectionName,
           oldItem: `${fileName}2.md`,
           newItem: renamedItem,
@@ -377,7 +377,7 @@ describe("Collection Yml Service", () => {
       ).resolves.toMatchObject({
         newSha: sha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: COLLECTION_FILE_NAME,
         directoryName,
         fileContent: modifiedRawContent,
@@ -403,14 +403,14 @@ describe("Collection Yml Service", () => {
       }
       const modifiedRawContent = sanitizedYamlStringify(modifiedParsedContent)
       await expect(
-        service.renameCollectionInOrder(reqDetails, {
+        service.renameCollectionInOrder(sessionData, {
           oldCollectionName: collectionName,
           newCollectionName: renamedCollection,
         })
       ).resolves.toMatchObject({
         newSha: sha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: COLLECTION_FILE_NAME,
         directoryName: `_${renamedCollection}`,
         fileContent: modifiedRawContent,
@@ -435,14 +435,14 @@ describe("Collection Yml Service", () => {
       modifiedParsedContent.collections[collectionName].order = expectedArray
       const modifiedRawContent = sanitizedYamlStringify(modifiedParsedContent)
       await expect(
-        service.deleteSubfolderFromOrder(reqDetails, {
+        service.deleteSubfolderFromOrder(sessionData, {
           collectionName,
           subfolder: subcollectionName,
         })
       ).resolves.toMatchObject({
         newSha: sha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: COLLECTION_FILE_NAME,
         directoryName,
         fileContent: modifiedRawContent,
@@ -468,7 +468,7 @@ describe("Collection Yml Service", () => {
       modifiedParsedContent.collections[collectionName].order = expectedArray
       const modifiedRawContent = sanitizedYamlStringify(modifiedParsedContent)
       await expect(
-        service.renameSubfolderInOrder(reqDetails, {
+        service.renameSubfolderInOrder(sessionData, {
           collectionName,
           oldSubfolder: subcollectionName,
           newSubfolder: renamedSubcollection,
@@ -476,7 +476,7 @@ describe("Collection Yml Service", () => {
       ).resolves.toMatchObject({
         newSha: sha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: COLLECTION_FILE_NAME,
         directoryName,
         fileContent: modifiedRawContent,
@@ -505,14 +505,14 @@ describe("Collection Yml Service", () => {
       modifiedParsedContent.collections[collectionName].order = newOrder
       const modifiedRawContent = sanitizedYamlStringify(modifiedParsedContent)
       await expect(
-        service.updateOrder(reqDetails, {
+        service.updateOrder(sessionData, {
           collectionName,
           newOrder,
         })
       ).resolves.toMatchObject({
         newSha: sha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: COLLECTION_FILE_NAME,
         directoryName,
         fileContent: modifiedRawContent,

--- a/src/services/fileServices/YmlFileServices/__tests__/ConfigYmlService.spec.js
+++ b/src/services/fileServices/YmlFileServices/__tests__/ConfigYmlService.spec.js
@@ -9,7 +9,7 @@ const { ConfigYmlService } = require("../ConfigYmlService")
 describe("Config Yml Service", () => {
   const siteName = "test-site"
   const accessToken = "test-token"
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
 
   const CONFIG_FILE_NAME = "_config.yml"
 
@@ -33,11 +33,11 @@ describe("Config Yml Service", () => {
       sha: mockConfigSha,
     })
     it("Reading the _config.yml file works correctly", async () => {
-      await expect(service.read(reqDetails)).resolves.toMatchObject({
+      await expect(service.read(sessionData)).resolves.toMatchObject({
         content: mockConfigContent,
         sha: mockConfigSha,
       })
-      expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.read).toHaveBeenCalledWith(sessionData, {
         fileName: CONFIG_FILE_NAME,
       })
     })
@@ -48,14 +48,14 @@ describe("Config Yml Service", () => {
     mockGithubService.update.mockResolvedValueOnce({ newSha: mockConfigSha })
     it("Updating _config.yml file works correctly", async () => {
       await expect(
-        service.update(reqDetails, {
+        service.update(sessionData, {
           fileContent: mockConfigContent,
           sha: oldSha,
         })
       ).resolves.toMatchObject({
         newSha: mockConfigSha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: CONFIG_FILE_NAME,
         fileContent: mockRawConfigContent,
         sha: oldSha,

--- a/src/services/fileServices/YmlFileServices/__tests__/FooterYmlService.spec.js
+++ b/src/services/fileServices/YmlFileServices/__tests__/FooterYmlService.spec.js
@@ -9,7 +9,7 @@ const { FooterYmlService } = require("../FooterYmlService")
 describe("Footer Yml Service", () => {
   const siteName = "test-site"
   const accessToken = "test-token"
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
 
   const FOOTER_FILE_NAME = "footer.yml"
   const FOOTER_FILE_DIR = "_data"
@@ -34,11 +34,11 @@ describe("Footer Yml Service", () => {
       sha: mockFooterSha,
     })
     it("Reading the _data/footer.yml file works correctly", async () => {
-      await expect(service.read(reqDetails)).resolves.toMatchObject({
+      await expect(service.read(sessionData)).resolves.toMatchObject({
         content: mockFooterContent,
         sha: mockFooterSha,
       })
-      expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.read).toHaveBeenCalledWith(sessionData, {
         fileName: FOOTER_FILE_NAME,
         directoryName: FOOTER_FILE_DIR,
       })
@@ -50,14 +50,14 @@ describe("Footer Yml Service", () => {
     mockGithubService.update.mockResolvedValueOnce({ newSha: mockFooterSha })
     it("Updating _data/footer.yml file works correctly", async () => {
       await expect(
-        service.update(reqDetails, {
+        service.update(sessionData, {
           fileContent: mockFooterContent,
           sha: oldSha,
         })
       ).resolves.toMatchObject({
         newSha: mockFooterSha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: FOOTER_FILE_NAME,
         directoryName: FOOTER_FILE_DIR,
         fileContent: mockRawFooterContent,

--- a/src/services/fileServices/YmlFileServices/__tests__/NavYmlService.spec.js
+++ b/src/services/fileServices/YmlFileServices/__tests__/NavYmlService.spec.js
@@ -23,7 +23,7 @@ describe("Nav Yml Service", () => {
   const collectionName = "collection"
   const directoryName = NAV_FILE_DIR
 
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
   const mockParsedContent = {
     links: [
       {
@@ -81,11 +81,11 @@ describe("Nav Yml Service", () => {
       sha: mockNavigationSha,
     })
     it("Reading the _data/navigation.yml file works correctly", async () => {
-      await expect(service.read(reqDetails)).resolves.toMatchObject({
+      await expect(service.read(sessionData)).resolves.toMatchObject({
         content: mockNavigationContent,
         sha: mockNavigationSha,
       })
-      expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.read).toHaveBeenCalledWith(sessionData, {
         fileName: NAV_FILE_NAME,
         directoryName: NAV_FILE_DIR,
       })
@@ -99,14 +99,14 @@ describe("Nav Yml Service", () => {
     })
     it("Updating _data/navigation.yml file works correctly", async () => {
       await expect(
-        service.update(reqDetails, {
+        service.update(sessionData, {
           fileContent: mockNavigationContent,
           sha: oldSha,
         })
       ).resolves.toMatchObject({
         newSha: mockNavigationSha,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName: NAV_FILE_NAME,
         directoryName: NAV_FILE_DIR,
         fileContent: mockRawNavigationContent,
@@ -132,15 +132,15 @@ describe("Nav Yml Service", () => {
     mockGithubService.update.mockResolvedValueOnce({ newSha })
     it("Adds new collections to the end of the navigation file and returns the new sha", async () => {
       await expect(
-        service.createCollectionInNav(reqDetails, {
+        service.createCollectionInNav(sessionData, {
           collectionName: newCollection,
         })
       ).resolves.toMatchObject({ newSha })
-      expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.read).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
         fileContent: sanitizedYamlStringify(updatedMockParsedContent),
@@ -171,16 +171,16 @@ describe("Nav Yml Service", () => {
     mockGithubService.update.mockResolvedValueOnce({ newSha })
     it("Adds new collections to the end of the navigation file and returns the new sha", async () => {
       await expect(
-        service.renameCollectionInNav(reqDetails, {
+        service.renameCollectionInNav(sessionData, {
           oldCollectionName: collectionName,
           newCollectionName: newCollection,
         })
       ).resolves.toMatchObject({ newSha })
-      expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.read).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
         fileContent: sanitizedYamlStringify(updatedMockParsedContent),
@@ -204,15 +204,15 @@ describe("Nav Yml Service", () => {
     mockGithubService.update.mockResolvedValueOnce({ newSha })
     it("Removes selected collection from navigation file", async () => {
       await expect(
-        service.deleteCollectionInNav(reqDetails, {
+        service.deleteCollectionInNav(sessionData, {
           collectionName,
         })
       ).resolves.toMatchObject({ newSha })
-      expect(mockGithubService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.read).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
       })
-      expect(mockGithubService.update).toHaveBeenCalledWith(reqDetails, {
+      expect(mockGithubService.update).toHaveBeenCalledWith(sessionData, {
         fileName,
         directoryName,
         fileContent: sanitizedYamlStringify(updatedMockParsedContent),

--- a/src/services/identity/__tests__/AuthService.spec.ts
+++ b/src/services/identity/__tests__/AuthService.spec.ts
@@ -15,7 +15,7 @@ const AuthService = new _AuthService({
 })
 
 describe("Auth Service", () => {
-  const mockReqDetails = {
+  const mocksessionData = {
     accessToken: mockAccessToken,
     siteName: mockSiteName,
   }

--- a/src/services/moverServices/__tests__/MoverService.spec.js
+++ b/src/services/moverServices/__tests__/MoverService.spec.js
@@ -18,7 +18,7 @@ describe("Mover Service", () => {
   }
   const sha = "12345"
 
-  const reqDetails = { siteName, accessToken }
+  const sessionData = { siteName, accessToken }
 
   const mockUnlinkedPageService = {
     create: jest.fn(),
@@ -69,7 +69,7 @@ describe("Mover Service", () => {
     mockSubcollectionPageService.create.mockResolvedValue(createResp)
     it("Moving unlinked page to a collection works correctly", async () => {
       await expect(
-        service.movePage(reqDetails, {
+        service.movePage(sessionData, {
           fileName,
           // oldFileCollection,
           // oldFileSubcollection,
@@ -77,15 +77,15 @@ describe("Mover Service", () => {
           // newFileSubcollection,
         })
       ).resolves.toMatchObject(createResp)
-      expect(mockUnlinkedPageService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockUnlinkedPageService.read).toHaveBeenCalledWith(sessionData, {
         fileName,
       })
-      expect(mockUnlinkedPageService.delete).toHaveBeenCalledWith(reqDetails, {
+      expect(mockUnlinkedPageService.delete).toHaveBeenCalledWith(sessionData, {
         fileName,
         sha,
       })
       expect(mockCollectionPageService.create).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           content: mockContent,
           frontMatter: mockFrontMatter,
@@ -97,7 +97,7 @@ describe("Mover Service", () => {
     })
     it("Moving unlinked page to a subcollection works correctly", async () => {
       await expect(
-        service.movePage(reqDetails, {
+        service.movePage(sessionData, {
           fileName,
           // oldFileCollection,
           // oldFileSubcollection,
@@ -105,15 +105,15 @@ describe("Mover Service", () => {
           newFileSubcollection: subcollectionName,
         })
       ).resolves.toMatchObject(createResp)
-      expect(mockUnlinkedPageService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockUnlinkedPageService.read).toHaveBeenCalledWith(sessionData, {
         fileName,
       })
-      expect(mockUnlinkedPageService.delete).toHaveBeenCalledWith(reqDetails, {
+      expect(mockUnlinkedPageService.delete).toHaveBeenCalledWith(sessionData, {
         fileName,
         sha,
       })
       expect(mockSubcollectionPageService.create).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           content: mockContent,
           frontMatter: mockFrontMatter,
@@ -126,7 +126,7 @@ describe("Mover Service", () => {
     })
     it("Moving collection page to unlinked pages works correctly", async () => {
       await expect(
-        service.movePage(reqDetails, {
+        service.movePage(sessionData, {
           fileName,
           oldFileCollection: oldCollectionName,
           // oldFileSubcollection,
@@ -134,19 +134,19 @@ describe("Mover Service", () => {
           // newFileSubcollection,
         })
       ).resolves.toMatchObject(createResp)
-      expect(mockCollectionPageService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockCollectionPageService.read).toHaveBeenCalledWith(sessionData, {
         fileName,
         collectionName: oldCollectionName,
       })
       expect(mockCollectionPageService.delete).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           fileName,
           collectionName: oldCollectionName,
           sha,
         }
       )
-      expect(mockUnlinkedPageService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockUnlinkedPageService.create).toHaveBeenCalledWith(sessionData, {
         content: mockContent,
         frontMatter: mockFrontMatter,
         fileName,
@@ -155,7 +155,7 @@ describe("Mover Service", () => {
     })
     it("Moving collection page to another collection works correctly", async () => {
       await expect(
-        service.movePage(reqDetails, {
+        service.movePage(sessionData, {
           fileName,
           oldFileCollection: oldCollectionName,
           // oldFileSubcollection,
@@ -163,12 +163,12 @@ describe("Mover Service", () => {
           // newFileSubcollection,
         })
       ).resolves.toMatchObject(createResp)
-      expect(mockCollectionPageService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockCollectionPageService.read).toHaveBeenCalledWith(sessionData, {
         fileName,
         collectionName: oldCollectionName,
       })
       expect(mockCollectionPageService.delete).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           fileName,
           collectionName: oldCollectionName,
@@ -176,7 +176,7 @@ describe("Mover Service", () => {
         }
       )
       expect(mockCollectionPageService.create).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           content: mockContent,
           frontMatter: mockFrontMatter,
@@ -188,7 +188,7 @@ describe("Mover Service", () => {
     })
     it("Moving collection page to a subcollection works correctly", async () => {
       await expect(
-        service.movePage(reqDetails, {
+        service.movePage(sessionData, {
           fileName,
           oldFileCollection: oldCollectionName,
           // oldFileSubcollection,
@@ -196,12 +196,12 @@ describe("Mover Service", () => {
           newFileSubcollection: subcollectionName,
         })
       ).resolves.toMatchObject(createResp)
-      expect(mockCollectionPageService.read).toHaveBeenCalledWith(reqDetails, {
+      expect(mockCollectionPageService.read).toHaveBeenCalledWith(sessionData, {
         fileName,
         collectionName: oldCollectionName,
       })
       expect(mockCollectionPageService.delete).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           fileName,
           collectionName: oldCollectionName,
@@ -209,7 +209,7 @@ describe("Mover Service", () => {
         }
       )
       expect(mockSubcollectionPageService.create).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           content: mockContent,
           frontMatter: mockFrontMatter,
@@ -222,14 +222,14 @@ describe("Mover Service", () => {
     })
     it("Moving subcollection page to unlinked pages works correctly", async () => {
       await expect(
-        service.movePage(reqDetails, {
+        service.movePage(sessionData, {
           fileName,
           oldFileCollection: oldCollectionName,
           oldFileSubcollection: oldSubcollectionName,
         })
       ).resolves.toMatchObject(createResp)
       expect(mockSubcollectionPageService.read).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           fileName,
           collectionName: oldCollectionName,
@@ -237,7 +237,7 @@ describe("Mover Service", () => {
         }
       )
       expect(mockSubcollectionPageService.delete).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           fileName,
           collectionName: oldCollectionName,
@@ -245,7 +245,7 @@ describe("Mover Service", () => {
           sha,
         }
       )
-      expect(mockUnlinkedPageService.create).toHaveBeenCalledWith(reqDetails, {
+      expect(mockUnlinkedPageService.create).toHaveBeenCalledWith(sessionData, {
         content: mockContent,
         frontMatter: mockFrontMatter,
         fileName,
@@ -254,7 +254,7 @@ describe("Mover Service", () => {
     })
     it("Moving subcollection page to a collection works correctly", async () => {
       await expect(
-        service.movePage(reqDetails, {
+        service.movePage(sessionData, {
           fileName,
           oldFileCollection: oldCollectionName,
           oldFileSubcollection: oldSubcollectionName,
@@ -262,7 +262,7 @@ describe("Mover Service", () => {
         })
       ).resolves.toMatchObject(createResp)
       expect(mockSubcollectionPageService.read).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           fileName,
           collectionName: oldCollectionName,
@@ -270,7 +270,7 @@ describe("Mover Service", () => {
         }
       )
       expect(mockSubcollectionPageService.delete).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           fileName,
           collectionName: oldCollectionName,
@@ -279,7 +279,7 @@ describe("Mover Service", () => {
         }
       )
       expect(mockCollectionPageService.create).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           content: mockContent,
           frontMatter: mockFrontMatter,
@@ -291,7 +291,7 @@ describe("Mover Service", () => {
     })
     it("Moving subcollection page to another subcollection works correctly", async () => {
       await expect(
-        service.movePage(reqDetails, {
+        service.movePage(sessionData, {
           fileName,
           oldFileCollection: oldCollectionName,
           oldFileSubcollection: oldSubcollectionName,
@@ -300,7 +300,7 @@ describe("Mover Service", () => {
         })
       ).resolves.toMatchObject(createResp)
       expect(mockSubcollectionPageService.read).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           fileName,
           collectionName: oldCollectionName,
@@ -308,7 +308,7 @@ describe("Mover Service", () => {
         }
       )
       expect(mockSubcollectionPageService.delete).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           fileName,
           collectionName: oldCollectionName,
@@ -317,7 +317,7 @@ describe("Mover Service", () => {
         }
       )
       expect(mockSubcollectionPageService.create).toHaveBeenCalledWith(
-        reqDetails,
+        sessionData,
         {
           content: mockContent,
           frontMatter: mockFrontMatter,


### PR DESCRIPTION
## Problem

This PR fixes an issue with our subcollection rename and resource room rename/delete methods. For subcollection rename, when renaming subcollections, we no longer use the `baseDirectoryService.rename` but instead delete and recreate each individual file, meaning it was no longer necessary to pass `githubSessionData`, but our call site still passed this as an argument, which resulted in subcollection renaming not working as expected. The resource room delete/rename methods were missing the `githubSessionData` argument. This PR fjxes this behaviour.

In addition, the existing use of `reqDetails` was changed to `sessionData` to bring it in line with the rest of our methods to reduce confusion.