### PR TITLE
[LS-81] fix(markdown-utils): change sanitization process + add unescape

### DIFF
--- a/src/fixtures/markdown-fixtures.ts
+++ b/src/fixtures/markdown-fixtures.ts
@@ -152,3 +152,5 @@ third_nav_title: Masterclasses & Workshops
 title: <b>Digital Strategy & the 101 of Search Engine Optimisation (SEO)</b>
 ---
 <b>&amp;something</b>`
+
+export const HTML_COMMENT_TAG = "<!---->"

--- a/src/fixtures/markdown-fixtures.ts
+++ b/src/fixtures/markdown-fixtures.ts
@@ -53,143 +53,53 @@ export const rawInstagramEmbedScript =
 export const sanitizedInstagramEmbedScript =
   '<script async="" src="//www.instagram.com/embed.js"></script>'
 
-export const frontMatterWithSymbol = `---
+export const frontMatterWithSymbolAndHtmlBody = `---
 title: Digital Strategy & the 101 of Search Engine Optimisation (SEO)
 permalink: /digital-programmes/masterclasses-and-workshops/digital-strategy-and-the-101-of-seo/
 breadcrumb: Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO)
 third_nav_title: Masterclasses &amp; Workshops
 description: ""
 ---
-<img style="width:100%;" src="/images/images-2021/DigitalProgrammes-Image-Masterclass.png">
+<b>&something</b>`
 
-<h4 style="text-align:center;">Next intake:</h4>
+export const frontMatterWithSymbolWithoutBodyAndHtml = `---
+title: Digital Strategy & the 101 of Search Engine Optimisation (SEO)
+permalink: /digital-programmes/masterclasses-and-workshops/digital-strategy-and-the-101-of-seo/
+breadcrumb: Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO)
+third_nav_title: Masterclasses &amp; Workshops
+description: ""
+---`
 
-<center><table style="width:80%;">
-    <tbody><tr style="text-align:center;">
-      <th style="text-align:center;width:50%;">Online Training</th>
-      <th style="text-align:center;width:50%;">Face-to-Face</th>
-    </tr>
-    <tr style="text-align:center;">
-      <td style="text-align:center;width:50%;">16 June (Fri)</td>
-      <td style="text-align:center;width:50%;">To be confirmed</td>
-    </tr>
-</tbody></table></center>
+export const frontMatterWithSymbolAndBodyWithoutHtml = `---
+title: Digital Strategy & the 101 of Search Engine Optimisation (SEO)
+permalink: /digital-programmes/masterclasses-and-workshops/digital-strategy-and-the-101-of-seo/
+breadcrumb: Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO)
+third_nav_title: Masterclasses &amp; Workshops
+description: ""
+---
+something`
 
-<p>Business decision makers will learn how to apply simple digital frameworks, analyse digital campaign successes, formulate an actionable, forward-focus review, perform simple budgeting for digital strategies, project potential marketing ROI from digital campaigns as well as drive sales and boost business through SEO execution. This class covers successful case studies in Singapore and is extremely hands-on.</p>
+export const frontMatterWithSymbolAndHtml = `---
+title: <b>Digital Strategy & the 101 of Search Engine Optimisation (SEO)</b>
+permalink: /digital-programmes/masterclasses-and-workshops/digital-strategy-and-the-101-of-seo/
+breadcrumb: Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO)
+third_nav_title: Masterclasses &amp; Workshops
+description: ""
+---`
 
-<p>This is an introductory program that is suitable for acquiring an overview of existing industry practices in digital marketing and SEO, looking to understand the change in consumer behaviour to adapt their business marketing plans, and seeking clear direction to drive breakthrough marketing campaigns.</p>
+export const escapedFrontMatterWithSymbolAndHtml = `---
+title: <b>Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO)</b>
+permalink: /digital-programmes/masterclasses-and-workshops/digital-strategy-and-the-101-of-seo/
+breadcrumb: Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO)
+third_nav_title: Masterclasses &amp; Workshops
+description: ""
+---`
 
