### PR TITLE
chore/remove api token name from sites table

### DIFF
--- a/src/database/migrations/20230421020459-remove-sites-api-token-name.js
+++ b/src/database/migrations/20230421020459-remove-sites-api-token-name.js
@@ -1,0 +1,21 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.removeColumn(
+      "sites", // name of Source Model
+      "api_token_name" // name of column we want to remove
+    )
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.addColumn(
+      "sites", // name of Source model
+      "api_token_name", // name of column we're adding
+      {
+        allowNull: true,
+        defaultValue: "",
+        type: Sequelize.TEXT,
+      }
+    )
+  },
+}

--- a/src/database/models/Site.ts
+++ b/src/database/models/Site.ts
@@ -39,12 +39,6 @@ export class Site extends Model {
 
   @Column({
     allowNull: false,
-    type: DataType.TEXT,
-  })
-  apiTokenName!: string
-
-  @Column({
-    allowNull: false,
     type: DataType.ENUM(...Object.values(SiteStatus)),
     defaultValue: SiteStatus.Empty,
   })

--- a/src/fixtures/sites.ts
+++ b/src/fixtures/sites.ts
@@ -38,7 +38,6 @@ export const MOCK_DEPLOYMENT_STAGING_URL_TWO =
 export const MOCK_SITE_DBENTRY_ONE: Attributes<Site> = {
   id: MOCK_SITE_ID_ONE,
   name: MOCK_REPO_NAME_ONE,
-  apiTokenName: "unused",
   siteStatus: SiteStatus.Launched,
   jobStatus: JobStatus.Ready,
   creatorId: MOCK_USER_ID_ONE,
@@ -49,7 +48,6 @@ export const MOCK_SITE_DBENTRY_ONE: Attributes<Site> = {
 export const MOCK_SITE_DBENTRY_TWO: Attributes<Site> = {
   id: MOCK_SITE_ID_TWO,
   name: MOCK_REPO_NAME_TWO,
-  apiTokenName: "unused",
   siteStatus: SiteStatus.Launched,
   jobStatus: JobStatus.Ready,
   creatorId: MOCK_USER_ID_TWO,

--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -192,7 +192,6 @@ describe("Notifications Router", () => {
     await Site.create({
       id: mockSiteId,
       name: mockSiteName,
-      apiTokenName: "token",
       jobStatus: "READY",
       siteStatus: "LAUNCHED",
       creatorId: mockIsomerUserId,
@@ -217,7 +216,6 @@ describe("Notifications Router", () => {
     await Site.create({
       id: mockAdditionalSiteId,
       name: "mockSite2",
-      apiTokenName: "token",
       jobStatus: "READY",
       siteStatus: "LAUNCHED",
       creatorId: mockIsomerUserId,

--- a/src/integration/Notifications.spec.ts
+++ b/src/integration/Notifications.spec.ts
@@ -173,7 +173,6 @@ describe("Notifications Router", () => {
     await Site.create({
       id: MOCK_SITE_ID,
       name: mockSiteName,
-      apiTokenName: "token",
       jobStatus: "READY",
       siteStatus: "LAUNCHED",
       creatorId: mockIsomerUserId,
@@ -198,7 +197,6 @@ describe("Notifications Router", () => {
     await Site.create({
       id: MOCK_ADDITIONAL_SITE_ID,
       name: `${mockSiteName}2`,
-      apiTokenName: "token",
       jobStatus: "READY",
       siteStatus: "LAUNCHED",
       creatorId: mockIsomerUserId,

--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -177,7 +177,6 @@ describe("Sites Router", () => {
       await Site.create({
         id: mockSiteId,
         name: mockSite,
-        apiTokenName: "token",
         jobStatus: "READY",
         siteStatus: "LAUNCHED",
         creatorId: mockIsomerUserId,
@@ -185,7 +184,6 @@ describe("Sites Router", () => {
       await Site.create({
         id: "200",
         name: mockAdminSite,
-        apiTokenName: "token",
         jobStatus: "READY",
         siteStatus: "LAUNCHED",
         creatorId: mockIsomerUserId,

--- a/src/services/identity/SitesService.ts
+++ b/src/services/identity/SitesService.ts
@@ -409,7 +409,6 @@ class SitesService {
   async create(
     createParams: Partial<Site> & {
       name: Site["name"]
-      apiTokenName: Site["apiTokenName"]
       creator: Site["creator"]
     }
   ) {

--- a/src/services/identity/__tests__/SitesService.spec.ts
+++ b/src/services/identity/__tests__/SitesService.spec.ts
@@ -95,7 +95,6 @@ const SpySitesService = {
 const mockSiteName = "some site name"
 const mockSite = ({
   name: "i m a site",
-  apiTokenName: "0000",
   users: [],
 } as unknown) as Site
 

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -91,7 +91,6 @@ export default class InfraService {
       // 1. Create a new site record in the Sites table
       const newSiteParams = {
         name: siteName,
-        apiTokenName: "", // TODO (IS-76): Remove once DB has removed this param
         creator,
         creatorId: creator.id,
       }


### PR DESCRIPTION
This PR removes the unused `apiTokenName` param from our Sites table. Resolves IS-76.

## Deploy Notes
Before merging, run db:migrate on staging/production
Between running migration on prod and release, ensure that no sites are created using the site creation form - that endpoint is the only one which still uses `apiTokenName`