### PR TITLE
fix(redirection lambda): fix `www` error

### DIFF
--- a/microservices/site-launch/lambda-functions/redirection-domain-validation/index.ts
+++ b/microservices/site-launch/lambda-functions/redirection-domain-validation/index.ts
@@ -32,15 +32,13 @@ export const redirectionDomainValidation = async (
    * The params of `MessageBody` is designed to handle more complicated
    * redirects for future extensions.
    * */
-
-  const githubRedirect = githubRedirects[0] // only handling blah.gov.sg -> www.blah.gov.sg
   const template = `server {
       listen          443 ssl http2;
       listen          [::]:443 ssl http2;
       server_name     ${primaryDomainSource};
       ssl_certificate /etc/letsencrypt/live/${primaryDomainSource}/fullchain.pem;
       ssl_certificate_key     /etc/letsencrypt/live/${primaryDomainSource}/privkey.pem;
-      return          301 https://${githubRedirect.source}$request_uri;
+      return          301 https://www.${primaryDomainSource}$request_uri;
   }`
 
   const octokit = new Octokit({


### PR DESCRIPTION
## Problem

Bug in prod, it does not append the prepending 'www.'. (eg. https://github.com/isomerpages/isomer-redirection/commit/5aaacbf246a0f141a6bc7a1a3d1b4d2896c087e9) 



## Solution

Add `www.` 

## Reviewer notes 
Prod has already been deployed. This PR is for version control only. We will be tacking automated deployment to the cloud in the `isomer-infra` repo in the future