### PR TITLE
Fix: handle updating of files in root directory

### DIFF
--- a/src/services/db/GitHubService.js
+++ b/src/services/db/GitHubService.js
@@ -233,8 +233,9 @@ class GitHubService {
     const { accessToken, siteName, isomerUserId: userId } = sessionData
     try {
       const endpoint = this.getFilePath({ siteName, fileName, directoryName })
-      // this is to check if the file path still exists, else this will throw a 404
-      await this.readDirectory(sessionData, { directoryName })
+      // this is to check if the file path still exists, else this will throw a 404. Only needed for paths outside of root
+      if (directoryName)
+        await this.readDirectory(sessionData, { directoryName })
       const encodedNewContent = Base64.encode(fileContent)
 
       let fileSha = sha


### PR DESCRIPTION
This PR fixes a bug in our update behaviour - we were previously checking that the directory a file was in exists before making any update call, but this was failing for our root directory. This PR skips the check if the file belongs to our root directory. Note that `Create` does not need to have this same behaviour - we never create files inside our root folder.