### PR TITLE
fix(site launch email): make table nicer

### DIFF
--- a/src/services/utilServices/SendDNSRecordEmailClient.ts
+++ b/src/services/utilServices/SendDNSRecordEmailClient.ts
@@ -33,11 +33,15 @@ const headerRowStyle =
 const repoNameStyle =
   "padding: 8px; text-align: left; font-weight: bold; border: 1px solid #ddd;"
 
+const bodyTitleStyle = "font-size: 16px; font-weight: bold;"
+
+const bodyFooterStyle = "font-size: 14px;"
+
 export function getDNSRecordsEmailBody(
   submissionId: string,
   dnsRecordsEmailProps: DnsRecordsEmailProps[]
 ) {
-  let html = `<p style="font-size: 16px; font-weight: bold;">Isomer sites are in the process of launching. (Form submission id [${submissionId}])</p>
+  let html = `<p style="${bodyTitleStyle}">Isomer sites are in the process of launching. (Form submission id [${submissionId}])</p>
       <table style="${tableStyle}">
         <thead>
           <tr style="${headerRowStyle}">
@@ -88,7 +92,7 @@ export function getDNSRecordsEmailBody(
     })
   })
   html += `</tbody></table>
-      <p style="font-size: 14px;">This email was sent from the Isomer CMS backend.</p>`
+      <p style="${bodyFooterStyle}">This email was sent from the Isomer CMS backend.</p>`
   return html
 }
 
@@ -96,7 +100,7 @@ export function getErrorEmailBody(
   submissionId: string,
   failureResults: LaunchFailureEmailProps[]
 ) {
-  let html = `<p style="font-size: 16px; font-weight: bold;">The following sites were NOT launched successfully. (Form submission id [${submissionId}])</p>
+  let html = `<p style="${bodyTitleStyle}">The following sites were NOT launched successfully. (Form submission id [${submissionId}])</p>
         <table style="${tableStyle}">
           <thead>
             <tr style="${headerRowStyle}">
@@ -116,6 +120,6 @@ export function getErrorEmailBody(
   html += `
           </tbody>
         </table>
-        <p style="font-size: 14px;">This email was sent from the Isomer CMS backend.</p>`
+        <p style="${bodyFooterStyle}">This email was sent from the Isomer CMS backend.</p>`
   return html
 }

--- a/src/services/utilServices/SendDNSRecordEmailClient.ts
+++ b/src/services/utilServices/SendDNSRecordEmailClient.ts
@@ -1,0 +1,121 @@
+import { groupBy } from "lodash"
+
+export interface DnsRecordsEmailProps {
+  requesterEmail: string
+  repoName: string
+  domainValidationSource: string
+  domainValidationTarget: string
+  primaryDomainSource: string
+  primaryDomainTarget: string
+  redirectionDomainSource?: string
+  redirectionDomainTarget?: string
+}
+
+export interface LaunchFailureEmailProps {
+  // The fields here are optional since a misconfiguration in our
+  // formSG can cause some or even all fields to be missing
+  requesterEmail?: string
+  repoName?: string
+  primaryDomain?: string
+  error: string
+}
+
+const tableStyle =
+  "border-collapse: collapse; width: 100%; border: 1px solid #ddd; text-align: center;"
+
+const thStyle = "padding: 8px; text-align: center; border: 1px solid #ddd;"
+
+const tdStyle = "padding: 8px; text-align: left; border: 1px solid #ddd;"
+
+const headerRowStyle =
+  "background-color: #f2f2f2; border: 1px solid #ddd; text-align: center;"
+
+const repoNameStyle =
+  "padding: 8px; text-align: left; font-weight: bold; border: 1px solid #ddd;"
+
+export function getDNSRecordsEmailBody(
+  submissionId: string,
+  dnsRecordsEmailProps: DnsRecordsEmailProps[]
+) {
+  let html = `<p style="font-size: 16px; font-weight: bold;">Isomer sites are in the process of launching. (Form submission id [${submissionId}])</p>
+      <table style="${tableStyle}">
+        <thead>
+          <tr style="${headerRowStyle}">
+            <th style="${thStyle}">Repo Name</th>
+            <th style="${thStyle}">Source</th>
+            <th style="${thStyle}">Target</th>
+            <th style="${thStyle}">Type</th>
+          </tr>
+        </thead>
+        <tbody>`
+  const groupedDnsRecords = groupBy(dnsRecordsEmailProps, "repoName")
+  Object.keys(groupedDnsRecords).forEach((repoName) => {
+    const hasRedirection = !!groupedDnsRecords[repoName].some(
+      (dnsRecords) => !!dnsRecords.redirectionDomainSource
+    )
+    html += `<tr style="${headerRowStyle}">
+          <td style="${repoNameStyle}" rowspan="${
+      hasRedirection ? 4 : 3
+    }">${repoName}</td>
+        </tr>`
+    groupedDnsRecords[repoName].forEach((dnsRecords) => {
+      // check if dnsRecords.redirectionDomain is undefined
+      html += `
+        <tr style="${tdStyle}">
+  
+          <td style="${tdStyle}">${dnsRecords.domainValidationSource}</td>
+          <td style="${tdStyle}">${dnsRecords.domainValidationTarget}</td>
+          <td style="${tdStyle}">CNAME</td>
+        </tr>
+        <tr style="${tdStyle}">
+          <td style="${tdStyle}">${
+        hasRedirection
+          ? `www.${dnsRecords.primaryDomainSource}`
+          : dnsRecords.primaryDomainSource
+      }</td>
+          <td style="${tdStyle}">${dnsRecords.primaryDomainTarget}</td>
+          <td style="${tdStyle}">CNAME</td>
+        </tr>`
+
+      if (hasRedirection) {
+        html += `
+          <tr style="${tdStyle}">
+            <td style="${tdStyle}">${dnsRecords.primaryDomainSource}</td>
+            <td style="${tdStyle}">${dnsRecords.redirectionDomainTarget}</td>
+            <td style="${tdStyle}">A Record</td>
+          </tr>`
+      }
+    })
+  })
+  html += `</tbody></table>
+      <p style="font-size: 14px;">This email was sent from the Isomer CMS backend.</p>`
+  return html
+}
+
+export function getErrorEmailBody(
+  submissionId: string,
+  failureResults: LaunchFailureEmailProps[]
+) {
+  let html = `<p style="font-size: 16px; font-weight: bold;">The following sites were NOT launched successfully. (Form submission id [${submissionId}])</p>
+        <table style="${tableStyle}">
+          <thead>
+            <tr style="${headerRowStyle}">
+              <th style="${thStyle}">Repo Name</th>
+              <th style="${thStyle}">Error</th>
+            </tr>
+          </thead>
+          <tbody>`
+  failureResults.forEach((failureResult) => {
+    const displayedRepoName = failureResult.repoName || "<missing repo name>"
+    html += `
+            <tr style="${tdStyle}">
+              <td style="${repoNameStyle}">${displayedRepoName}</td>
+              <td style="${tdStyle}">${failureResult.error}</td>
+            </tr>`
+  })
+  html += `
+          </tbody>
+        </table>
+        <p style="font-size: 14px;">This email was sent from the Isomer CMS backend.</p>`
+  return html
+}


