### PR TITLE
feat: return sites from db for email login

### DIFF
--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -220,30 +220,10 @@ describe("Sites Router", () => {
       const expected = {
         siteNames: [
           {
-            lastUpdated: mockUpdatedAt,
             repoName: mockSite,
-            isPrivate: mockPrivate,
-            permissions: mockPermissions,
           },
         ],
       }
-
-      mockGenericAxios.get.mockResolvedValueOnce({
-        data: [
-          {
-            pushed_at: mockUpdatedAt,
-            permissions: mockPermissions,
-            name: mockSite,
-            private: mockPrivate,
-          },
-          {
-            pushed_at: mockUpdatedAt,
-            permissions: mockPermissions,
-            name: mockAdminSite,
-            private: mockPrivate,
-          },
-        ],
-      })
 
       // Act
       const actual = await request(app).get("/")

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -128,7 +128,6 @@ export class SitesRouter {
 
     router.get(
       "/",
-      this.statsMiddleware.countGithubSites,
       this.statsMiddleware.countMigratedSites,
       attachReadRouteHandlerWrapper(this.getSites)
     )

--- a/src/services/identity/SitesService.ts
+++ b/src/services/identity/SitesService.ts
@@ -331,14 +331,10 @@ class SitesService {
       })
     )
 
-    // helper type guard
-    // note: empty strings will return false as well
-    const isString = (val: string | undefined): val is string => !!val
-
     // get sites from DB for email login users
     if (!isAdminUser && isEmailUser) {
       const retrievedSitesByEmail = await this.getSitesForEmailUser(userId)
-      const filteredValidSites = retrievedSitesByEmail.filter(isString)
+      const filteredValidSites = retrievedSitesByEmail.filter(_.isString)
 
       const repoData: RepositoryData[] = filteredValidSites.map((site) => ({
         repoName: site,

--- a/src/services/identity/__tests__/SitesService.spec.ts
+++ b/src/services/identity/__tests__/SitesService.spec.ts
@@ -916,10 +916,7 @@ describe("SitesService", () => {
 
       const expectedResp: RepositoryData[] = [
         {
-          lastUpdated: repoInfo.pushed_at,
-          permissions: repoInfo.permissions,
           repoName: repoInfo.name,
-          isPrivate: repoInfo.private,
         },
       ]
       MockIsomerAdminsService.getByUserId.mockImplementationOnce(() => null)
@@ -939,7 +936,7 @@ describe("SitesService", () => {
       expect(MockIsomerAdminsService.getByUserId).toHaveBeenCalledWith(
         mockIsomerUserId
       )
-      expect(mockAxios.get).toHaveBeenCalledTimes(3)
+      expect(mockAxios.get).toHaveBeenCalledTimes(0)
       config.set("sites.pageCount", currRepoCount)
       expect(config.get("sites.pageCount")).toBe(currRepoCount)
     })
@@ -968,7 +965,7 @@ describe("SitesService", () => {
       expect(MockUsersService.findSitesByUserId).toHaveBeenCalledWith(
         mockIsomerUserId
       )
-      expect(mockAxios.get).toHaveBeenCalledTimes(3)
+      expect(mockAxios.get).toHaveBeenCalledTimes(0)
       config.set("sites.pageCount", currRepoCount)
       expect(config.get("sites.pageCount")).toBe(currRepoCount)
     })

--- a/src/types/repoInfo.ts
+++ b/src/types/repoInfo.ts
@@ -15,10 +15,10 @@ export type GitHubRepositoryData = {
 }
 
 export type RepositoryData = {
-  lastUpdated: GitHubRepositoryData["pushed_at"]
-  permissions: GitHubRepositoryData["permissions"]
+  lastUpdated?: GitHubRepositoryData["pushed_at"]
+  permissions?: GitHubRepositoryData["permissions"]
   repoName: GitHubRepositoryData["name"]
-  isPrivate: GitHubRepositoryData["private"]
+  isPrivate?: GitHubRepositoryData["private"]
 }
 
 type SiteUrlTypes = "staging" | "prod"


### PR DESCRIPTION
## Problem

We are making unnecessary Github calls on /sites page especially on email login flow when this could be a call to our DB. In light of us reaching the limits of Github api, we should try to prevent excessive calls.

Closes IS-165

## Solution

Added a check on getSites to return the list of site names for the user from our DB (only if it is a non-admin and non-github flow user).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

## Deploy Notes

Note minor dependency on https://github.com/isomerpages/isomercms-frontend/pull/1265
Needs to be deployed together
