### PR TITLE
chore: add new env vars for db

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -36,6 +36,8 @@ export E2E_TEST_GH_TOKEN=""
 export DB_URI="postgres://isomer:password@localhost:15432/isomercms_dev"
 export DB_MIN_POOL="1"
 export DB_MAX_POOL="10"
+export DB_ACQUIRE="60000"
+export DB_TIMEOUT="30000"
 export DB_ENABLE_LOGGING=""
 
 export LOCAL_SITE_ACCESS_TOKEN=""

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -327,6 +327,18 @@ const config = convict({
       format: "required-positive-number",
       default: 10,
     },
+    dbAcquire: {
+      doc: "",
+      env: "DB_ACQUIRE",
+      format: "required-positive-number",
+      default: 60000,
+    },
+    dbTimeout: {
+      doc: "",
+      env: "DB_TIMEOUT",
+      format: "required-positive-number",
+      default: 10000,
+    },
     dbEnableLogging: {
       doc: "Enable database logging",
       env: "DB_ENABLE_LOGGING",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -328,13 +328,15 @@ const config = convict({
       default: 10,
     },
     dbAcquire: {
-      doc: "",
+      doc:
+        "The maximum time, in milliseconds, that pool will try to get connection before throwing error",
       env: "DB_ACQUIRE",
       format: "required-positive-number",
       default: 60000,
     },
     dbTimeout: {
-      doc: "",
+      doc:
+        "The maximum time, in milliseconds, before an idle session within an open transaction will be terminated",
       env: "DB_TIMEOUT",
       format: "required-positive-number",
       default: 10000,

--- a/src/database/config.js
+++ b/src/database/config.js
@@ -10,6 +10,8 @@ const { parse } = require("pg-connection-string")
 const { DB_URI } = process.env
 const DB_MIN_POOL = parseInt(process.env.DB_MIN_POOL, 10)
 const DB_MAX_POOL = parseInt(process.env.DB_MAX_POOL, 10)
+const DB_ACQUIRE = parseInt(process.env.DB_ACQUIRE, 10)
+const DB_TIMEOUT = parseInt(process.env.DB_TIMEOUT, 10)
 
 const parsed = parse(DB_URI)
 const port = parsed.port ? parseInt(parsed.port, 10) : 5432
@@ -27,6 +29,7 @@ module.exports = {
   dialectOptions: {
     useUTC: false,
     timezone: "+08:00",
+    idle_in_transaction_session_timeout: DB_TIMEOUT,
   },
   timezone: "+08:00",
   define: {
@@ -38,5 +41,6 @@ module.exports = {
   pool: {
     min: DB_MIN_POOL,
     max: DB_MAX_POOL,
+    acquire: DB_ACQUIRE,
   },
 }


### PR DESCRIPTION
## Problem

This PR adds new env vars which allow us to toggle our DB settings more easily, in response to the frequent `SequelizeConnectionAcquireTimeoutError` we're been encountering on prod.

New env vars added:

- DB_ACQUIRE
  - The maximum time, in milliseconds, that pool will try to get connection before throwing error
  - currently set to 60000, will increase to 120000
- DB_TIMEOUT
  - The maximum time, in milliseconds, before an idle session within an open transaction will be terminated
  - currently set to 0 (never timeout), will set to 30000