### PR TITLE
fix(staging links): fix failing staging links

### DIFF
--- a/src/routes/v2/authenticated/__tests__/Sites.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/Sites.spec.ts
@@ -1,4 +1,5 @@
 import express from "express"
+import { ok } from "neverthrow"
 import request from "supertest"
 
 import type { AuthorizationMiddleware } from "@middleware/authorization"
@@ -91,7 +92,7 @@ describe("Sites Router", () => {
   describe("getStagingUrl", () => {
     it("returns the site's staging URL", async () => {
       const stagingUrl = "staging-url"
-      mockSitesService.getStagingUrl.mockResolvedValueOnce(stagingUrl)
+      mockSitesService.getStagingUrl.mockResolvedValueOnce(ok(stagingUrl))
 
       const resp = await request(app)
         .get(`/${mockSiteName}/stagingUrl`)

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -68,10 +68,10 @@ export class SitesRouter {
     )
 
     // Check for error and throw
-    if (possibleStagingUrl instanceof BaseIsomerError) {
-      return res.status(404).json({ message: possibleStagingUrl.message })
+    if (possibleStagingUrl.isErr()) {
+      return res.status(404).json({ message: possibleStagingUrl.error.message })
     }
-    return res.status(200).json({ stagingUrl: possibleStagingUrl })
+    return res.status(200).json({ stagingUrl: possibleStagingUrl.value })
   }
 
   getSiteUrl: RequestHandler<


### PR DESCRIPTION
Links to staging is now defined as `https://staging-cms.isomer.gov.sg/sites/kishore-test/[object%20Object]`

This fix fixes it back to the original state