### PR TITLE
Feat(Site Launch): Mock calls to Amplify 

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -26,6 +26,7 @@ export SITE_CREATE_FORM_KEY=""
 # generate your own access key and secret access key from AWS
 export AWS_ACCESS_KEY_ID="" 
 export AWS_SECRET_ACCESS_KEY=""
+export MOCK_AMPLIFY_CREATE_DOMAIN_CALLS="true"
 
 # Required to run end-to-end tests
 export E2E_TEST_REPO="e2e-test-repo"

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -172,6 +172,12 @@ const config = convict({
         format: String,
         default: "",
       },
+      mockAmplifyCreateDomainAssociationCalls: {
+        doc: "Mock createDomainAssociation calls to Amplify ",
+        env: "MOCK_AMPLIFY_CREATE_DOMAIN_ASSOCIATION_CALLS",
+        format: "required-boolean",
+        default: true,
+      },
     },
     sqs: {
       incomingQueueUrl: {

--- a/src/services/identity/LaunchClient.ts
+++ b/src/services/identity/LaunchClient.ts
@@ -155,8 +155,8 @@ class LaunchClient {
         statusReason: undefined,
       },
     }
-    const hasCreated = true // this is a get call, assume domain has already been created
-    const subDomains = this.getSubDomains(input.subDomainSettings, hasCreated)
+    const isCreated = true // this is a get call, assume domain has already been created
+    const subDomains = this.getSubDomains(input.subDomainSettings, isCreated)
 
     // We know that domainAssociation is not undefined, so we can use the non-null assertion operator
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/services/identity/LaunchClient.ts
+++ b/src/services/identity/LaunchClient.ts
@@ -10,7 +10,7 @@ import {
 } from "@aws-sdk/client-amplify"
 import { SubDomain } from "aws-sdk/clients/amplify"
 
-import { config } from "@config/config"
+import { isSecure } from "@root/utils/auth-utils"
 
 // create a new interface that extends GetDomainAssociationCommandInput
 interface MockGetDomainAssociationCommandInput
@@ -114,7 +114,7 @@ class LaunchClient {
   }
 
   private isTestEnv() {
-    return config.get("env") === "test" || config.get("env") === "dev"
+    return isSecure
   }
 
   private getSubDomains(subDomainList: SubDomainSetting[], hasCreated = false) {

--- a/src/services/identity/LaunchClient.ts
+++ b/src/services/identity/LaunchClient.ts
@@ -83,7 +83,7 @@ class LaunchClient {
    * We want to limit interference with operations, as such we mock this call during development.
    * @returns Mocked output for CreateDomainAssociationCommand
    */
-  mockCreateDomainAssociationOutput = (
+  private mockCreateDomainAssociationOutput = (
     input: CreateDomainAssociationCommandInput
   ): Promise<CreateDomainAssociationCommandOutput> => {
     // We are mocking the response from the Amplify API, so we need to store the input
@@ -142,7 +142,7 @@ class LaunchClient {
     return subDomains
   }
 
-  mockGetDomainAssociationOutput(
+  private mockGetDomainAssociationOutput(
     input: GetDomainAssociationCommandInput
   ): Promise<GetDomainAssociationCommandOutput> {
     const isSubDomainCreated = true // this is a `get` call, assume domain has already been created

--- a/src/services/identity/LaunchClient.ts
+++ b/src/services/identity/LaunchClient.ts
@@ -113,11 +113,14 @@ class LaunchClient {
     return Promise.resolve(mockResponse)
   }
 
-  private isTestEnv() {
+  private isTestEnv(): boolean {
     return isSecure
   }
 
-  private getSubDomains(subDomainList: SubDomainSetting[], hasCreated = false) {
+  private getSubDomains(
+    subDomainList: SubDomainSetting[],
+    hasCreated = false
+  ): SubDomain[] {
     const subDomainPrefixList = subDomainList
       .map((subDomain) => subDomain.prefix)
       .filter((prefix) => prefix !== undefined) as string[]

--- a/src/services/identity/LaunchClient.ts
+++ b/src/services/identity/LaunchClient.ts
@@ -135,10 +135,10 @@ class LaunchClient {
         }`,
         subDomainSetting: {
           branchName: "master",
-          prefix: subDomainPrefix,
+          prefix: subDomainPrefix as string,
         },
         verified: false,
-      })) as SubDomain[]
+      }))
     return subDomains
   }
 

--- a/src/services/identity/LaunchClient.ts
+++ b/src/services/identity/LaunchClient.ts
@@ -10,7 +10,7 @@ import {
 } from "@aws-sdk/client-amplify"
 import { SubDomain } from "aws-sdk/clients/amplify"
 
-import config from "@config/config"
+import { config } from "@config/config"
 
 // create a new interface that extends GetDomainAssociationCommandInput
 interface MockGetDomainAssociationCommandInput

--- a/src/services/identity/LaunchClient.ts
+++ b/src/services/identity/LaunchClient.ts
@@ -10,7 +10,7 @@ import {
 } from "@aws-sdk/client-amplify"
 import { SubDomain } from "aws-sdk/clients/amplify"
 
-import { isSecure } from "@root/utils/auth-utils"
+import { config } from "@config/config"
 
 // create a new interface that extends GetDomainAssociationCommandInput
 interface MockGetDomainAssociationCommandInput
@@ -41,7 +41,7 @@ class LaunchClient {
   sendCreateDomainAssociation = (
     input: CreateDomainAssociationCommandInput
   ): Promise<CreateDomainAssociationCommandOutput> => {
-    if (this.isTestEnv()) {
+    if (this.shouldMockAmplifyCreateDomainCalls()) {
       return this.mockCreateDomainAssociationOutput(input)
     }
     const output = this.amplifyClient.send(
@@ -59,7 +59,7 @@ class LaunchClient {
     | MockGetDomainAssociationCommandInput => ({
     appId,
     domainName,
-    ...(this.isTestEnv() && { subDomainSettings }),
+    ...(this.shouldMockAmplifyCreateDomainCalls() && { subDomainSettings }),
   })
 
   sendGetDomainAssociationCommand = (
@@ -113,8 +113,8 @@ class LaunchClient {
     return Promise.resolve(mockResponse)
   }
 
-  private isTestEnv(): boolean {
-    return isSecure
+  private shouldMockAmplifyCreateDomainCalls(): boolean {
+    return config.get("aws.amplify.mockAmplifyCreateDomainAssociationCalls")
   }
 
   private getSubDomains(

--- a/src/services/identity/LaunchesService.ts
+++ b/src/services/identity/LaunchesService.ts
@@ -192,11 +192,13 @@ export class LaunchesService {
 
   getDomainAssociationRecord = async (
     domainName: string,
-    appId: string
+    appId: string,
+    subDomainSettings: SubDomainSetting[]
   ): Promise<GetDomainAssociationCommandOutput> => {
     const getDomainAssociationOptions = this.launchClient.createGetDomainAssociationCommandInput(
       appId,
-      domainName
+      domainName,
+      subDomainSettings
     )
     return this.launchClient.sendGetDomainAssociationCommand(
       getDomainAssociationOptions

--- a/src/services/identity/LaunchesService.ts
+++ b/src/services/identity/LaunchesService.ts
@@ -192,13 +192,11 @@ export class LaunchesService {
 
   getDomainAssociationRecord = async (
     domainName: string,
-    appId: string,
-    subDomainSettings: SubDomainSetting[]
+    appId: string
   ): Promise<GetDomainAssociationCommandOutput> => {
     const getDomainAssociationOptions = this.launchClient.createGetDomainAssociationCommandInput(
       appId,
-      domainName,
-      subDomainSettings
+      domainName
     )
     return this.launchClient.sendGetDomainAssociationCommand(
       getDomainAssociationOptions

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -248,8 +248,7 @@ export default class InfraService {
 
       const dnsInfo = await this.launchesService.getDomainAssociationRecord(
         primaryDomain,
-        appId,
-        subDomainSettings
+        appId
       )
 
       const certificationRecord = this.parseDNSRecords(

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -375,7 +375,7 @@ export default class InfraService {
     await Promise.all(
       messages.map(async (message) => {
         const site = await this.sitesService.getBySiteName(message.repoName)
-        if (!site || site.isErr()) {
+        if (site.isErr()) {
           return
         }
         const isSuccess = message.status === SiteLaunchLambdaStatus.SUCCESS


### PR DESCRIPTION
## Problem

During development, the CreateDomainAssociation calls are rate-limited to 10 per hour. This low rate limit can cause issues during actual site launches that may affect operations.

## Solution

To avoid impeding with the actual infrastructure rate limits, this PR mocks all calls to CreateDomainAssociation and GetDomainAssociation in LaunchesService. Only staging, vapt, and prod environments should be making actual calls to Amplify. Additionally, since we are mocking Amplify calls now, we no longer need to wait for 90 seconds after creating domain associations for Amplify to generate the required values.

The mocked objects may seem verbose, but they closely resemble the actual values received when calling Amplify.

## Breaking Changes

There are no breaking changes.

## Reviewer Notes
I am concerned that future devs working around site launch feature might be confused why they are not able to create domain associations during development. Not too sure if there is a way to highlight clearly in code that the calls are mocks apart from the proposed solution of already naming them  `mockCreateDomainAssociationOutput` and `mockCreateDomainAssociationOutput` in `LaunchesClient`. Open to feedback on this! 

## Tests

To mock form responses, you can call the following code directly from server.js:
```
const formResponses = [
  {
    submissionId: "",
    requesterEmail: "kishore@open.gov.sg",
    repoName: "kishore-test",
    primaryDomain: "kishorewithwww.isomer.gov.sg",
    redirectionDomain: "www.kishorewithwww.isomer.gov.sg",
    agencyEmail: "alexander@open.gov.sg",
  },
  {
    submissionId: "",
    requesterEmail: "kishore@open.gov.sg",
    repoName: "test-vincent",
    primaryDomain: "kishorewithoutwww.isomer.gov.sg",
    redirectionDomain: "",
    agencyEmail: "alexander@open.gov.sg",
  },
]

formsgSiteLaunchRouter.handleSiteLaunchResults(formResponses, "test")
```
After mocking a site launch form submission, the launches and redirections in the database are populated, and emails are sent as expected.
<img width="991" alt="Screenshot 2023-04-13 at 2 12 43 PM" src="https://user-images.githubusercontent.com/42832651/231669463-2864c8b9-23ab-4aab-b632-b61d401d68a4.png">
<img width="984" alt="Screenshot 2023-04-13 at 2 12 57 PM" src="https://user-images.githubusercontent.com/42832651/231669502-2317ea82-f442-4538-bc2f-539121c0ecdf.png">

## Deploy Notes 

**New environment variables**:

- `MOCK_AMPLIFY_CREATE_DOMAIN_CALLS` : mocking amplify calls so as to not impede with operations 

Values in 1pw prod and staging env vars are also updated. TLDR; MOCK_AMPLIFY_CREATE_DOMAIN_CALLS is `true` in prod and staging env, `false` in local dev. 
