### PR TITLE
feat(datadog): add tracing for http requests out

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,5 @@
-import "dd-trace/init"
+// NOTE: the import for tracer doesn't resolve with path aliasing
+import "./utils/tracer"
 import "module-alias/register"
 import SequelizeStoreFactory from "connect-session-sequelize"
 import session from "express-session"

--- a/src/services/api/AxiosInstance.ts
+++ b/src/services/api/AxiosInstance.ts
@@ -5,6 +5,7 @@ import { config } from "@config/config"
 import logger from "@logger/logger"
 
 import { getAccessToken } from "@utils/token-retrieval-utils"
+import tracer from "@utils/tracer"
 
 // Env vars
 const GITHUB_ORG_NAME = config.get("github.orgName")
@@ -15,13 +16,31 @@ const requestFormatter = async (config: AxiosRequestConfig) => {
   const authMessage = config.headers.Authorization
 
   // If accessToken is missing, authMessage is `token `
-  if (
+  // NOTE: This also implies that the user has not provided
+  // their own github token and hence, are email login users.
+  const isEmailLoginUser =
     !authMessage ||
     authMessage === "token " ||
     authMessage === "token undefined"
-  ) {
+
+  if (isEmailLoginUser) {
     const accessToken = await getAccessToken()
     config.headers.Authorization = `token ${accessToken}`
+    tracer.use("http", {
+      hooks: {
+        request: (span, req, res) => {
+          span?.setTag("user.type", "email")
+        },
+      },
+    })
+  } else {
+    tracer.use("http", {
+      hooks: {
+        request: (span, req, res) => {
+          span?.setTag("user.type", "github")
+        },
+      },
+    })
   }
   return {
     ...config,

--- a/src/utils/tracer.ts
+++ b/src/utils/tracer.ts
@@ -1,0 +1,5 @@
+import tracer from "dd-trace"
+
+tracer.init()
+
+export default tracer


### PR DESCRIPTION
## Problem
currently we got no observability/metrics for email logins etc, which makes it hard to monitor what routes are being hit..

## Solution
1. add tag onto datadog trace so that the trace contains info on the user type. because this is set on the trace, we also know the http request path. this could be potentially extended by forwarding our session data object onto our isomer axios instance and tying it into the trace

## Testing
Go to this [link](https://app.datadoghq.com/apm/traces?query=@_top_level:1%20service:isomer-http-client%20env:local%20@user.type:github&cols=core_service,core_resource_name,log_duration,log_http.method,log_http.status_code&historicalData=false&messageDisplay=inline&sort=desc&spanType=service-entry&spanViewType=metadata&start=1683133494852&end=1683134394852&paused=false) and observe that you can sort by `user.type = <email | github>`

to repro on local, just run this branch + hit an endpoint (either through FE or a client) 