### PR TITLE
fix(sites): unwrap the ok value if no errors

### DIFF
--- a/src/routes/v2/authenticated/__tests__/Sites.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/Sites.spec.ts
@@ -138,7 +138,7 @@ describe("Sites Router", () => {
         stagingUrl: "staging-url",
         siteUrl: "prod-url",
       }
-      mockSitesService.getSiteInfo.mockResolvedValueOnce(siteInfo)
+      mockSitesService.getSiteInfo.mockResolvedValueOnce(ok(siteInfo))
 
       const resp = await request(app).get(`/${mockSiteName}/info`).expect(200)
 

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -117,10 +117,10 @@ export class SitesRouter {
     )
 
     // Check for error and throw
-    if (possibleSiteInfo instanceof BaseIsomerError) {
-      return res.status(400).json({ message: possibleSiteInfo.message })
+    if (possibleSiteInfo.isErr()) {
+      return res.status(400).json({ message: possibleSiteInfo.error.message })
     }
-    return res.status(200).json(possibleSiteInfo)
+    return res.status(200).json(possibleSiteInfo.value)
   }
 
   getRouter() {


### PR DESCRIPTION
## Problem

Site members were not able to view the staging site because the value was wrapped in an `ok`. 
Closes [138]

## Solution

This unwraps the value and fixes test cases 

## Tests [email flow] 
1. Become a site member of a site
2. Go to the dashboard, make sure you are able to view the staging url