### PR TITLE
chore(tracer.ts): changed samplerate to 1

### DIFF
--- a/src/utils/tracer.ts
+++ b/src/utils/tracer.ts
@@ -1,5 +1,7 @@
 import tracer from "dd-trace"
 
-tracer.init()
+tracer.init({
+  sampleRate: 1,
+})
 
 export default tracer


### PR DESCRIPTION
## Problem
`dd-trace` did not fully sample, so we might have missed traces. this is sub-optimal when we want to determine the # of email/github requests hitting our backend api.

## Solution
see [here](https://docs.datadoghq.com/tracing/trace_collection/library_config/nodejs/) - we just don't let the dd agent decide the sample rate.
