### PR TITLE
[LS-97] chore(stats): add logout tracking

### DIFF
--- a/src/middleware/stats.ts
+++ b/src/middleware/stats.ts
@@ -53,6 +53,14 @@ export class StatsMiddleware {
     this.statsService.trackGithubLogins(Versions.V2)
   )
 
+  trackV1Logout = wrapAsRequestHandler(async () =>
+    this.statsService.trackLogout(Versions.V1)
+  )
+
+  trackV2Logout = wrapAsRequestHandler(async () =>
+    this.statsService.trackLogout(Versions.V2)
+  )
+
   trackEmailLogins = wrapAsRequestHandler(async () =>
     this.statsService.trackEmailLogins()
   )

--- a/src/routes/v1/auth.js
+++ b/src/routes/v1/auth.js
@@ -162,7 +162,11 @@ router.get(
   statsMiddleware.trackV1GithubLogins,
   attachReadRouteHandlerWrapper(githubAuth)
 )
-router.delete("/logout", attachReadRouteHandlerWrapper(logout))
+router.delete(
+  "/logout",
+  statsMiddleware.trackV1Logout,
+  attachReadRouteHandlerWrapper(logout)
+)
 router.get(
   "/whoami",
   authenticationMiddleware.verifyAccess,

--- a/src/routes/v2/auth.js
+++ b/src/routes/v2/auth.js
@@ -133,7 +133,11 @@ class AuthRouter {
       this.statsMiddleware.trackEmailLogins,
       attachReadRouteHandlerWrapper(this.verify)
     )
-    router.delete("/logout", attachReadRouteHandlerWrapper(this.logout))
+    router.delete(
+      "/logout",
+      this.statsMiddleware.trackV2Logout,
+      attachReadRouteHandlerWrapper(this.logout)
+    )
     router.get(
       "/whoami",
       this.authenticationMiddleware.verifyAccess,

--- a/src/services/infra/StatsService.ts
+++ b/src/services/infra/StatsService.ts
@@ -105,6 +105,12 @@ export class StatsService {
       version: Versions.V2,
     })
   }
+
+  trackLogout = (version: VersionNumber) => {
+    this.statsD.increment("users.logout", {
+      version,
+    })
+  }
 }
 
 const statsDClient = new StatsDClient({


### PR DESCRIPTION
## Problem
At present, there is no way of knowing how many users are logged into our cms. This is a useful metric to have to give us some insight into how heavily our cms is used.

Closes [LS-105]

## Solution
This could be achieved in 2 ways - either through querying our db or to track all logins - all logouts. The second way was chosen because it tracks ephemeral metrics as well as allowing us to derive the desired metric. Moreover, querying the database requires some contortion on our end (need to hit the `SequelizeStore` + pass in its deps).

This will allow us to graph the # of active users in dd using a formula

**Notes**
Do note that this implementation **might** overcount the # of currently logged in users because the tracking call is done **when the endpoint is hit**, not when the login is successful. This means that a high # of 401s could potentially cause the metric to be wrongly over-represented. a way to fix this is to call the stat tracking only at point of success (ideally). 

However, if this way (to call at point of success) is chosen, it will be done in a future PR (out of scope for now). Also, we might want to consider differentiating between _successful_ logins and _all_ logins.