### PR TITLE
fix(githhub service): get call to github to prevent race condition

### DIFF
--- a/src/services/db/GitHubService.js
+++ b/src/services/db/GitHubService.js
@@ -106,6 +106,11 @@ class GitHubService {
         !isCreatingTopLevelDirectory && !isCreatingNewResourceFolder
 
       if (checkDirectoryExist) {
+        /**
+         * When we are creating a new resource post or creating a new subDirectory,
+         * we create a _posts and a .keep folder respectively. However, we still need to check if
+         * parent directory still exists.
+         */
         const isCreatingSubDirectory = fileName === ".keep"
         const isCreatingPostResource = directoryName.endsWith("_posts")
         if (!directoryName) {
@@ -113,6 +118,7 @@ class GitHubService {
         }
         let pathToCheck = directoryName
         if (isCreatingSubDirectory || isCreatingPostResource) {
+          // get parent directory
           pathToCheck = directoryName.split("/").slice(0, -1).join("/")
         }
         // this is to check if the file path still exists, else this will throw a 404

--- a/src/services/db/GitHubService.js
+++ b/src/services/db/GitHubService.js
@@ -94,6 +94,23 @@ class GitHubService {
     const { accessToken, siteName, isomerUserId: userId } = sessionData
     try {
       const endpoint = this.getFilePath({ siteName, fileName, directoryName })
+      const isCreatingTopLevelDirectory = fileName === "collection.yml"
+      const isCreatingNewResourceFolder = fileName === "index.html"
+      const checkDirectoryExist =
+        !isCreatingTopLevelDirectory && !isCreatingNewResourceFolder
+
+      if (checkDirectoryExist) {
+        const isCreatingSubDirectory = fileName === ".keep"
+        const isCreatingPostResource = directoryName.endsWith("_posts")
+
+        let pathToCheck = directoryName
+        if (isCreatingSubDirectory || isCreatingPostResource) {
+          pathToCheck = directoryName.split("/").slice(0, -1).join("/")
+        }
+        // this is to check if the file path still exists, else this will throw a 404
+        await this.readDirectory(sessionData, { directoryName: pathToCheck })
+      }
+
       // Validation and sanitisation of media already done
       const encodedContent = isMedia ? content : Base64.encode(content)
 
@@ -202,6 +219,8 @@ class GitHubService {
     const { accessToken, siteName, isomerUserId: userId } = sessionData
     try {
       const endpoint = this.getFilePath({ siteName, fileName, directoryName })
+      // this is to check if the file path still exists, else this will throw a 404
+      await this.readDirectory(sessionData, { directoryName })
       const encodedNewContent = Base64.encode(fileContent)
 
       let fileSha = sha

--- a/src/services/db/GitHubService.js
+++ b/src/services/db/GitHubService.js
@@ -94,6 +94,12 @@ class GitHubService {
     const { accessToken, siteName, isomerUserId: userId } = sessionData
     try {
       const endpoint = this.getFilePath({ siteName, fileName, directoryName })
+
+      /**
+       * Currently, this rides on the assumption that creating a top level
+       * directly will create a collection.yml file, and creating a new resource
+       * folder will create an index.html file.
+       */
       const isCreatingTopLevelDirectory = fileName === "collection.yml"
       const isCreatingNewResourceFolder = fileName === "index.html"
       const checkDirectoryExist =
@@ -102,7 +108,9 @@ class GitHubService {
       if (checkDirectoryExist) {
         const isCreatingSubDirectory = fileName === ".keep"
         const isCreatingPostResource = directoryName.endsWith("_posts")
-
+        if (!directoryName) {
+          throw new NotFoundError("Directory name is not defined")
+        }
         let pathToCheck = directoryName
         if (isCreatingSubDirectory || isCreatingPostResource) {
           pathToCheck = directoryName.split("/").slice(0, -1).join("/")

--- a/src/services/db/__tests__/GitHubService.spec.js
+++ b/src/services/db/__tests__/GitHubService.spec.js
@@ -121,6 +121,7 @@ describe("Github Service", () => {
         },
       }
       mockAxiosInstance.put.mockResolvedValueOnce(resp)
+      mockAxiosInstance.get.mockResolvedValueOnce("")
       await expect(
         service.create(sessionData, {
           content,
@@ -145,6 +146,7 @@ describe("Github Service", () => {
           },
         },
       }
+      mockAxiosInstance.get.mockResolvedValueOnce("")
       mockAxiosInstance.put.mockResolvedValueOnce(resp)
       await expect(
         service.create(sessionData, {
@@ -167,6 +169,7 @@ describe("Github Service", () => {
     })
 
     it("Create parses and throws the correct error in case of a conflict", async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce("")
       mockAxiosInstance.put.mockImplementation(() => {
         const err = new Error()
         err.response = {
@@ -346,6 +349,7 @@ describe("Github Service", () => {
     }
 
     it("Updating a file works correctly", async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce("")
       const resp = {
         data: {
           content: {
@@ -372,6 +376,7 @@ describe("Github Service", () => {
     })
 
     it("Update throws the correct error if file cannot be found", async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce("")
       mockAxiosInstance.put.mockImplementation(() => {
         const err = new Error()
         err.response = {
@@ -395,6 +400,7 @@ describe("Github Service", () => {
     })
 
     it("Updating a file with no sha works correctly", async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce("")
       const getResp = {
         data: {
           content: encodedContent,
@@ -435,6 +441,7 @@ describe("Github Service", () => {
     })
 
     it("Update with no sha provided throws the correct error if file cannot be found", async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce("")
       const readParams = {
         ref: BRANCH_REF,
       }


### PR DESCRIPTION
Copying from @alexanderleegs's write up in slack: 
## Problem

issue with releasing the refetch behaviour change - specifically for concurrent editing of pages in similar locations with different users, there is the risk of race conditions. E.g. User A and B both want to modify folder 1; User A edits a page in folder 1, but before he submits the operation, user B deletes the folder - we suspect this will cause a floating page in the deleted folder 1 that is inaccessible via CMS. This issue is already present in production currently, but it's mostly mitigated by our refetch behaviour, because retrieving updated data on refocus will immediately stop users from making these changes to recently updated files/folders.

Closes [insert issue #]

## Solution

Our proposed solution involves adding guards to create and update operations in the base GithubService - other operations (e.g. deleting an already removed file) will trigger an error from Github itself already, so only create and update endpoints have the potential to cause errors. We would have to make an additional query for each create and update endpoint to check that the file/directory still exists before we can make the change, so this increases the number of API calls we're making, but we feel that this is still an overall improvement over refetching on focus since there are a lot more GET queries than CREATE/UPDATE. We can monitor the overall change in token usage after pushing all the changes to see if this will cause any issues

## Tests

To be honest, quite worried about this PR since the surface area of bugs is quite large. Manual testing done so far:
1) CRUD operations for files,folders 
2) unable to replicate bug in the problem stated in this PR 
3) Creating resource rooms folders
4) Creating more deeply nested media folders
5) Moving pages

Please feel free to put any notes about flows that I might have missed out here!  
