### PR TITLE
Test/image retrieval tests

### DIFF
--- a/src/fixtures/media.ts
+++ b/src/fixtures/media.ts
@@ -1,8 +1,9 @@
-import { MediaFile } from "@root/types"
+import { MediaType, MediaFile } from "@root/types"
 
 export const MEDIA_FILE_NAME = "test file"
 export const MEDIA_SITE_NAME = "site"
 export const MEDIA_DIRECTORY_NAME = "dir"
+export const MEDIA_SUBDIRECTORY_NAME = "sub dir"
 export const MEDIA_FILE_SHA = "sha"
 
 export const MEDIA_DIR: MediaFile = {
@@ -19,6 +20,11 @@ const BASE_MEDIA_FILE: MediaFile = {
   path: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
 }
 
+export const NESTED_MEDIA_FILE: MediaFile = {
+  ...BASE_MEDIA_FILE,
+  path: `${MEDIA_DIRECTORY_NAME}/${MEDIA_SUBDIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
+}
+
 export const SVG_FILE = {
   ...BASE_MEDIA_FILE,
   name: `${MEDIA_FILE_NAME}.svg`,
@@ -33,15 +39,21 @@ const BASE_INPUT = {
 export const DIR_INPUT = {
   ...BASE_INPUT,
   file: MEDIA_DIR,
-  mediaType: "images",
+  mediaType: "images" as MediaType,
   isPrivate: false,
 }
 
 export const IMAGE_FILE_PUBLIC_INPUT = {
   ...BASE_INPUT,
   file: BASE_MEDIA_FILE,
-  mediaType: "images",
+  mediaType: "images" as MediaType,
   isPrivate: false,
+}
+
+export const NESTED_IMAGE_FILE_PUBLIC_INPUT = {
+  ...IMAGE_FILE_PUBLIC_INPUT,
+  file: NESTED_MEDIA_FILE,
+  directoryName: `${MEDIA_DIRECTORY_NAME}/${MEDIA_SUBDIRECTORY_NAME}`,
 }
 
 export const SVG_FILE_PUBLIC_INPUT = {
@@ -61,7 +73,7 @@ export const SVG_FILE_PRIVATE_INPUT = {
 
 export const PDF_FILE_PUBLIC_INPUT = {
   ...IMAGE_FILE_PUBLIC_INPUT,
-  mediaType: "files",
+  mediaType: "files" as MediaType,
 }
 
 export const PDF_FILE_PRIVATE_INPUT = {

--- a/src/fixtures/media.ts
+++ b/src/fixtures/media.ts
@@ -1,0 +1,70 @@
+import { MediaFile } from "@root/utils/media-utils"
+
+export const MEDIA_FILE_NAME = "test file"
+export const MEDIA_SITE_NAME = "site"
+export const MEDIA_DIRECTORY_NAME = "dir"
+export const MEDIA_FILE_SHA = "sha"
+
+export const mediaDir: MediaFile = {
+  name: "directory",
+  type: "dir",
+  sha: MEDIA_FILE_SHA,
+  path: `${MEDIA_DIRECTORY_NAME}/directory`,
+}
+
+const baseMediaFile: MediaFile = {
+  name: MEDIA_FILE_NAME,
+  type: "file",
+  sha: MEDIA_FILE_SHA,
+  path: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
+}
+
+export const svgFile = {
+  ...baseMediaFile,
+  name: `${MEDIA_FILE_NAME}.svg`,
+  path: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}.svg`,
+}
+
+const baseInput = {
+  siteName: MEDIA_SITE_NAME,
+  directoryName: MEDIA_DIRECTORY_NAME,
+}
+
+export const dirInput = {
+  ...baseInput,
+  file: mediaDir,
+  mediaType: "images",
+  isPrivate: false,
+}
+
+export const imageFilePublicInput = {
+  ...baseInput,
+  file: baseMediaFile,
+  mediaType: "images",
+  isPrivate: false,
+}
+
+export const svgFilePublicInput = {
+  ...imageFilePublicInput,
+  file: svgFile,
+}
+
+export const imageFilePrivateInput = {
+  ...imageFilePublicInput,
+  isPrivate: true,
+}
+
+export const svgFilePrivateInput = {
+  ...svgFilePublicInput,
+  isPrivate: true,
+}
+
+export const pdfFilePublicInput = {
+  ...imageFilePublicInput,
+  mediaType: "files",
+}
+
+export const pdfFilePrivateInput = {
+  ...pdfFilePublicInput,
+  isPrivate: true,
+}

--- a/src/fixtures/media.ts
+++ b/src/fixtures/media.ts
@@ -1,70 +1,70 @@
-import { MediaFile } from "@root/utils/media-utils"
+import { MediaFile } from "@root/types"
 
 export const MEDIA_FILE_NAME = "test file"
 export const MEDIA_SITE_NAME = "site"
 export const MEDIA_DIRECTORY_NAME = "dir"
 export const MEDIA_FILE_SHA = "sha"
 
-export const mediaDir: MediaFile = {
+export const MEDIA_DIR: MediaFile = {
   name: "directory",
   type: "dir",
   sha: MEDIA_FILE_SHA,
   path: `${MEDIA_DIRECTORY_NAME}/directory`,
 }
 
-const baseMediaFile: MediaFile = {
+const BASE_MEDIA_FILE: MediaFile = {
   name: MEDIA_FILE_NAME,
   type: "file",
   sha: MEDIA_FILE_SHA,
   path: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
 }
 
-export const svgFile = {
-  ...baseMediaFile,
+export const SVG_FILE = {
+  ...BASE_MEDIA_FILE,
   name: `${MEDIA_FILE_NAME}.svg`,
   path: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}.svg`,
 }
 
-const baseInput = {
+const BASE_INPUT = {
   siteName: MEDIA_SITE_NAME,
   directoryName: MEDIA_DIRECTORY_NAME,
 }
 
-export const dirInput = {
-  ...baseInput,
-  file: mediaDir,
+export const DIR_INPUT = {
+  ...BASE_INPUT,
+  file: MEDIA_DIR,
   mediaType: "images",
   isPrivate: false,
 }
 
-export const imageFilePublicInput = {
-  ...baseInput,
-  file: baseMediaFile,
+export const IMAGE_FILE_PUBLIC_INPUT = {
+  ...BASE_INPUT,
+  file: BASE_MEDIA_FILE,
   mediaType: "images",
   isPrivate: false,
 }
 
-export const svgFilePublicInput = {
-  ...imageFilePublicInput,
-  file: svgFile,
+export const SVG_FILE_PUBLIC_INPUT = {
+  ...IMAGE_FILE_PUBLIC_INPUT,
+  file: SVG_FILE,
 }
 
-export const imageFilePrivateInput = {
-  ...imageFilePublicInput,
+export const IMAGE_FILE_PRIVATE_INPUT = {
+  ...IMAGE_FILE_PUBLIC_INPUT,
   isPrivate: true,
 }
 
-export const svgFilePrivateInput = {
-  ...svgFilePublicInput,
+export const SVG_FILE_PRIVATE_INPUT = {
+  ...SVG_FILE_PUBLIC_INPUT,
   isPrivate: true,
 }
 
-export const pdfFilePublicInput = {
-  ...imageFilePublicInput,
+export const PDF_FILE_PUBLIC_INPUT = {
+  ...IMAGE_FILE_PUBLIC_INPUT,
   mediaType: "files",
 }
 
-export const pdfFilePrivateInput = {
-  ...pdfFilePublicInput,
+export const PDF_FILE_PRIVATE_INPUT = {
+  ...PDF_FILE_PUBLIC_INPUT,
   isPrivate: true,
 }

--- a/src/services/directoryServices/__tests__/MediaDirectoryService.spec.js
+++ b/src/services/directoryServices/__tests__/MediaDirectoryService.spec.js
@@ -130,46 +130,6 @@ describe("Media Directory Service", () => {
       })
     })
     mockGitHubService.getRepoInfo.mockResolvedValueOnce({
-      private: true,
-    })
-    mockBaseDirectoryService.list.mockResolvedValueOnce(readImgDirResp)
-    mockGitHubService.readMedia.mockResolvedValueOnce({
-      content: mockContent1,
-    })
-    mockGitHubService.readMedia.mockResolvedValueOnce({
-      content: mockContent2,
-    })
-    it("ListFiles for an image directory in a private repo returns all images properly formatted", async () => {
-      const expectedResp = [
-        {
-          mediaUrl: `data:image/png;base64,${mockContent1}`,
-          name: testImg1.name,
-          sha: testImg1.sha,
-          mediaPath: `${imageDirectoryName}/${testImg1.name}`,
-        },
-        {
-          mediaUrl: `data:image/svg+xml;base64,${mockContent2}`,
-          name: testImg2.name,
-          sha: testImg2.sha,
-          mediaPath: `${imageDirectoryName}/${testImg2.name}`,
-        },
-        {
-          name: dir.name,
-          type: dir.type,
-        },
-      ]
-      await expect(
-        service.listFiles(sessionData, {
-          mediaType: "images",
-          directoryName: imageDirectoryName,
-        })
-      ).resolves.toMatchObject(expectedResp)
-      expect(mockGitHubService.getRepoInfo).toHaveBeenCalledWith(sessionData)
-      expect(mockBaseDirectoryService.list).toHaveBeenCalledWith(sessionData, {
-        directoryName: imageDirectoryName,
-      })
-    })
-    mockGitHubService.getRepoInfo.mockResolvedValueOnce({
       private: false,
     })
     mockBaseDirectoryService.list.mockResolvedValueOnce(readFileDirResp)

--- a/src/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
@@ -8,7 +8,9 @@ describe("Media File Service", () => {
   const siteName = "test-site"
   const accessToken = "test-token"
   const imageName = "test image.png"
+  const imageEncodedName = encodeURIComponent(imageName)
   const fileName = "test file.pdf"
+  const fileEncodedName = encodeURIComponent(fileName)
   const directoryName = "images/subfolder"
   const mockContent = "schema, test"
   const mockSanitizedContent = "sanitized-test"
@@ -90,20 +92,24 @@ describe("Media File Service", () => {
     const imageDirResp = [
       {
         name: imageName,
+        path: `${directoryName}/${imageName}`,
         sha,
       },
       {
         name: "image2.png",
+        path: `${directoryName}/image2.png`,
         sha: "image2sha",
       },
     ]
     const fileDirResp = [
       {
         name: fileName,
+        path: `${directoryName}/${fileName}`,
         sha,
       },
       {
         name: "file2.pdf",
+        path: `${directoryName}/file2.pdf`,
         sha: "file2sha",
       },
     ]
@@ -116,7 +122,7 @@ describe("Media File Service", () => {
     })
     it("Reading image files in public repos works correctly", async () => {
       const expectedResp = {
-        mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${directoryName}/${imageName}`,
+        mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${directoryName}/${imageEncodedName}`,
         name: imageName,
         sha,
       }
@@ -139,6 +145,7 @@ describe("Media File Service", () => {
       ...imageDirResp,
       {
         sha,
+        path: `${directoryName}/${svgName}`,
         name: svgName,
       },
     ])
@@ -166,34 +173,6 @@ describe("Media File Service", () => {
       )
       expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(sessionData)
     })
-    mockGithubService.readDirectory.mockResolvedValueOnce(imageDirResp)
-    mockGithubService.getRepoInfo.mockResolvedValueOnce({
-      private: true,
-    })
-    it("Reading image files in private repos works correctly", async () => {
-      const expectedResp = {
-        mediaUrl: `data:image/png;base64,${mockContent}`,
-        name: imageName,
-        sha,
-      }
-      await expect(
-        service.read(sessionData, {
-          fileName: imageName,
-          directoryName,
-          mediaType: "images",
-        })
-      ).resolves.toMatchObject(expectedResp)
-      expect(mockGithubService.readDirectory).toHaveBeenCalledWith(
-        sessionData,
-        {
-          directoryName,
-        }
-      )
-      expect(mockGithubService.getRepoInfo).toHaveBeenCalledWith(sessionData)
-      expect(mockGithubService.readMedia).toHaveBeenCalledWith(sessionData, {
-        fileSha: sha,
-      })
-    })
     mockGithubService.readDirectory.mockResolvedValueOnce(fileDirResp)
     mockGithubService.getRepoInfo.mockResolvedValueOnce({
       private: false,
@@ -203,7 +182,7 @@ describe("Media File Service", () => {
     })
     it("Reading files in public repos works correctly", async () => {
       const expectedResp = {
-        mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${directoryName}/${fileName}`,
+        mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${siteName}/staging/${directoryName}/${fileEncodedName}`,
         name: fileName,
         sha,
       }

--- a/src/utils/__tests__/media-utils.spec.ts
+++ b/src/utils/__tests__/media-utils.spec.ts
@@ -77,7 +77,7 @@ describe("Media utils test", () => {
     )
   })
 
-  it("should handle mediaUrl for images in private repos", async () => {
+  it("should return the mediaUrl as a data url for images in private repos", async () => {
     const expectedPartialResp = {
       name: MEDIA_FILE_NAME,
       sha: MEDIA_FILE_SHA,

--- a/src/utils/__tests__/media-utils.spec.ts
+++ b/src/utils/__tests__/media-utils.spec.ts
@@ -100,7 +100,7 @@ describe("Media utils test", () => {
     )
   })
 
-  it("should handle mediaUrl for svgs and sanitise image in private repos", async () => {
+  it("should return the mediaUrl as a data url for svgs and sanitise the svgs for svgs in private repos", async () => {
     const expectedPartialResp = {
       name: `${MEDIA_FILE_NAME}.svg`,
       sha: MEDIA_FILE_SHA,

--- a/src/utils/__tests__/media-utils.spec.ts
+++ b/src/utils/__tests__/media-utils.spec.ts
@@ -7,14 +7,12 @@ import {
   MEDIA_FILE_NAME,
   MEDIA_FILE_SHA,
   MEDIA_SITE_NAME,
-  dirInput,
-  imageFilePrivateInput,
-  imageFilePublicInput,
-  mediaDir,
-  pdfFilePrivateInput,
-  pdfFilePublicInput,
-  svgFilePrivateInput,
-  svgFilePublicInput,
+  IMAGE_FILE_PRIVATE_INPUT,
+  IMAGE_FILE_PUBLIC_INPUT,
+  PDF_FILE_PRIVATE_INPUT,
+  PDF_FILE_PUBLIC_INPUT,
+  SVG_FILE_PRIVATE_INPUT,
+  SVG_FILE_PUBLIC_INPUT,
 } from "@root/fixtures/media"
 
 import { getMediaFileInfo, isMediaFileOutput } from "../media-utils"

--- a/src/utils/__tests__/media-utils.spec.ts
+++ b/src/utils/__tests__/media-utils.spec.ts
@@ -32,13 +32,6 @@ jest.mock("axios", () => ({
 }))
 
 describe("Media utils test", () => {
-  it("should return directory information", async () => {
-    const expectedResp = {
-      name: `${mediaDir.name}`,
-      type: "dir",
-    }
-    expect(await getMediaFileInfo(dirInput)).toStrictEqual(expectedResp)
-  })
   it("should return normal information for images in public repos", async () => {
     const expectedResp = {
       mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${MEDIA_SITE_NAME}/staging/${MEDIA_DIRECTORY_NAME}/${encodeURIComponent(

--- a/src/utils/__tests__/media-utils.spec.ts
+++ b/src/utils/__tests__/media-utils.spec.ts
@@ -15,7 +15,7 @@ import {
   SVG_FILE_PUBLIC_INPUT,
 } from "@root/fixtures/media"
 
-import { getMediaFileInfo, isMediaFileOutput } from "../media-utils"
+import { getMediaFileInfo } from "../media-utils"
 
 const GITHUB_ORG_NAME = config.get("github.orgName")
 
@@ -85,9 +85,6 @@ describe("Media utils test", () => {
       type: "file",
     }
     const resp = await getMediaFileInfo(IMAGE_FILE_PRIVATE_INPUT)
-    if (!isMediaFileOutput(resp)) {
-      fail("Should not reach here")
-    }
     expect(resp).toStrictEqual(expect.objectContaining(expectedPartialResp))
     expect(resp.mediaUrl).toContain("data:")
     expect(
@@ -108,9 +105,6 @@ describe("Media utils test", () => {
       type: "file",
     }
     const resp = await getMediaFileInfo(SVG_FILE_PRIVATE_INPUT)
-    if (!isMediaFileOutput(resp)) {
-      fail("Should not reach here")
-    }
     expect(resp).toStrictEqual(expect.objectContaining(expectedPartialResp))
     expect(resp.mediaUrl).toContain("data:")
     expect(

--- a/src/utils/__tests__/media-utils.spec.ts
+++ b/src/utils/__tests__/media-utils.spec.ts
@@ -13,6 +13,8 @@ import {
   PDF_FILE_PUBLIC_INPUT,
   SVG_FILE_PRIVATE_INPUT,
   SVG_FILE_PUBLIC_INPUT,
+  MEDIA_SUBDIRECTORY_NAME,
+  NESTED_IMAGE_FILE_PUBLIC_INPUT,
 } from "@root/fixtures/media"
 
 import { getMediaFileInfo } from "../media-utils"
@@ -45,6 +47,21 @@ describe("Media utils test", () => {
     expect(await getMediaFileInfo(IMAGE_FILE_PUBLIC_INPUT)).toStrictEqual(
       expectedResp
     )
+  })
+
+  it("should handle nested images in public repos", async () => {
+    const expectedResp = {
+      mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${MEDIA_SITE_NAME}/staging/${MEDIA_DIRECTORY_NAME}/${encodeURIComponent(
+        MEDIA_SUBDIRECTORY_NAME
+      )}/${encodeURIComponent(MEDIA_FILE_NAME)}`,
+      name: MEDIA_FILE_NAME,
+      sha: MEDIA_FILE_SHA,
+      mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_SUBDIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
+      type: "file",
+    }
+    expect(
+      await getMediaFileInfo(NESTED_IMAGE_FILE_PUBLIC_INPUT)
+    ).toStrictEqual(expectedResp)
   })
 
   it("should return mediaUrl as raw github information for svgs with sanitisation in public repos", async () => {

--- a/src/utils/__tests__/media-utils.spec.ts
+++ b/src/utils/__tests__/media-utils.spec.ts
@@ -1,0 +1,149 @@
+import axios from "axios"
+
+import { config } from "@config/config"
+
+import {
+  MEDIA_DIRECTORY_NAME,
+  MEDIA_FILE_NAME,
+  MEDIA_FILE_SHA,
+  MEDIA_SITE_NAME,
+  dirInput,
+  imageFilePrivateInput,
+  imageFilePublicInput,
+  mediaDir,
+  pdfFilePrivateInput,
+  pdfFilePublicInput,
+  svgFilePrivateInput,
+  svgFilePublicInput,
+} from "@root/fixtures/media"
+
+import { getMediaFileInfo, isMediaFileOutput } from "../media-utils"
+
+const GITHUB_ORG_NAME = config.get("github.orgName")
+
+jest.mock("@utils/token-retrieval-utils", () => ({
+  getAccessToken: jest.fn().mockResolvedValue("token"),
+}))
+jest.mock("axios", () => ({
+  get: jest.fn().mockResolvedValue({
+    data: "blahblah",
+    headers: {
+      "content-type": "blahblah",
+    },
+  }),
+}))
+
+describe("Media utils test", () => {
+  it("should return directory information", async () => {
+    const expectedResp = {
+      name: `${mediaDir.name}`,
+      type: "dir",
+    }
+    expect(await getMediaFileInfo(dirInput)).toStrictEqual(expectedResp)
+  })
+  it("should return normal information for images in public repos", async () => {
+    const expectedResp = {
+      mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${MEDIA_SITE_NAME}/staging/${MEDIA_DIRECTORY_NAME}/${encodeURIComponent(
+        MEDIA_FILE_NAME
+      )}`,
+      name: MEDIA_FILE_NAME,
+      sha: MEDIA_FILE_SHA,
+      mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
+      type: "file",
+    }
+    expect(await getMediaFileInfo(imageFilePublicInput)).toStrictEqual(
+      expectedResp
+    )
+  })
+
+  it("should return normal information for svgs in public repos", async () => {
+    const expectedResp = {
+      mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${MEDIA_SITE_NAME}/staging/${MEDIA_DIRECTORY_NAME}/${encodeURIComponent(
+        MEDIA_FILE_NAME
+      )}.svg?sanitize=true`,
+      name: `${MEDIA_FILE_NAME}.svg`,
+      sha: MEDIA_FILE_SHA,
+      mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}.svg`,
+      type: "file",
+    }
+    expect(await getMediaFileInfo(svgFilePublicInput)).toStrictEqual(
+      expectedResp
+    )
+  })
+
+  it("should return normal information for files in public repos", async () => {
+    const expectedResp = {
+      mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${MEDIA_SITE_NAME}/staging/${MEDIA_DIRECTORY_NAME}/${encodeURIComponent(
+        MEDIA_FILE_NAME
+      )}`,
+      name: MEDIA_FILE_NAME,
+      sha: MEDIA_FILE_SHA,
+      mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
+      type: "file",
+    }
+    expect(await getMediaFileInfo(pdfFilePublicInput)).toStrictEqual(
+      expectedResp
+    )
+  })
+
+  it("should handle mediaUrl for images in private repos", async () => {
+    const expectedPartialResp = {
+      name: MEDIA_FILE_NAME,
+      sha: MEDIA_FILE_SHA,
+      mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
+      type: "file",
+    }
+    const resp = await getMediaFileInfo(imageFilePrivateInput)
+    if (!isMediaFileOutput(resp)) {
+      fail("Should not reach here")
+    }
+    expect(resp).toStrictEqual(expect.objectContaining(expectedPartialResp))
+    expect(resp.mediaUrl).toContain("data:")
+    expect(
+      axios.get
+    ).toHaveBeenCalledWith(
+      `https://token@raw.githubusercontent.com/${GITHUB_ORG_NAME}/${MEDIA_SITE_NAME}/staging/${MEDIA_DIRECTORY_NAME}/${encodeURIComponent(
+        MEDIA_FILE_NAME
+      )}`,
+      { responseType: "arraybuffer" }
+    )
+  })
+
+  it("should handle mediaUrl for svgs in private repos", async () => {
+    const expectedPartialResp = {
+      name: `${MEDIA_FILE_NAME}.svg`,
+      sha: MEDIA_FILE_SHA,
+      mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}.svg`,
+      type: "file",
+    }
+    const resp = await getMediaFileInfo(svgFilePrivateInput)
+    if (!isMediaFileOutput(resp)) {
+      fail("Should not reach here")
+    }
+    expect(resp).toStrictEqual(expect.objectContaining(expectedPartialResp))
+    expect(resp.mediaUrl).toContain("data:")
+    expect(
+      axios.get
+    ).toHaveBeenCalledWith(
+      `https://token@raw.githubusercontent.com/${GITHUB_ORG_NAME}/${MEDIA_SITE_NAME}/staging/${MEDIA_DIRECTORY_NAME}/${encodeURIComponent(
+        MEDIA_FILE_NAME
+      )}.svg?sanitize=true`,
+      { responseType: "arraybuffer" }
+    )
+  })
+
+  it("should return normal information for files in private repos", async () => {
+    const expectedResp = {
+      mediaUrl: `https://raw.githubusercontent.com/${GITHUB_ORG_NAME}/${MEDIA_SITE_NAME}/staging/${MEDIA_DIRECTORY_NAME}/${encodeURIComponent(
+        MEDIA_FILE_NAME
+      )}`,
+      name: MEDIA_FILE_NAME,
+      sha: MEDIA_FILE_SHA,
+      mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
+      type: "file",
+    }
+    expect(await getMediaFileInfo(pdfFilePrivateInput)).toStrictEqual(
+      expectedResp
+    )
+  })
+})


### PR DESCRIPTION
This PR introduces tests for PR #740. It removes existing tests for private repos in `MediaDirectoryService` and `MediaFileService` and moves them to the newly created `media-utils` test instead, to be able to better mock and handle axios calls.