### PR TITLE
fix(markdown-utils): add check for falsy values

### DIFF
--- a/src/utils/markdown-utils.js
+++ b/src/utils/markdown-utils.js
@@ -11,7 +11,7 @@ const getTrailingSlashWithPermalink = (permalink) =>
   permalink.endsWith("/") ? permalink : `${permalink}/`
 
 const recursiveUnescape = (val) => {
-  if (val === "") return val
+  if (!val) return val
   if (Array.isArray(val)) {
     return val.map(recursiveUnescape)
   }


### PR DESCRIPTION
## Problem
Empty keys on the object leads to us calling `Object.keys` on a `null` value, which causes an error.

## Solution
check for falsy values