### PR TITLE
Fix: remove modification of non-existent team

### DIFF
--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -170,13 +170,6 @@ export default class ReposService {
       repo: repoName,
       permission: "admin",
     })
-    await octokit.teams.addOrUpdateRepoPermissionsInOrg({
-      org: ISOMER_GITHUB_ORGANIZATION_NAME,
-      team_slug: repoName,
-      owner: ISOMER_GITHUB_ORGANIZATION_NAME,
-      repo: repoName,
-      permission: "push",
-    })
   }
 
   generateRepoAndPublishToGitHub = async (


### PR DESCRIPTION
## Problem

This PR fixes an issue with our existing site creation form, which attempts to modify the team permissions of a non-existent team when creating a site.