### PR TITLE
[IS-104] fix(errorhandler): tweak serialisation of error object

### DIFF
--- a/src/middleware/__tests__/errorHandler.spec.ts
+++ b/src/middleware/__tests__/errorHandler.spec.ts
@@ -1,0 +1,63 @@
+import { AxiosError } from "axios"
+import _ from "lodash"
+import { serializeError } from "serialize-error"
+
+import { errorHandler } from "../errorHandler"
+
+const mockReq = {
+  app: {
+    get: () => "development",
+  },
+}
+const mockJson = jest.fn().mockImplementation(() => null)
+const mockRes = {
+  locals: {
+    message: "some message",
+    error: "some error",
+  },
+  status: () => ({
+    json: mockJson,
+  }),
+}
+const mockNext = jest.fn()
+const mockAxiosError: AxiosError = {
+  config: {},
+  request: {},
+  isAxiosError: true,
+  toJSON: jest.fn().mockReturnThis(),
+  name: "MOCK_AXIOS_ERROR",
+  message: "oops",
+}
+
+describe("error handler", () => {
+  const stringifySpy = jest.spyOn(JSON, "stringify")
+
+  it("should not omit any data if the request property does not exist", async () => {
+    // Act
+    errorHandler(mockAxiosError, mockReq, mockRes, mockNext)
+
+    // Assert
+    expect(stringifySpy).toHaveBeenCalledWith(serializeError(mockAxiosError))
+  })
+
+  it("should omit both `request` and `config` if `request` exists", async () => {
+    // Assert
+    const mockAxiosErrorWithRequest = {
+      ...mockAxiosError,
+      config: {
+        headers: {
+          Authorization: "token MOCK_TOKEN",
+        },
+      },
+    }
+
+    // Act
+    errorHandler(mockAxiosErrorWithRequest, mockReq, mockRes, mockNext)
+
+    // Assert
+    expect(stringifySpy).toHaveBeenCalledWith(
+      // NOTE: `config` property removed
+      serializeError(_.omit(mockAxiosError, ["config", "request"]))
+    )
+  })
+})

--- a/src/middleware/__tests__/errorHandler.spec.ts
+++ b/src/middleware/__tests__/errorHandler.spec.ts
@@ -57,7 +57,7 @@ describe("error handler", () => {
     // Assert
     expect(stringifySpy).toHaveBeenCalledWith(
       // NOTE: `config` property removed
-      serializeError(_.omit(mockAxiosError, ["config", "request"]))
+      serializeError(_.pick(mockAxiosError, ["name", "message"]))
     )
   })
 })

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -7,17 +7,15 @@ const logger = require("@logger/logger")
 
 function errorHandler(err, req, res, next) {
   if (!err) return next()
-  const containsSensitiveInfo = _.isEmpty(err.request)
+  const containsSensitiveInfo = !_.isEmpty(err.config?.headers?.Authorization)
   const serialisedErr = serializeError(err)
-  // NOTE: If the error is an axios error or a network error, it will have a response.
-  // We only take the `body` section because `request` + `config`
-  // might contain the auth token used, which is sensitive
+  // NOTE: If the error is an axios error or a network error,
+  // the token used (if any) will be present on `request` + `config`.
+  // Hence, we omit both of these.
   const sanitisedErr = containsSensitiveInfo
     ? _.omit(serialisedErr, ["request", "config"])
     : serialisedErr
-  const errMsg = `${new Date()}: ${JSON.stringify(
-    serializeError(sanitisedErr)
-  )}`
+  const errMsg = `${new Date()}: ${JSON.stringify(sanitisedErr)}`
 
   // set locals, only providing error in development
   res.locals.message = err.message

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -11,11 +11,17 @@ function errorHandler(err, req, res, next) {
   const serialisedErr = serializeError(err)
   // NOTE: If the error is an axios error or a network error,
   // the token used (if any) will be present on `request` + `config`.
-  // Hence, we omit both of these.
+  // Hence, we omit both of these and only pick the selected properties.
+  // This is also to avoid picking the `session`, which has raws bytes
+  // that is not useful to debugging
   const sanitisedErr = containsSensitiveInfo
-    ? _.omit(serialisedErr, ["request", "config"])
+    ? {
+        // NOTE: Default error properties
+        ..._.pick(serialisedErr, ["name", "message", "stack"]),
+        ..._.pick(serialisedErr.response, ["headers", "data", "status"]),
+      }
     : serialisedErr
-  const errMsg = `${new Date()}: ${JSON.stringify(sanitisedErr)}`
+  const errMsg = JSON.stringify(sanitisedErr)
 
   // set locals, only providing error in development
   res.locals.message = err.message


### PR DESCRIPTION
## Problem
refer [here](https://isomeropengov.atlassian.net/browse/IS-104?atlOrigin=eyJpIjoiOTJlMGY5ZDk3MTQ3NDdkN2EzNmFjZjNkMTI1MzUwZjAiLCJwIjoiaiJ9) for overview. brief summary is that auth tokens are being logged and written into our logs. 

Closes IS-104

## Solution
1. for the error object, we check if there exists an authorization header. if there is, both `request` + `config` is removed. this is heavy handed but required because the library (`serialize-errors`) resolves circular references by [walking down teh properties](https://github.com/sindresorhus/serialize-error/blob/main/index.js#L95), which imght have more references to the header. a brief copy-pasting of the attached log + searching for `token ghp` revealed 15 references, of which some were deeply nested, so this was preferred. 
2. the test setup is **not** ideal. the jest mock axios exposes a `mockError` method which mocks a failed (4xx or 5xx) response from the external server but i could not get this to work well with axios, so a object conforming to the axios error interface was created instead. `jest-mock-axios` uses the internal promise queue (see [here](https://github.com/knee-cola/jest-mock-axios/blob/master/lib/mock-axios.ts#L261)) to mock a failed response but the internal promise queue appears to be empty from the error message @__@


## Testing
Prior to testing, we need to change a few things
1. in `axios-utils`, change `validateStatus` so that 404s are recognised as an error. 
2. change `isValidE2E` to `true` in `verifyAccess` in `AuthenticationMiddlewareService` 
3. go to a repo and rename the contact us file to `contactus` (note the lack of dash) 
4. query this endpoint: `/v2/sites/<site-name>/contactUs`
5. log `sanitizedErr` in `errorHandler.js`

`sanitizedErr` should be short and **not contain raw bytes**

