### PR TITLE
feat(site creation): add support for email + github logins

### DIFF
--- a/src/routes/formsgSiteCreation.ts
+++ b/src/routes/formsgSiteCreation.ts
@@ -87,8 +87,10 @@ export class FormsgRouter {
         await this.sendCreateError(requesterEmail, repoName, submissionId, err)
         return res.sendStatus(200)
       }
-      const foundOwner = await this.usersService.findOrCreateByEmail(ownerEmail)
-
+      let foundOwner
+      if (isEmailLogin) {
+        foundOwner = await this.usersService.findOrCreateByEmail(ownerEmail)
+      }
       // 3. Use service to create site
       const { deployment } = await this.infraService.createSite({
         creator: foundIsomerRequester,

--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -187,7 +187,7 @@ export default class ReposService {
       repo: repoName,
       permission: "admin",
     })
-    if (isEmailLogin) {
+    if (!isEmailLogin) {
       await octokit.teams.addOrUpdateRepoPermissionsInOrg({
         org: ISOMER_GITHUB_ORGANIZATION_NAME,
         team_slug: repoName,

--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -66,7 +66,7 @@ export default class ReposService {
     const repoUrl = `https://github.com/isomerpages/${repoName}`
 
     await this.createRepoOnGithub(repoName)
-    if (isEmailLogin) {
+    if (!isEmailLogin) {
       await this.createTeamOnGitHub(repoName)
     }
     await this.generateRepoAndPublishToGitHub(repoName, repoUrl)

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -45,7 +45,8 @@ interface dnsRecordDto {
 
 type CreateSiteParams = {
   creator: User
-  member: User
+  // this is ok, since we don't need this for github login flow
+  member: User | undefined
   siteName: string
   repoName: string
   isEmailLogin: boolean
@@ -132,11 +133,7 @@ export default class InfraService {
 
       // 5. Set up permissions
       await this.reposService.setRepoAndTeamPermissions(repoName, isEmailLogin)
-      if (isEmailLogin) {
-        if (!memberEmail) {
-          // This should never happen
-          throw new Error(`Should not reach here`)
-        }
+      if (isEmailLogin && memberEmail) {
         await this.collaboratorsService.create(repoName, memberEmail, true)
       }
       // 6. Update status

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -89,7 +89,7 @@ export default class InfraService {
     isEmailLogin,
   }: CreateSiteParams) => {
     let site: Site | undefined // For error handling
-    const memberEmail = member.email
+    const memberEmail = member?.email
     const doesMemberEmailExistForEmailLogin = !memberEmail && isEmailLogin
     if (doesMemberEmailExistForEmailLogin) {
       logger.error(

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -132,7 +132,7 @@ export default class InfraService {
 
       // 5. Set up permissions
       await this.reposService.setRepoAndTeamPermissions(repoName, isEmailLogin)
-      if (doesMemberEmailExistForEmailLogin) {
+      if (isEmailLogin) {
         if (!memberEmail) {
           // This should never happen
           throw new Error(`Should not reach here`)


### PR DESCRIPTION
## Problem

Currently, the new site creation only allows for email based logins. This is disruptive for ops as there are still some agencies that use the github based logins, and it might be confusing for them to have some websites in the email flow, and some in the github flow. 

Closes 154

## Solution

Rather than only allowing for email based logins, ops will now have the choice of either email or github logins. 
This PR effectively brings back the code [here](https://github.com/isomerpages/isomercms-backend/pull/713/files) and [here](https://github.com/isomerpages/isomercms-backend/pull/679), but only executes the relevant code iff ops wants to use the email login flow.

## Other notes 
The member email is disregarded if ops select the github login flow. 

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Testing 
Staging is now live with this form, feel free to test it out directly. I have tested out for both the email and github flow, both seems to work fine.
