### PR TITLE
feat(site launch): Allow for ops to remove timed out domain associations

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -26,7 +26,7 @@ export SITE_CREATE_FORM_KEY=""
 # generate your own access key and secret access key from AWS
 export AWS_ACCESS_KEY_ID="" 
 export AWS_SECRET_ACCESS_KEY=""
-export MOCK_AMPLIFY_CREATE_DOMAIN_CALLS="true"
+export MOCK_AMPLIFY_DOMAIN_ASSOCIATION_CALLS="true"
 
 # Required to run end-to-end tests
 export E2E_TEST_REPO="e2e-test-repo"

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -172,9 +172,9 @@ const config = convict({
         format: String,
         default: "",
       },
-      mockAmplifyCreateDomainAssociationCalls: {
-        doc: "Mock createDomainAssociation calls to Amplify ",
-        env: "MOCK_AMPLIFY_CREATE_DOMAIN_ASSOCIATION_CALLS",
+      mockAmplifyDomainAssociationCalls: {
+        doc: "Mock domain association calls to Amplify",
+        env: "MOCK_AMPLIFY_DOMAIN_ASSOCIATION_CALLS",
         format: "required-boolean",
         default: true,
       },

--- a/src/services/identity/LaunchClient.ts
+++ b/src/services/identity/LaunchClient.ts
@@ -119,7 +119,7 @@ class LaunchClient {
   }
 
   private shouldMockAmplifyDomainCalls(): boolean {
-    return config.get("aws.amplify.mockAmplifyCreateDomainAssociationCalls")
+    return config.get("aws.amplify.mockAmplifyDomainAssociationCalls")
   }
 
   private getSubDomains(

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -228,8 +228,9 @@ export default class InfraService {
       )
 
       // Get DNS records from Amplify
-      const isTestEnv =
-        config.get("env") === "test" || config.get("env") === "dev"
+      const isTestEnv = config.get(
+        "aws.amplify.mockAmplifyDomainAssociationCalls"
+      )
       // since we mock values during development, we don't have to await for the dns records
       if (!isTestEnv) {
         /**


### PR DESCRIPTION
## Problem

If we try to associate the same domain twice, Amplify will generally throw a `BadRequestException: One or more domains requested are already associated with another Amplify app`, which can inform the user to delete + retry. 

However, this did not hold true if the domain association process timed out, in which case Amplify did _**not**_ throw an error, and neither did it create a new Domain Association during the `CreateDomainAssociation` call. 

To replicate the bug, this sequence of errors would need to happen: 
1) Submit the form for blah.gov.sg for blah-test app.
2) Receive an email for the DNS Results
3) Wait for 24 hours for domain association to time out
4) Retry step 1 
5) Receive an email with the exact same DNS results as step 2. 
One would think that the email received in step 5 is the most recent values, but it is in fact a lingering DomainAssociation that has yet to be deleted. 

Closes IS93

## Solution

Before calling a `CreateDomainAssociation`, delete any failed domain associations for the application. 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Testing 
While I have tested it manually on the `kishore-test` app, it is a bit hard to easily replicate this test this as it requires the existence of an App timeout over 24 hours. :/ 