### PR TITLE
Fix: add svg to allowed image types

### DIFF
--- a/src/utils/file-upload-utils.js
+++ b/src/utils/file-upload-utils.js
@@ -18,6 +18,7 @@ const ALLOWED_FILE_EXTENSIONS = [
   "tif",
   "bmp",
   "ico",
+  "svg",
 ]
 const defaultCloudmersiveClient = CloudmersiveVirusApiClient.ApiClient.instance
 


### PR DESCRIPTION
This PR fixes an issue where svg images were not allowed to be uploaded.