### PR TITLE
test(markdown-fixtures): add a test for DOMPurify sanitization

### DIFF
--- a/src/fixtures/markdown-fixtures.ts
+++ b/src/fixtures/markdown-fixtures.ts
@@ -46,3 +46,9 @@ export const maliciousJsonObject = {
   },
   pageContent: maliciousPageContent,
 }
+
+export const rawInstagramEmbedScript =
+  '<script src="//www.instagram.com/embed.js" async></script>'
+
+export const sanitizedInstagramEmbedScript =
+  '<script async="" src="//www.instagram.com/embed.js"></script>'

--- a/src/utils/__tests__/markdown-utils.spec.ts
+++ b/src/utils/__tests__/markdown-utils.spec.ts
@@ -8,7 +8,10 @@ import {
   maliciousMarkdownContent,
   normalJsonObject,
   maliciousJsonObject,
+  rawInstagramEmbedScript,
+  sanitizedInstagramEmbedScript,
 } from "@fixtures/markdown-fixtures"
+import { sanitizer } from "@root/services/utilServices/Sanitizer"
 
 describe("Sanitized markdown utils test", () => {
   it("should parse normal markdown content into an object successfully", () => {
@@ -34,6 +37,15 @@ describe("Sanitized markdown utils test", () => {
     const { frontMatter, pageContent } = maliciousJsonObject
     expect(convertDataToMarkdown(frontMatter, pageContent)).toBe(
       normalMarkdownContent
+    )
+  })
+
+  it("should sanitize boolean tags with an empty string", () => {
+    // NOTE: Setting a boolean attr to an empty string is equivalent
+    // to it being true.
+    // See the HTML spec: https://html.spec.whatwg.org/#boolean-attributes
+    expect(sanitizer.sanitize(rawInstagramEmbedScript)).toBe(
+      sanitizedInstagramEmbedScript
     )
   })
 })


### PR DESCRIPTION
## Problem
Right now, we have no tests for the behaviour of the `sanitize` function, which leads to some behaviour being potentially inconsistent.

This was observed in the frontend `sanitize` call vs the backend `sanitize` call, where the frontend call preserves the property `async` as-is, but the backend call adds the empty string to turn it into `async=""`. 

## Solution
This PR adds a short test for sanitization to ensure that 
1. this behaviour is known
2. that this behaviour doesn't affect functionality.

from the html [spec](https://html.spec.whatwg.org/#boolean-attributes), the 2 forms (`async` and `async=""`) are equivalent and [browser support](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script) for the async tag as a whole is wide (only edge support is at v12, others start at v1), so this shouldn't be an issue