### PR DESCRIPTION
## Problem

Currently, the emails that are being sent to operations is very bare. This had led to copy pasting errors before, leading to issues with the site launch process in the end / our users have complained that the this information is unclear. As a low handing fruit, this PR changes the way the DNS results are being rendered for lesser chances of error. 

Closes IS-94

## Solution

This PR has two main changes. 
1. Adds inline HTML styles to make the tables look nicer, refer to the screenshots below for a visual change.
2. Refactoring of the code. Right now, our `formSgSiteLaunch.ts` has too much responsibility, I have created a  `SendDNSRecordEmailClient.ts` whose responsibility would be to return the body of the email content. 

## Reviewer Notes 
Feedback wanted: While I am certain I want to shift the logic needed to generate the body of the html to a separate file, not too sure where might be a best place to put the file `SendDNSRecordEmailClient.ts`  in, open to feedback regarding this!

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible


## Before & After Screenshots

**BEFORE**:

<img width="634" alt="Screenshot 2023-04-26 at 1 06 14 PM" src="https://user-images.githubusercontent.com/42832651/234475014-2a14f719-3582-4a18-b1d2-5754443e4c3d.png">
<img width="727" alt="Screenshot 2023-04-26 at 1 07 21 PM" src="https://user-images.githubusercontent.com/42832651/234475025-c28ce61a-3ec3-40bd-8362-b52816faa2dc.png">


**AFTER**:

<img width="1502" alt="Screenshot 2023-04-26 at 12 53 22 PM" src="https://user-images.githubusercontent.com/42832651/234474223-63f3ac48-6e9d-496f-ae9c-17346d736d7b.png">

<img width="1503" alt="Screenshot 2023-04-26 at 12 52 11 PM" src="https://user-images.githubusercontent.com/42832651/234474252-9216d2e5-e1e6-4ece-b5b3-2cd68b74ecd4.png">

## Tests
**_Step 0: Set your `export MOCK_AMPLIFY_DOMAIN_ASSOCIATION_CALLS="true"`_**
Step 1. Run this from `server.js` to trigger a fake formsg response
```
const formResponses = [
  {
    submissionId: "",
    requesterEmail: "kishore@open.gov.sg",
    repoName: "kishore-test",
    primaryDomain: "kishorewithwww.isomer.gov.sg",
    redirectionDomain: "www.kishorewithwww.isomer.gov.sg",
    agencyEmail: "alexander@open.gov.sg",
  },
  {
    submissionId: "",
    requesterEmail: "kishore@open.gov.sg",
    repoName: "test-vincent",
    primaryDomain: "kishorewithoutwww.isomer.gov.sg",
    redirectionDomain: "",
    agencyEmail: "alexander@open.gov.sg",
  },
]

formsgSiteLaunchRouter.handleSiteLaunchResults(formResponses, "test")

```

Step 2: Refer to terminal output for resulting email content