-<h4>Course Title | Mode of Training | Course Ref</h4>
-
-<p>Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO) 
-<br>Synchronous E-learning -TGS-2020501149</p>
-
-<h4>Outline</h4>
-<ul>
-<li>Introduction to today’s digital space</li>
-<li>Understand social media, search engine, email marketing and e-Commerce platforms</li>
-<li>Fundamental digital strategy</li>
-<li>Select the right digital channel, craft a simple  digital framework, understand how digital ROI is derived, plan a budget and project returns</li>
-<li>Introduction to SEO</li>
-<li>Determine this channel for growth, understand all necessary aspects of optimisation/ backlinking strategy and know 101 of hiring/ working with SEO vendors</li>
-<li>Evaluating digital campaigns &amp; key metrics</li>
-<li>Create a simple framework to evaluate campaign success or failure and understand key metrics from Google Analytics and Google Webmaster tools</li>
-  </ul>
-
-<h4>Requirements</h4>
-<p>Participants are required to have a Gmail account, bring a laptop and have Google Chrome (Safari on Mac) browser installed for constant practice.</p>
-  
-<h4>Duration</h4>
-<p>9am - 6pm (8 hours)</p>
-  
-<h4>Trainer Profile</h4>
-
-
-<div class="row">
-    <div class="col is-4">
-		<figure style="margin:0;">
-			<img style="width:60%;" src="/images/images-2021/Masterclass Trainer_Jayden Ooi.png">
-			<figcaption style="color:#0AD25A" class="has-text-weight-bold"> </figcaption>
-		</figure>
-	</div>
-	<div class="col is-8">
-        <b>Jayden Ooi</b><br><i>Entrepreneur, Digital Strategist</i><br><br>Jayden Ooi is highly qualified in practice with many successful digital transformations for SMEs to pivot their brick-and-mortar businesses into the digital space. With his
-expertise, a local retailer successfully redesigned its business model, ranked number one on Google, and achieved more than three million dollars in e-commerce sales. In another instance, he helped a local F&amp;B SME to rise to the top ranking and triple its
-annual revenue. Jayden is an experienced professional in SEO, digital marketing, and e-commerce development. Over the years, he has built a staunch customer portfolio and a successful team in Singapore and Malaysia. His agency, NightOwl SEO, has helped many of his clients to be in the top 5 rankings on Google.
-	</div>
-</div>
-
-<h4>Fees (GST 8% - For payment made on/after 1 Jan 2023)</h4>
-
-<center>
-<table style="width:100%;">
-<tbody><tr>
-<th style="width:70%;">Category</th>
-<th style="width:30%:">Price</th>
-</tr>
-
-<tr>
-<td>Full Fee</td>
-<td>$810</td>
-</tr>
-
-<tr>
-  <td>Singapore Citizen<sup>0</sup> (70% funding)</td>
-<td>$240.75</td>
-</tr>
-	
-<tr>
-  <td>Singapore Citizen 40 years and above<sup>0,1</sup> (90% funding)</td>
-<td>$90.75</td>
-</tr>
-
-<tr>
-  <td>Singapore Citizen sponsored by SMEs<sup>0,2</sup> (90% funding)</td>
-<td>$90.75</td>
-</tr>
-
-<tr>
-  <td>Singapore PR (70% funding)</td>
-<td>$243</td>
-</tr>
-
-<tr>
-<td>Singapore PR sponsored by SMEs<sup>2</sup> (90% funding)</td>
-<td>$93</td>
-</tr>
-
-</tbody></table>
-</center>
-
-
-<small><i>Fees include prevailing GST
-<br>Funding Eligibility Period: 1 Oct 2021 to 30 Sep 2024
-<br><small><i><sup>0</sup>The increase of 1% GST on fees will be absorbed for Singapore Citizens in 2023
-<br><small><i><sup>1</sup>Fee is under the <a href="/services/consultancy/skillsfuture-midcareer-enhanced-subsidy">Mid-career Enhanced Subsidy(MCES)</a>
-<br><sup>2</sup>Fee is under the <a href="/services/consultancy/etss">Enhanced Training Support for SMEs (ETSS)</a><br>
-</i></small>
-
-<h4>Additional Support</h4>
-
-<p>This course is also eligible for the following:</p>
-
-<b>For self-sponsored participants:</b>
-<ul>
-  <li><a href="/services/consultancy/skillsfuture-credit">SkillsFuture Credit</a></li>
- 
-  <li><a href="/services/consultancy/wss-individuals">Workfare Skills Support (WSS) Scheme (For Individuals)</a></li>
-</ul>
-
-<b>For company-sponsored participants:</b>
-<ul>
-  <li><a href="/services/consultancy/absentee-payroll-ap">Absentee Payroll</a></li>
-  <li><a href="/services/consultancy/wss-companies">Workfare Skills Support (WSS) Scheme (For Companies)</a></li>
-	<li><a href="/services/consultancy/skillsfuture-enterprise-credit">SkillsFuture Enterprise Credit</a></li>
-  </ul>
-
-<p>For more information about funding and support, click <a href="/services/consultancy">here.</a></p>
-
-<div style="width:50%;float:left;"><center><a style="background-color:#06225e; border:white; color:white; padding: 10px 10px; text-align:center; display:inline-block; margin: 4px 2px; cursor:pointer;text-decoration:none;" href="https://form.gov.sg/642d0e18682ef300118c4588">Register Now</a></center></div>
-
-<div style="width:50%;float:left;"><center><a style="background-color:#06225e; border:white; color:white; padding: 10px 10px; text-align:center; display:inline-block; margin: 4px 2px; cursor:pointer;text-decoration:none;" href="https://form.gov.sg/602f33f172d5100012d6ca8b">Request for Brochure</a></center></div>
-</i></small></i></small>`
+export const escapedFrontMatterWithSymbolAndHtmlBody = `---
+title: Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO)
+permalink: /digital-programmes/masterclasses-and-workshops/digital-strategy-and-the-101-of-seo/
+breadcrumb: Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO)
+third_nav_title: Masterclasses &amp; Workshops
+description: ""
+---
+<b>&amp;something</b>`

--- a/src/fixtures/markdown-fixtures.ts
+++ b/src/fixtures/markdown-fixtures.ts
@@ -87,6 +87,15 @@ third_nav_title: Masterclasses &amp; Workshops
 description: ""
 ---`
 
