### PR TITLE
Is 166 race condition when editing a page inside a deleted folder

### DIFF
--- a/src/routes/v2/authenticatedSites/__tests__/CollectionPages.spec.ts
+++ b/src/routes/v2/authenticatedSites/__tests__/CollectionPages.spec.ts
@@ -1,12 +1,12 @@
-const express = require("express")
-const request = require("supertest")
+import express from "express"
+import request from "supertest"
 
-const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
+import { attachReadRouteHandlerWrapper } from "@middleware/routeHandler"
 
-const { generateRouter } = require("@fixtures/app")
-const { mockUserWithSiteSessionData } = require("@fixtures/sessionData")
+import { generateRouter } from "@fixtures/app"
+import { mockUserWithSiteSessionData } from "@fixtures/sessionData"
 
-const { CollectionPagesRouter } = require("../collectionPages")
+import { CollectionPagesRouter } from "../collectionPages"
 
 describe("Collection Pages Router", () => {
   const mockCollectionPageService = {
@@ -15,6 +15,8 @@ describe("Collection Pages Router", () => {
     update: jest.fn(),
     delete: jest.fn(),
     rename: jest.fn(),
+    gitHubService: {},
+    collectionYmlService: {},
   }
 
   const mockSubcollectionPageService = {
@@ -23,6 +25,9 @@ describe("Collection Pages Router", () => {
     update: jest.fn(),
     delete: jest.fn(),
     rename: jest.fn(),
+    updateSubcollection: jest.fn(),
+    gitHubService: {},
+    collectionYmlService: {},
   }
 
   const router = new CollectionPagesRouter({
@@ -103,6 +108,7 @@ describe("Collection Pages Router", () => {
         collectionName,
         content: pageDetails.content.pageBody,
         frontMatter: pageDetails.content.frontMatter,
+        shouldIgnoreCheck: false,
       }
       await request(app)
         .post(`/${siteName}/collections/${collectionName}/pages`)
@@ -121,6 +127,7 @@ describe("Collection Pages Router", () => {
         subcollectionName,
         content: pageDetails.content.pageBody,
         frontMatter: pageDetails.content.frontMatter,
+        shouldIgnoreCheck: false,
       }
       await request(app)
         .post(

--- a/src/routes/v2/authenticatedSites/collectionPages.js
+++ b/src/routes/v2/authenticatedSites/collectionPages.js
@@ -68,6 +68,21 @@ class CollectionPagesRouter {
 
     const { pageName, collectionName, subcollectionName } = req.params
 
+    const readResp = await this.getCollectionPage(
+      subcollectionName,
+      userWithSiteSessionData,
+      pageName,
+      collectionName
+    )
+    return res.status(200).json(readResp)
+  }
+
+  async getCollectionPage(
+    subcollectionName,
+    userWithSiteSessionData,
+    pageName,
+    collectionName
+  ) {
     let readResp
     if (subcollectionName) {
       readResp = await this.subcollectionPageService.read(
@@ -87,7 +102,7 @@ class CollectionPagesRouter {
         }
       )
     }
-    return res.status(200).json(readResp)
+    return readResp
   }
 
   // Update page in collection
@@ -97,6 +112,21 @@ class CollectionPagesRouter {
     const { pageName, collectionName, subcollectionName } = req.params
     const { error } = UpdatePageRequestSchema.validate(req.body)
     if (error) throw new BadRequestError(error.message)
+    // check if subcollection still exists
+    try {
+      await this.getCollectionPage(
+        subcollectionName,
+        userWithSiteSessionData,
+        pageName,
+        collectionName
+      )
+    } catch (_) {
+      res
+        .status(409)
+        .json("The page that you are trying to edit does not exist")
+      return next()
+    }
+
     const {
       content: { frontMatter, pageBody },
       sha,

--- a/src/routes/v2/authenticatedSites/collectionPages.ts
+++ b/src/routes/v2/authenticatedSites/collectionPages.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/prefer-default-export */
 import autoBind from "auto-bind"
 import express, { NextFunction, Request, Response } from "express"
 
@@ -19,7 +20,7 @@ import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import { CollectionPageService } from "@services/fileServices/MdPageServices/CollectionPageService"
 import { SubcollectionPageService } from "@services/fileServices/MdPageServices/SubcollectionPageService"
 
-class CollectionPagesRouter {
+export class CollectionPagesRouter {
   collectionPageService: CollectionPageService
 
   subcollectionPageService: SubcollectionPageService
@@ -203,6 +204,7 @@ class CollectionPagesRouter {
     const { pageName, collectionName, subcollectionName } = req.params
     const { error } = DeletePageRequestSchema.validate(req.body)
     if (error) throw new BadRequestError(error.message)
+    const { sha } = req.body
     try {
       await this.getCollectionPage({
         subcollectionName,
@@ -212,7 +214,7 @@ class CollectionPagesRouter {
       })
     } catch (_) {
       res
-        .status(409)
+        .status(404)
         .json("The page that you are trying to delete does not exist")
       return next()
     }
@@ -224,12 +226,7 @@ class CollectionPagesRouter {
           fileName: pageName,
           collectionName,
           subcollectionName,
-          /**
-           * todo: can remove this line after moving
-           * subcollectionPageService.delete to use deleteFile
-           * into ts and marking this as optional
-           * */
-          sha: undefined,
+          sha,
         }
       )
     } else {
@@ -238,12 +235,7 @@ class CollectionPagesRouter {
         {
           fileName: pageName,
           collectionName,
-          /**
-           * todo: can remove this line after moving
-           * subcollectionPageService.delete to use deleteFile
-           * into ts and marking this as optional
-           * */
-          sha: undefined,
+          sha,
         }
       )
     }
@@ -290,4 +282,3 @@ class CollectionPagesRouter {
     return router
   }
 }
-export default CollectionPagesRouter

--- a/src/routes/v2/authenticatedSites/collectionPages.ts
+++ b/src/routes/v2/authenticatedSites/collectionPages.ts
@@ -133,7 +133,7 @@ class CollectionPagesRouter {
       })
     } catch (_) {
       res
-        .status(409)
+        .status(404)
         .json("The page that you are trying to edit does not exist")
       return next()
     }


### PR DESCRIPTION
## Problem

User A creates a folder A

User A creates a page `testPage` inside folder A

User B starts editing page testPage

User A deletes folder A

User B saves page testPage


Observed behaviour: 

Folder A exists, but is no longer accessible in the CMS. (404 error thrown) 


## Solution

Do a read call to ensure that the page still exists before making and mutation to the repo in github. 
Modifying the file just makes the user see the 404 page, and they have to navigate back to their workspace, which, while annoying, preserves the valid state of the repo.



## Limitations 
Since we are working with stale data, one would need to do a read call to make sure that the file exists in the particular folder. This would incur an additional call, but the hunch here is that the user will call this endpoint lesser than a window refresh. 
 
**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [X] No - this PR is backwards compatible

