### PR TITLE
style(env var): change naming of var

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -26,7 +26,7 @@ export SITE_CREATE_FORM_KEY=""
 # generate your own access key and secret access key from AWS
 export AWS_ACCESS_KEY_ID="" 
 export AWS_SECRET_ACCESS_KEY=""
-export MOCK_AMPLIFY_CREATE_DOMAIN_CALLS="true"
+export MOCK_AMPLIFY_DOMAIN_ASSOCIATION_CALLS="true"
 
 # Required to run end-to-end tests
 export E2E_TEST_REPO="e2e-test-repo"

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -165,9 +165,9 @@ const config = convict({
         format: String,
         default: "",
       },
-      mockAmplifyCreateDomainAssociationCalls: {
-        doc: "Mock createDomainAssociation calls to Amplify ",
-        env: "MOCK_AMPLIFY_CREATE_DOMAIN_ASSOCIATION_CALLS",
+      mockAmplifyDomainAssociationCalls: {
+        doc: "Mock domain association calls to Amplify",
+        env: "MOCK_AMPLIFY_DOMAIN_ASSOCIATION_CALLS",
         format: "required-boolean",
         default: true,
       },

--- a/src/services/identity/LaunchClient.ts
+++ b/src/services/identity/LaunchClient.ts
@@ -119,7 +119,7 @@ class LaunchClient {
   }
 
   private shouldMockAmplifyDomainCalls(): boolean {
-    return config.get("aws.amplify.mockAmplifyCreateDomainAssociationCalls")
+    return config.get("aws.amplify.mockAmplifyDomainAssociationCalls")
   }
 
   private getSubDomains(

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -228,8 +228,9 @@ export default class InfraService {
       )
 
       // Get DNS records from Amplify
-      const isTestEnv =
-        config.get("env") === "test" || config.get("env") === "dev"
+      const isTestEnv = config.get(
+        "aws.amplify.mockAmplifyDomainAssociationCalls"
+      )
       // since we mock values during development, we don't have to await for the dns records
       if (!isTestEnv) {
         /**


### PR DESCRIPTION
## Problem
Technically we mock both `createDomainAssociation` and `getDomainAssociation` calls, therefore var name is not really accurate
## Solution
changing the var name before release today to reflect this. 

1pw already updated with the new values. 

## Deploy notes

new env var: 
export MOCK_AMPLIFY_DOMAIN_ASSOCIATION_CALLS="false" 