+export const frontMatterWithSymbolAndHtmlAndBody = `---
+title: <b>Digital Strategy & the 101 of Search Engine Optimisation (SEO)</b>
+permalink: /digital-programmes/masterclasses-and-workshops/digital-strategy-and-the-101-of-seo/
+breadcrumb: Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO)
+third_nav_title: Masterclasses &amp; Workshops
+description: ""
+---
+<b>&something</b>`
+
 export const escapedFrontMatterWithSymbolAndHtml = `---
 title: <b>Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO)</b>
 permalink: /digital-programmes/masterclasses-and-workshops/digital-strategy-and-the-101-of-seo/
@@ -101,5 +110,45 @@ permalink: /digital-programmes/masterclasses-and-workshops/digital-strategy-and-
 breadcrumb: Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO)
 third_nav_title: Masterclasses &amp; Workshops
 description: ""
+---
+<b>&amp;something</b>`
+
+export const safeEscapedJson = {
+  frontMatter: {
+    breadcrumb:
+      "Digital Strategy & the 101 of Search Engine Optimisation (SEO)",
+    description: "",
+    permalink:
+      "/digital-programmes/masterclasses-and-workshops/digital-strategy-and-the-101-of-seo/",
+    third_nav_title: "Masterclasses & Workshops",
+    // NOTE: **NOT** escaped even when enclosed in <b/> tag
+    title:
+      "<b>Digital Strategy & the 101 of Search Engine Optimisation (SEO)</b>",
+  },
+  // NOTE: Properly escaped
+  pageContent: "<b>&amp;something</b>",
+}
+
+export const encodedFrontmatterJson = {
+  frontMatter: {
+    breadcrumb:
+      "Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO)",
+    description: "",
+    permalink:
+      "/digital-programmes/masterclasses-and-workshops/digital-strategy-and-the-101-of-seo/",
+    third_nav_title: "Masterclasses & Workshops",
+    // NOTE: The special character is escaped within a html tag
+    title:
+      "<b>Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO)</b>",
+  },
+  pageContent: "<b>&amp;something</b>",
+}
+
+export const frontMatterWithSymbolAndEscapedBody = `---
+breadcrumb: Digital Strategy & the 101 of Search Engine Optimisation (SEO)
+description: ""
+permalink: /digital-programmes/masterclasses-and-workshops/digital-strategy-and-the-101-of-seo/
+third_nav_title: Masterclasses & Workshops
+title: <b>Digital Strategy & the 101 of Search Engine Optimisation (SEO)</b>
 ---
 <b>&amp;something</b>`

--- a/src/fixtures/markdown-fixtures.ts
+++ b/src/fixtures/markdown-fixtures.ts
@@ -52,3 +52,144 @@ export const rawInstagramEmbedScript =
 
 export const sanitizedInstagramEmbedScript =
   '<script async="" src="//www.instagram.com/embed.js"></script>'
