### PR TITLE
fix(authservice): return `userId` when e2e

### DIFF
--- a/src/services/utilServices/AuthService.js
+++ b/src/services/utilServices/AuthService.js
@@ -141,7 +141,11 @@ class AuthService {
   async getUserInfo(sessionData) {
     try {
       if (sessionData.isomerUserId === E2E_ISOMER_ID) {
-        return { email: E2E_TEST_EMAIL, contactNumber: E2E_TEST_CONTACT }
+        return {
+          userId: E2E_ISOMER_ID,
+          email: E2E_TEST_EMAIL,
+          contactNumber: E2E_TEST_CONTACT,
+        }
       }
       if (sessionData.isEmailUser()) {
         const { email } = sessionData


### PR DESCRIPTION
## Problem
> FE uses !!userId to determine if a user should be directed to the github login flow (which is what our tests work with), this requires a backend change to also return userId when it is the E2E_USER. separately, we should probably maintain 2 types of users for e2e (github + email) or, if we decide that we want to deprecate github in the future, make our existing tests compat w/ email flow
Related to IS-87

## Solution
add `userId` property when e2e
