### PR TITLE
Is 59/fix/disallow special character as first character

### DIFF
--- a/src/services/directoryServices/SubcollectionDirectoryService.js
+++ b/src/services/directoryServices/SubcollectionDirectoryService.js
@@ -44,7 +44,7 @@ class SubcollectionDirectoryService {
   ) {
     if (titleSpecialCharCheck({ title: subcollectionName, isFile: false }))
       throw new BadRequestError(
-        "Special characters not allowed in directory name"
+        `Special characters not allowed when creating subdirectory. Given name: ${subcollectionName}`
       )
     const parsedSubcollectionName = deslugifyCollectionName(subcollectionName)
     const parsedDir = `_${collectionName}/${parsedSubcollectionName}`
@@ -84,7 +84,7 @@ class SubcollectionDirectoryService {
   ) {
     if (titleSpecialCharCheck({ title: newDirectoryName, isFile: false }))
       throw new BadRequestError(
-        "Special characters not allowed in directory name"
+        `Special characters not allowed when renaming subdirectory. Given name: ${newDirectoryName}`
       )
     const parsedNewName = deslugifyCollectionName(newDirectoryName)
     const dir = `_${collectionName}/${subcollectionName}`

--- a/src/services/directoryServices/SubcollectionDirectoryService.js
+++ b/src/services/directoryServices/SubcollectionDirectoryService.js
@@ -2,7 +2,7 @@ const { BadRequestError } = require("@errors/BadRequestError")
 
 const { deslugifyCollectionName } = require("@utils/utils")
 
-const { titleSpecialCharCheck } = require("@validators/validators")
+const { hasSpecialCharInTitle } = require("@validators/validators")
 
 const PLACEHOLDER_FILE_NAME = ".keep"
 
@@ -42,7 +42,7 @@ class SubcollectionDirectoryService {
     reqDetails,
     { collectionName, subcollectionName, objArray }
   ) {
-    if (titleSpecialCharCheck({ title: subcollectionName, isFile: false }))
+    if (hasSpecialCharInTitle({ title: subcollectionName, isFile: false }))
       throw new BadRequestError(
         `Special characters not allowed when creating subdirectory. Given name: ${subcollectionName}`
       )
@@ -82,7 +82,7 @@ class SubcollectionDirectoryService {
     reqDetails,
     { collectionName, subcollectionName, newDirectoryName }
   ) {
-    if (titleSpecialCharCheck({ title: newDirectoryName, isFile: false }))
+    if (hasSpecialCharInTitle({ title: newDirectoryName, isFile: false }))
       throw new BadRequestError(
         `Special characters not allowed when renaming subdirectory. Given name: ${newDirectoryName}`
       )

--- a/src/services/fileServices/MdPageServices/CollectionPageService.js
+++ b/src/services/fileServices/MdPageServices/CollectionPageService.js
@@ -21,7 +21,9 @@ class CollectionPageService {
       !shouldIgnoreCheck &&
       titleSpecialCharCheck({ title: fileName, isFile: true })
     )
-      throw new BadRequestError("Special characters not allowed in file name")
+      throw new BadRequestError(
+        `Special characters not allowed when creating files. Given name: ${fileName}`
+      )
     const parsedCollectionName = `_${collectionName}`
 
     await this.collectionYmlService.addItemToOrder(sessionData, {
@@ -94,7 +96,9 @@ class CollectionPageService {
     { oldFileName, newFileName, collectionName, content, frontMatter, sha }
   ) {
     if (titleSpecialCharCheck({ title: newFileName, isFile: true }))
-      throw new BadRequestError("Special characters not allowed in file name")
+      throw new BadRequestError(
+        `Special characters not allowed when renaming files. Given name: ${newFileName}`
+      )
     const parsedCollectionName = `_${collectionName}`
 
     await this.collectionYmlService.updateItemInOrder(sessionData, {

--- a/src/services/fileServices/MdPageServices/CollectionPageService.js
+++ b/src/services/fileServices/MdPageServices/CollectionPageService.js
@@ -5,7 +5,7 @@ const {
   convertDataToMarkdown,
 } = require("@utils/markdown-utils")
 
-const { titleSpecialCharCheck } = require("@validators/validators")
+const { hasSpecialCharInTitle } = require("@validators/validators")
 
 class CollectionPageService {
   constructor({ gitHubService, collectionYmlService }) {
@@ -19,7 +19,7 @@ class CollectionPageService {
   ) {
     if (
       !shouldIgnoreCheck &&
-      titleSpecialCharCheck({ title: fileName, isFile: true })
+      hasSpecialCharInTitle({ title: fileName, isFile: true })
     )
       throw new BadRequestError(
         `Special characters not allowed when creating files. Given name: ${fileName}`
@@ -95,7 +95,7 @@ class CollectionPageService {
     sessionData,
     { oldFileName, newFileName, collectionName, content, frontMatter, sha }
   ) {
-    if (titleSpecialCharCheck({ title: newFileName, isFile: true }))
+    if (hasSpecialCharInTitle({ title: newFileName, isFile: true }))
       throw new BadRequestError(
         `Special characters not allowed when renaming files. Given name: ${newFileName}`
       )

--- a/src/services/fileServices/MdPageServices/ResourcePageService.js
+++ b/src/services/fileServices/MdPageServices/ResourcePageService.js
@@ -27,7 +27,9 @@ class ResourcePageService {
     const title = titleTokenArray.join("-")
 
     if (titleSpecialCharCheck({ title, isFile: true }))
-      throw new BadRequestError("Special characters not allowed in file name")
+      throw new BadRequestError(
+        `Special characters not allowed when creating resource files. Given name: ${title}`
+      )
 
     return { date, type, title }
   }

--- a/src/services/fileServices/MdPageServices/ResourcePageService.js
+++ b/src/services/fileServices/MdPageServices/ResourcePageService.js
@@ -5,7 +5,7 @@ const {
   convertDataToMarkdown,
 } = require("@utils/markdown-utils")
 
-const { titleSpecialCharCheck, isDateValid } = require("@validators/validators")
+const { hasSpecialCharInTitle, isDateValid } = require("@validators/validators")
 
 class ResourcePageService {
   constructor({ gitHubService }) {
@@ -26,7 +26,7 @@ class ResourcePageService {
     const titleTokenArray = type ? tokenArray.slice(4) : tokenArray.slice(3)
     const title = titleTokenArray.join("-")
 
-    if (titleSpecialCharCheck({ title, isFile: true }))
+    if (hasSpecialCharInTitle({ title, isFile: true }))
       throw new BadRequestError(
         `Special characters not allowed when creating resource files. Given name: ${title}`
       )

--- a/src/services/fileServices/MdPageServices/SubcollectionPageService.js
+++ b/src/services/fileServices/MdPageServices/SubcollectionPageService.js
@@ -29,7 +29,9 @@ class SubcollectionPageService {
       !shouldIgnoreCheck &&
       titleSpecialCharCheck({ title: fileName, isFile: true })
     )
-      throw new BadRequestError("Special characters not allowed in file name")
+      throw new BadRequestError(
+        `Special characters not allowed when creating files. Given name: ${fileName}`
+      )
     const parsedDirectoryName = `_${collectionName}/${subcollectionName}`
 
     await this.collectionYmlService.addItemToOrder(sessionData, {
@@ -112,7 +114,9 @@ class SubcollectionPageService {
     }
   ) {
     if (titleSpecialCharCheck({ title: newFileName, isFile: true }))
-      throw new BadRequestError("Special characters not allowed in file name")
+      throw new BadRequestError(
+        `Special characters not allowed when renaming files. Given name: ${newFileName}`
+      )
     const parsedDirectoryName = `_${collectionName}/${subcollectionName}`
 
     await this.collectionYmlService.updateItemInOrder(sessionData, {

--- a/src/services/fileServices/MdPageServices/SubcollectionPageService.js
+++ b/src/services/fileServices/MdPageServices/SubcollectionPageService.js
@@ -6,7 +6,7 @@ const {
 } = require("@utils/markdown-utils")
 const { deslugifyCollectionName } = require("@utils/utils")
 
-const { titleSpecialCharCheck } = require("@validators/validators")
+const { hasSpecialCharInTitle } = require("@validators/validators")
 
 class SubcollectionPageService {
   constructor({ gitHubService, collectionYmlService }) {
@@ -27,7 +27,7 @@ class SubcollectionPageService {
   ) {
     if (
       !shouldIgnoreCheck &&
-      titleSpecialCharCheck({ title: fileName, isFile: true })
+      hasSpecialCharInTitle({ title: fileName, isFile: true })
     )
       throw new BadRequestError(
         `Special characters not allowed when creating files. Given name: ${fileName}`
@@ -113,7 +113,7 @@ class SubcollectionPageService {
       sha,
     }
   ) {
-    if (titleSpecialCharCheck({ title: newFileName, isFile: true }))
+    if (hasSpecialCharInTitle({ title: newFileName, isFile: true }))
       throw new BadRequestError(
         `Special characters not allowed when renaming files. Given name: ${newFileName}`
       )

--- a/src/services/fileServices/MdPageServices/UnlinkedPageService.js
+++ b/src/services/fileServices/MdPageServices/UnlinkedPageService.js
@@ -23,7 +23,9 @@ class UnlinkedPageService {
       !shouldIgnoreCheck &&
       titleSpecialCharCheck({ title: fileName, isFile: true })
     )
-      throw new BadRequestError("Special characters not allowed in file name")
+      throw new BadRequestError(
+        `Special characters not allowed when creating file. Given name: ${fileName}`
+      )
     delete frontMatter.third_nav_title
     const newContent = convertDataToMarkdown(frontMatter, content)
     const { sha } = await this.gitHubService.create(sessionData, {
@@ -75,7 +77,9 @@ class UnlinkedPageService {
     { oldFileName, newFileName, content, frontMatter, sha }
   ) {
     if (titleSpecialCharCheck({ title: newFileName, isFile: true }))
-      throw new BadRequestError("Special characters not allowed in file name")
+      throw new BadRequestError(
+        `Special characters not allowed when renaming file. Given name: ${newFileName}`
+      )
     const newContent = convertDataToMarkdown(frontMatter, content)
     await this.gitHubService.delete(sessionData, {
       sha,

--- a/src/services/fileServices/MdPageServices/UnlinkedPageService.js
+++ b/src/services/fileServices/MdPageServices/UnlinkedPageService.js
@@ -5,7 +5,7 @@ const {
   convertDataToMarkdown,
 } = require("@utils/markdown-utils")
 
-const { titleSpecialCharCheck } = require("@validators/validators")
+const { hasSpecialCharInTitle } = require("@validators/validators")
 
 const UNLINKED_PAGES_DIRECTORY_NAME = "pages"
 
@@ -21,7 +21,7 @@ class UnlinkedPageService {
     // Ensure that third_nav_title is removed for files that are being moved from collections
     if (
       !shouldIgnoreCheck &&
-      titleSpecialCharCheck({ title: fileName, isFile: true })
+      hasSpecialCharInTitle({ title: fileName, isFile: true })
     )
       throw new BadRequestError(
         `Special characters not allowed when creating file. Given name: ${fileName}`
@@ -76,7 +76,7 @@ class UnlinkedPageService {
     sessionData,
     { oldFileName, newFileName, content, frontMatter, sha }
   ) {
-    if (titleSpecialCharCheck({ title: newFileName, isFile: true }))
+    if (hasSpecialCharInTitle({ title: newFileName, isFile: true }))
       throw new BadRequestError(
         `Special characters not allowed when renaming file. Given name: ${newFileName}`
       )

--- a/src/validators/validators.js
+++ b/src/validators/validators.js
@@ -1,4 +1,5 @@
 const specialCharactersRegexTest = /[~%^*_+\-./\\`;~{}[\]"<>]/
+const jekyllFirstCharacterRegexTest = /^[._#~]/
 const dateRegexTest = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/
 
 const mediaSpecialCharactersRegexTest = /[~%^#*+\./\\`;~{}[\]"<>]/ // Allows dashes
@@ -11,7 +12,10 @@ const titleSpecialCharCheck = ({ title, isFile = false }) => {
     // Remove .md
     testTitle = title.replace(/.md$/, "")
   }
-  return specialCharactersRegexTest.test(testTitle)
+  return (
+    specialCharactersRegexTest.test(testTitle) ||
+    jekyllFirstCharacterRegexTest.test(testTitle)
+  )
 }
 
 const isDateValid = (date) => dateRegexTest.test(date)

--- a/src/validators/validators.js
+++ b/src/validators/validators.js
@@ -6,7 +6,7 @@ const mediaSpecialCharactersRegexTest = /[~%^#*+\./\\`;~{}[\]"<>]/ // Allows das
 // Allows only media root folders (/images or /files) and media subdirectories (/images/subdir or /files/subdir) with no banned characters
 const mediaSubfolderRegexText = /^(images|files|(images|files)\/[^#?~%^*+\.\\`;~{}[\]"<>]+)$/
 
-const titleSpecialCharCheck = ({ title, isFile = false }) => {
+const hasSpecialCharInTitle = ({ title, isFile = false }) => {
   let testTitle = title
   if (isFile) {
     // Remove .md
@@ -31,7 +31,7 @@ const isMediaPathValid = ({ path, isFile = false }) => {
 }
 
 module.exports = {
-  titleSpecialCharCheck,
+  hasSpecialCharInTitle,
   isDateValid,
   isMediaPathValid,
 }


### PR DESCRIPTION
This PR replicates the frontend changes made to restrict the use of `#` as the first character in files and subcollection titles. To be reviewed in conjunction with PR [#1231](https://github.com/isomerpages/isomercms-frontend/pull/1231) on the isomercms frontend repo.

This PR also updates our logging for failure cases on these create/rename endpoints, as the error message was previously not very informative.