+
+export const frontMatterWithSymbol = `---
+title: Digital Strategy & the 101 of Search Engine Optimisation (SEO)
+permalink: /digital-programmes/masterclasses-and-workshops/digital-strategy-and-the-101-of-seo/
+breadcrumb: Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO)
+third_nav_title: Masterclasses &amp; Workshops
+description: ""
+---
+<img style="width:100%;" src="/images/images-2021/DigitalProgrammes-Image-Masterclass.png">
+
+<h4 style="text-align:center;">Next intake:</h4>
+
+<center><table style="width:80%;">
+    <tbody><tr style="text-align:center;">
+      <th style="text-align:center;width:50%;">Online Training</th>
+      <th style="text-align:center;width:50%;">Face-to-Face</th>
+    </tr>
+    <tr style="text-align:center;">
+      <td style="text-align:center;width:50%;">16 June (Fri)</td>
+      <td style="text-align:center;width:50%;">To be confirmed</td>
+    </tr>
+</tbody></table></center>
+
+<p>Business decision makers will learn how to apply simple digital frameworks, analyse digital campaign successes, formulate an actionable, forward-focus review, perform simple budgeting for digital strategies, project potential marketing ROI from digital campaigns as well as drive sales and boost business through SEO execution. This class covers successful case studies in Singapore and is extremely hands-on.</p>
+
+<p>This is an introductory program that is suitable for acquiring an overview of existing industry practices in digital marketing and SEO, looking to understand the change in consumer behaviour to adapt their business marketing plans, and seeking clear direction to drive breakthrough marketing campaigns.</p>
+
+<h4>Course Title | Mode of Training | Course Ref</h4>
+
+<p>Digital Strategy &amp; the 101 of Search Engine Optimisation (SEO) 
+<br>Synchronous E-learning -TGS-2020501149</p>
+
+<h4>Outline</h4>
+<ul>
+<li>Introduction to today’s digital space</li>
+<li>Understand social media, search engine, email marketing and e-Commerce platforms</li>
+<li>Fundamental digital strategy</li>
+<li>Select the right digital channel, craft a simple  digital framework, understand how digital ROI is derived, plan a budget and project returns</li>
+<li>Introduction to SEO</li>
+<li>Determine this channel for growth, understand all necessary aspects of optimisation/ backlinking strategy and know 101 of hiring/ working with SEO vendors</li>
+<li>Evaluating digital campaigns &amp; key metrics</li>
+<li>Create a simple framework to evaluate campaign success or failure and understand key metrics from Google Analytics and Google Webmaster tools</li>
+  </ul>
+
+<h4>Requirements</h4>
+<p>Participants are required to have a Gmail account, bring a laptop and have Google Chrome (Safari on Mac) browser installed for constant practice.</p>
+  
+<h4>Duration</h4>
+<p>9am - 6pm (8 hours)</p>
+  
+<h4>Trainer Profile</h4>
+
+
+<div class="row">
+    <div class="col is-4">
+		<figure style="margin:0;">
+			<img style="width:60%;" src="/images/images-2021/Masterclass Trainer_Jayden Ooi.png">
+			<figcaption style="color:#0AD25A" class="has-text-weight-bold"> </figcaption>
+		</figure>
+	</div>
+	<div class="col is-8">
+        <b>Jayden Ooi</b><br><i>Entrepreneur, Digital Strategist</i><br><br>Jayden Ooi is highly qualified in practice with many successful digital transformations for SMEs to pivot their brick-and-mortar businesses into the digital space. With his
+expertise, a local retailer successfully redesigned its business model, ranked number one on Google, and achieved more than three million dollars in e-commerce sales. In another instance, he helped a local F&amp;B SME to rise to the top ranking and triple its
+annual revenue. Jayden is an experienced professional in SEO, digital marketing, and e-commerce development. Over the years, he has built a staunch customer portfolio and a successful team in Singapore and Malaysia. His agency, NightOwl SEO, has helped many of his clients to be in the top 5 rankings on Google.
+	</div>
+</div>
+
+<h4>Fees (GST 8% - For payment made on/after 1 Jan 2023)</h4>
+
+<center>
+<table style="width:100%;">
+<tbody><tr>
+<th style="width:70%;">Category</th>
+<th style="width:30%:">Price</th>
+</tr>
+
+<tr>
+<td>Full Fee</td>
+<td>$810</td>
+</tr>
+
+<tr>
+  <td>Singapore Citizen<sup>0</sup> (70% funding)</td>
+<td>$240.75</td>
+</tr>
+	
+<tr>
+  <td>Singapore Citizen 40 years and above<sup>0,1</sup> (90% funding)</td>
+<td>$90.75</td>
+</tr>
+
+<tr>
+  <td>Singapore Citizen sponsored by SMEs<sup>0,2</sup> (90% funding)</td>
+<td>$90.75</td>
+</tr>
+
+<tr>
+  <td>Singapore PR (70% funding)</td>
+<td>$243</td>
+</tr>
+
+<tr>
+<td>Singapore PR sponsored by SMEs<sup>2</sup> (90% funding)</td>
+<td>$93</td>
+</tr>
+
+</tbody></table>
+</center>
+
+
+<small><i>Fees include prevailing GST
+<br>Funding Eligibility Period: 1 Oct 2021 to 30 Sep 2024
+<br><small><i><sup>0</sup>The increase of 1% GST on fees will be absorbed for Singapore Citizens in 2023
+<br><small><i><sup>1</sup>Fee is under the <a href="/services/consultancy/skillsfuture-midcareer-enhanced-subsidy">Mid-career Enhanced Subsidy(MCES)</a>
+<br><sup>2</sup>Fee is under the <a href="/services/consultancy/etss">Enhanced Training Support for SMEs (ETSS)</a><br>
+</i></small>
+
+<h4>Additional Support</h4>
+
+<p>This course is also eligible for the following:</p>
+
+<b>For self-sponsored participants:</b>
+<ul>
+  <li><a href="/services/consultancy/skillsfuture-credit">SkillsFuture Credit</a></li>
+ 
+  <li><a href="/services/consultancy/wss-individuals">Workfare Skills Support (WSS) Scheme (For Individuals)</a></li>
+</ul>
+
+<b>For company-sponsored participants:</b>
+<ul>
+  <li><a href="/services/consultancy/absentee-payroll-ap">Absentee Payroll</a></li>
+  <li><a href="/services/consultancy/wss-companies">Workfare Skills Support (WSS) Scheme (For Companies)</a></li>
+	<li><a href="/services/consultancy/skillsfuture-enterprise-credit">SkillsFuture Enterprise Credit</a></li>
+  </ul>
+
+<p>For more information about funding and support, click <a href="/services/consultancy">here.</a></p>
+
+<div style="width:50%;float:left;"><center><a style="background-color:#06225e; border:white; color:white; padding: 10px 10px; text-align:center; display:inline-block; margin: 4px 2px; cursor:pointer;text-decoration:none;" href="https://form.gov.sg/642d0e18682ef300118c4588">Register Now</a></center></div>
+
+<div style="width:50%;float:left;"><center><a style="background-color:#06225e; border:white; color:white; padding: 10px 10px; text-align:center; display:inline-block; margin: 4px 2px; cursor:pointer;text-decoration:none;" href="https://form.gov.sg/602f33f172d5100012d6ca8b">Request for Brochure</a></center></div>
+</i></small></i></small>`

--- a/src/utils/__tests__/markdown-utils.spec.ts
+++ b/src/utils/__tests__/markdown-utils.spec.ts
@@ -20,6 +20,7 @@ import {
   safeEscapedJson,
   frontMatterWithSymbolAndEscapedBody,
   encodedFrontmatterJson,
+  HTML_COMMENT_TAG,
 } from "@fixtures/markdown-fixtures"
 import { sanitizer } from "@root/services/utilServices/Sanitizer"
 
@@ -100,6 +101,10 @@ describe("Sanitized markdown utils test", () => {
       expect(sanitizer.sanitize(frontMatterWithSymbolAndBodyWithoutHtml)).toBe(
         frontMatterWithSymbolAndBodyWithoutHtml
       )
+    })
+
+    it("should inject a html comment tag when the string is empty", () => {
+      expect(sanitizer.sanitize("")).toBe(HTML_COMMENT_TAG)
     })
   })
 })

--- a/src/utils/__tests__/markdown-utils.spec.ts
+++ b/src/utils/__tests__/markdown-utils.spec.ts
@@ -16,66 +16,90 @@ import {
   escapedFrontMatterWithSymbolAndHtml,
   escapedFrontMatterWithSymbolAndHtmlBody,
   frontMatterWithSymbolAndBodyWithoutHtml,
+  frontMatterWithSymbolAndHtmlAndBody,
+  safeEscapedJson,
+  frontMatterWithSymbolAndEscapedBody,
+  encodedFrontmatterJson,
 } from "@fixtures/markdown-fixtures"
 import { sanitizer } from "@root/services/utilServices/Sanitizer"
 
 describe("Sanitized markdown utils test", () => {
-  it("should parse normal markdown content into an object successfully", () => {
-    expect(retrieveDataFromMarkdown(normalMarkdownContent)).toStrictEqual(
-      normalJsonObject
-    )
+  describe("retrieveDataFromMarkdown", () => {
+    it("should parse normal markdown content into an object successfully", () => {
+      expect(retrieveDataFromMarkdown(normalMarkdownContent)).toStrictEqual(
+        normalJsonObject
+      )
+    })
+
+    it("should parse malicious markdown content into a sanitized object successfully", () => {
+      expect(retrieveDataFromMarkdown(maliciousMarkdownContent)).toStrictEqual(
+        normalJsonObject
+      )
+    })
+
+    it("should not html encode special characters in the frontmatter even when there is html but it should encode special characters in body", () => {
+      expect(
+        retrieveDataFromMarkdown(frontMatterWithSymbolAndHtmlAndBody)
+      ).toStrictEqual(safeEscapedJson)
+    })
   })
 
-  it("should parse malicious markdown content into a sanitized object successfully", () => {
-    expect(retrieveDataFromMarkdown(maliciousMarkdownContent)).toStrictEqual(
-      normalJsonObject
-    )
+  describe("convertDataToMarkdown", () => {
+    it("should stringify a normal JSON object into markdown content successfully", () => {
+      const { frontMatter, pageContent } = normalJsonObject
+      expect(convertDataToMarkdown(frontMatter, pageContent)).toBe(
+        normalMarkdownContent
+      )
+    })
+
+    it("should stringify a malicious JSON object into sanitized markdown content successfully", () => {
+      const { frontMatter, pageContent } = maliciousJsonObject
+      expect(convertDataToMarkdown(frontMatter, pageContent)).toBe(
+        normalMarkdownContent
+      )
+    })
+
+    it("should stringify a JSON object containing encoded frontmatter into markdown content without encoded frontmatter", () => {
+      const { frontMatter, pageContent } = encodedFrontmatterJson
+
+      expect(convertDataToMarkdown(frontMatter, pageContent)).toBe(
+        frontMatterWithSymbolAndEscapedBody
+      )
+    })
   })
 
-  it("should stringify a normal JSON object into markdown content successfully", () => {
-    const { frontMatter, pageContent } = normalJsonObject
-    expect(convertDataToMarkdown(frontMatter, pageContent)).toBe(
-      normalMarkdownContent
-    )
-  })
+  describe("sanitize", () => {
+    it("should sanitize boolean tags with an empty string", () => {
+      // NOTE: Setting a boolean attr to an empty string is equivalent
+      // to it being true.
+      // See the HTML spec: https://html.spec.whatwg.org/#boolean-attributes
+      expect(sanitizer.sanitize(rawInstagramEmbedScript)).toBe(
+        sanitizedInstagramEmbedScript
+      )
+    })
 
-  it("should stringify a malicious JSON object into sanitized markdown content successfully", () => {
-    const { frontMatter, pageContent } = maliciousJsonObject
-    expect(convertDataToMarkdown(frontMatter, pageContent)).toBe(
-      normalMarkdownContent
-    )
-  })
+    it("should escape special characters in our frontmatter if there is html in the frontmatter", () => {
+      expect(sanitizer.sanitize(frontMatterWithSymbolAndHtml)).toBe(
+        escapedFrontMatterWithSymbolAndHtml
+      )
+    })
 
-  it("should sanitize boolean tags with an empty string", () => {
-    // NOTE: Setting a boolean attr to an empty string is equivalent
-    // to it being true.
-    // See the HTML spec: https://html.spec.whatwg.org/#boolean-attributes
-    expect(sanitizer.sanitize(rawInstagramEmbedScript)).toBe(
-      sanitizedInstagramEmbedScript
-    )
-  })
+    it("should escape special characters in our frontmatter if there is html in the body", () => {
+      expect(sanitizer.sanitize(frontMatterWithSymbolAndHtmlBody)).toBe(
+        escapedFrontMatterWithSymbolAndHtmlBody
+      )
+    })
 
-  it("should escape special characters in our frontmatter if there is html in the frontmatter", () => {
-    expect(sanitizer.sanitize(frontMatterWithSymbolAndHtml)).toBe(
-      escapedFrontMatterWithSymbolAndHtml
-    )
-  })
+    it("should not escape special characters in our frontmatter if there is no html and no body", () => {
+      expect(sanitizer.sanitize(frontMatterWithSymbolWithoutBodyAndHtml)).toBe(
+        frontMatterWithSymbolWithoutBodyAndHtml
+      )
+    })
 
-  it("should escape special characters in our frontmatter if there is html in the body", () => {
-    expect(sanitizer.sanitize(frontMatterWithSymbolAndHtmlBody)).toBe(
-      escapedFrontMatterWithSymbolAndHtmlBody
-    )
-  })
-
-  it("should not escape special characters in our frontmatter if there is no html and no body", () => {
-    expect(sanitizer.sanitize(frontMatterWithSymbolWithoutBodyAndHtml)).toBe(
-      frontMatterWithSymbolWithoutBodyAndHtml
-    )
-  })
-
-  it("should not escape special characters in our frontmatter if there is no html but there is body", () => {
-    expect(sanitizer.sanitize(frontMatterWithSymbolAndBodyWithoutHtml)).toBe(
-      frontMatterWithSymbolAndBodyWithoutHtml
-    )
+    it("should not escape special characters in our frontmatter if there is no html but there is body", () => {
+      expect(sanitizer.sanitize(frontMatterWithSymbolAndBodyWithoutHtml)).toBe(
+        frontMatterWithSymbolAndBodyWithoutHtml
+      )
+    })
   })
 })

--- a/src/utils/__tests__/markdown-utils.spec.ts
+++ b/src/utils/__tests__/markdown-utils.spec.ts
@@ -10,6 +10,7 @@ import {
   maliciousJsonObject,
   rawInstagramEmbedScript,
   sanitizedInstagramEmbedScript,
+  frontMatterWithSymbol,
 } from "@fixtures/markdown-fixtures"
 import { sanitizer } from "@root/services/utilServices/Sanitizer"
 
@@ -46,6 +47,12 @@ describe("Sanitized markdown utils test", () => {
     // See the HTML spec: https://html.spec.whatwg.org/#boolean-attributes
     expect(sanitizer.sanitize(rawInstagramEmbedScript)).toBe(
       sanitizedInstagramEmbedScript
+    )
+  })
+
+  it("should not escape special characters in our frontmatter", () => {
+    expect(sanitizer.sanitize(frontMatterWithSymbol)).toBe(
+      frontMatterWithSymbol
     )
   })
 })

--- a/src/utils/__tests__/markdown-utils.spec.ts
+++ b/src/utils/__tests__/markdown-utils.spec.ts
@@ -10,7 +10,12 @@ import {
   maliciousJsonObject,
   rawInstagramEmbedScript,
   sanitizedInstagramEmbedScript,
-  frontMatterWithSymbol,
+  frontMatterWithSymbolAndHtmlBody,
+  frontMatterWithSymbolAndHtml,
+  frontMatterWithSymbolWithoutBodyAndHtml,
+  escapedFrontMatterWithSymbolAndHtml,
+  escapedFrontMatterWithSymbolAndHtmlBody,
+  frontMatterWithSymbolAndBodyWithoutHtml,
 } from "@fixtures/markdown-fixtures"
 import { sanitizer } from "@root/services/utilServices/Sanitizer"
 
@@ -50,9 +55,27 @@ describe("Sanitized markdown utils test", () => {
     )
   })
 
-  it("should not escape special characters in our frontmatter", () => {
-    expect(sanitizer.sanitize(frontMatterWithSymbol)).toBe(
-      frontMatterWithSymbol
+  it("should escape special characters in our frontmatter if there is html in the frontmatter", () => {
+    expect(sanitizer.sanitize(frontMatterWithSymbolAndHtml)).toBe(
+      escapedFrontMatterWithSymbolAndHtml
+    )
+  })
+
+  it("should escape special characters in our frontmatter if there is html in the body", () => {
+    expect(sanitizer.sanitize(frontMatterWithSymbolAndHtmlBody)).toBe(
+      escapedFrontMatterWithSymbolAndHtmlBody
+    )
+  })
+
+  it("should not escape special characters in our frontmatter if there is no html and no body", () => {
+    expect(sanitizer.sanitize(frontMatterWithSymbolWithoutBodyAndHtml)).toBe(
+      frontMatterWithSymbolWithoutBodyAndHtml
+    )
+  })
+
+  it("should not escape special characters in our frontmatter if there is no html but there is body", () => {
+    expect(sanitizer.sanitize(frontMatterWithSymbolAndBodyWithoutHtml)).toBe(
+      frontMatterWithSymbolAndBodyWithoutHtml
     )
   })
 })

--- a/src/utils/markdown-utils.js
+++ b/src/utils/markdown-utils.js
@@ -12,11 +12,17 @@ const getTrailingSlashWithPermalink = (permalink) =>
 
 const retrieveDataFromMarkdown = (fileContent) => {
   // eslint-disable-next-line no-unused-vars
-  const [unused, encodedFrontMatter, ...pageContent] = sanitizer
-    .sanitize(fileContent)
-    .split("---")
+  const [unused, encodedFrontMatter, ...pageContent] = fileContent.split("---")
+  // NOTE: We separate the sanitization into 2 steps.
+  // This is because DOMPurify does URL encoding when it detects html in the string.
+  // For example, `<b>&something</b>` will get escaped to `<b>&amp;something</b>`.
+  // To prevent this behaviour from affecting our frontmatter, we do the sanitization separately
+  // on the frontmatter and the content
   const frontMatter = sanitizedYamlParse(encodedFrontMatter)
-  return { frontMatter, pageContent: pageContent.join("---").trim() }
+  return {
+    frontMatter,
+    pageContent: sanitizer.sanitize(pageContent.join("---")).trim(),
+  }
 }
 
 const isResourceFileOrLink = (frontMatter) => {

--- a/src/utils/markdown-utils.js
+++ b/src/utils/markdown-utils.js
@@ -29,9 +29,15 @@ const retrieveDataFromMarkdown = (fileContent) => {
     // will get transformed regardless.
     (val) => _.unescape(val)
   )
+  const originalPageContent = pageContent.join("---")
+  // NOTE: We don't sanitize if there is no page content.
+  // This is to avoid injection of a HTML comment by the sanitize function.
+  const sanitizedPageContent = originalPageContent
+    ? sanitizer.sanitize(originalPageContent).trim()
+    : ""
   return {
     frontMatter,
-    pageContent: sanitizer.sanitize(pageContent.join("---")).trim(),
+    pageContent: sanitizedPageContent,
   }
 }
 
@@ -49,13 +55,18 @@ const convertDataToMarkdown = (originalFrontMatter, pageContent) => {
   if (permalink) {
     frontMatter.permalink = getTrailingSlashWithPermalink(permalink)
   }
+  // NOTE: We don't sanitize if there is no page content.
+  // This is to avoid injection of a HTML comment by the sanitize function.
+  const sanitizedPageContent = pageContent
+    ? sanitizer.sanitize(pageContent)
+    : ""
   // NOTE: See above on why we call `unescape`
   const newFrontMatter = _.unescape(sanitizedYamlStringify(frontMatter))
   const newContent = [
     "---\n",
     newFrontMatter,
     "---\n",
-    sanitizer.sanitize(pageContent),
+    sanitizedPageContent,
   ].join("")
   return newContent
 }


### PR DESCRIPTION
## Problem
Previously, there was inconsistent behaviour caused by sanitization on the backend. This is because of dompurify's sanitization config, where it will automatically html encode certain special characters if it detects that there is a html tag. 

This process affects not just content within the tag, but the string as a whole. For example, 
```ts
const x = "& <b>&something</b>"
```
will have both ampersands encoded even though the first one is outside of the b-tag. 

Closes LS-81

## Solution
In order to make sure that sanitization takes place properly, this PR establishes an invariant, as follows: 
**frontmatter content is never html encoded**. 

This is chosen over html encoding all content in our frontmatter due to the existence of the 3 special pages (homepage/nav/contact-us), where users are able to input html (:sadge:)

In order to preserve this property, a few rules have to be followed (done alr at present)
1. devs never call `sanitize` directly for markdown files but through a given interface (`<convert|retrieve>DataFromMarkdown`). 
2. the respective conversion/retrieval functions separately sanitize frontmatter/body 
3. we run `unescape` after sanitizing frontmatter. 

This allows us

## Testing 
- [ ] navigate to the CMS and choose a testing site
- [ ] make the page have special character in frontmatter (can be done through editing the page directly on github if lazy)
- [ ] rename a page to have a special character in the title
- [ ] check that clicking settings on the page does **not** show a html encoded title

**Notes**
This change **might be destructive** - existing pages w html encoded properties in their frontmatter will have them unescaped. I'm not entirely sure how this impacts things like `permalink` etc but it's also possible to guarantee only for the `title` property