### PR TITLE
Add details to drop Quad-A records in email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "morgan": "~1.10.0",
         "neverthrow": "^4.3.1",
         "nocache": "^3.0.4",
+        "node-dig-dns": "^0.3.3",
         "otplib": "^12.0.1",
         "pg": "^8.6.0",
         "pg-connection-string": "^2.5.0",
@@ -1964,6 +1965,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -16405,6 +16417,11 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
+    "node_modules/lodash.compact": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.compact/-/lodash.compact-3.0.1.tgz",
+      "integrity": "sha512-2ozeiPi+5eBXW1CLtzjk8XQFhQOEMwwfxblqeq6EGyTxZJ1bPATqilY0e6g2SLQpP4KuMeuioBhEnWz5Pr7ICQ=="
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -17315,6 +17332,15 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
       "dev": true
+    },
+    "node_modules/node-dig-dns": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/node-dig-dns/-/node-dig-dns-0.3.3.tgz",
+      "integrity": "sha512-l/57tMh/8D89MRiMF+iIYz3h5p2pGusxY75MM7gjsPegV/WqyVWC266DM9HTOeirmp4CdrQQBMbQssb2W7maAA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.9",
+        "lodash.compact": "^3.0.1"
+      }
     },
     "node_modules/node-dir": {
       "version": "0.1.17",
@@ -19513,10 +19539,9 @@
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexpp": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "morgan": "~1.10.0",
     "neverthrow": "^4.3.1",
     "nocache": "^3.0.4",
+    "node-dig-dns": "^0.3.3",
     "otplib": "^12.0.1",
     "pg": "^8.6.0",
     "pg-connection-string": "^2.5.0",

--- a/src/routes/formsgSiteLaunch.ts
+++ b/src/routes/formsgSiteLaunch.ts
@@ -18,6 +18,7 @@ import {
   getDNSRecordsEmailBody,
   getErrorEmailBody,
 } from "@root/services/utilServices/SendDNSRecordEmailClient"
+import { DigResponse, DigType } from "@root/types/dig"
 import UsersService from "@services/identity/UsersService"
 import InfraService from "@services/infra/InfraService"
 
@@ -58,32 +59,6 @@ interface FormResponsesProps {
 
   siteLaunchDetails?: string[] | string[][]
 }
-
-type DigResponse = {
-  question: string[][]
-  answer?: {
-    domain: string
-    ttl: string
-    class: string
-    type: string
-    value: string
-  }[]
-  time?: number
-  server?: string
-  datetime?: string
-  size?: number
-}
-
-type DigType =
-  | "A"
-  | "AAAA"
-  | "CNAME"
-  | "MX"
-  | "NS"
-  | "PTR"
-  | "SOA"
-  | "SRV"
-  | "TXT"
 
 export class FormsgSiteLaunchRouter {
   launchSiteFromForm = async (formResponses: FormResponsesProps) => {

--- a/src/routes/formsgSiteLaunch.ts
+++ b/src/routes/formsgSiteLaunch.ts
@@ -288,6 +288,10 @@ export class FormsgSiteLaunchRouter {
               type: record.type,
               value: record.value,
             }))
+          } else {
+            logger.info(
+              `Unable to get dig response for domain: ${launchResult.value.primaryDomainSource}`
+            )
           }
           successResults.push(successResult)
         }

--- a/src/routes/formsgSiteLaunch.ts
+++ b/src/routes/formsgSiteLaunch.ts
@@ -256,7 +256,7 @@ export class FormsgSiteLaunchRouter {
         logger.info(`Received DIG response: ${JSON.stringify(result)}`)
         return result
       })
-      .catch((err: any) => {
+      .catch((err: unknown) => {
         logger.error(
           `An error occurred while performing dig for domain: ${domain}`
         )

--- a/src/services/utilServices/SendDNSRecordEmailClient.ts
+++ b/src/services/utilServices/SendDNSRecordEmailClient.ts
@@ -1,9 +1,11 @@
 import { groupBy } from "lodash"
 
+import { DigType } from "@root/types/dig"
+
 export interface QuadARecord {
   domain: string
   class: string
-  type: string
+  type: DigType
   value: string
 }
 export interface DnsRecordsEmailProps {

--- a/src/services/utilServices/SendDNSRecordEmailClient.ts
+++ b/src/services/utilServices/SendDNSRecordEmailClient.ts
@@ -1,4 +1,4 @@
-import { groupBy, has } from "lodash"
+import { groupBy } from "lodash"
 
 export interface QuadARecord {
   domain: string
@@ -104,6 +104,8 @@ export function getDNSRecordsEmailBody(
   html += `
     </tbody>
   </table>`
+
+  console.log(`GROUPED: ${JSON.stringify(groupedDnsRecords, null, 2)}`)
 
   Object.keys(groupedDnsRecords).forEach((repoName) => {
     const allQuadARecordsForRepo: QuadARecord[] = []

--- a/src/services/utilServices/SendDNSRecordEmailClient.ts
+++ b/src/services/utilServices/SendDNSRecordEmailClient.ts
@@ -105,8 +105,6 @@ export function getDNSRecordsEmailBody(
     </tbody>
   </table>`
 
-  console.log(`GROUPED: ${JSON.stringify(groupedDnsRecords, null, 2)}`)
-
   Object.keys(groupedDnsRecords).forEach((repoName) => {
     const allQuadARecordsForRepo: QuadARecord[] = []
     groupedDnsRecords[repoName].forEach((dnsRecord) => {

--- a/src/services/utilServices/SendDNSRecordEmailClient.ts
+++ b/src/services/utilServices/SendDNSRecordEmailClient.ts
@@ -1,5 +1,11 @@
-import { groupBy } from "lodash"
+import { groupBy, has } from "lodash"
 
+export interface QuadARecord {
+  domain: string
+  class: string
+  type: string
+  value: string
+}
 export interface DnsRecordsEmailProps {
   requesterEmail: string
   repoName: string
@@ -9,6 +15,7 @@ export interface DnsRecordsEmailProps {
   primaryDomainTarget: string
   redirectionDomainSource?: string
   redirectionDomainTarget?: string
+  quadARecords?: QuadARecord[]
 }
 
 export interface LaunchFailureEmailProps {
@@ -57,6 +64,7 @@ export function getDNSRecordsEmailBody(
     const hasRedirection = !!groupedDnsRecords[repoName].some(
       (dnsRecords) => !!dnsRecords.redirectionDomainSource
     )
+
     html += `<tr style="${headerRowStyle}">
           <td style="${repoNameStyle}" rowspan="${
       hasRedirection ? 4 : 3
@@ -87,12 +95,56 @@ export function getDNSRecordsEmailBody(
             <td style="${tdStyle}">${dnsRecords.primaryDomainSource}</td>
             <td style="${tdStyle}">${dnsRecords.redirectionDomainTarget}</td>
             <td style="${tdStyle}">A Record</td>
-          </tr>`
+          </tr>
+        `
       }
     })
   })
-  html += `</tbody></table>
-      <p style="${bodyFooterStyle}">This email was sent from the Isomer CMS backend.</p>`
+
+  html += `
+    </tbody>
+  </table>`
+
+  Object.keys(groupedDnsRecords).forEach((repoName) => {
+    const allQuadARecordsForRepo: QuadARecord[] = []
+    groupedDnsRecords[repoName].forEach((dnsRecord) => {
+      if (dnsRecord.quadARecords) {
+        allQuadARecordsForRepo.push(...dnsRecord.quadARecords)
+      }
+    })
+
+    if (allQuadARecordsForRepo.length > 0) {
+      html += `<p style="${bodyFooterStyle}">Note that there are some AAAA records found for the following repo: <b>${repoName}</b>. Please
+        make sure to drop these records.</p>
+        <table style="${tableStyle}">
+        <thead>
+          <tr style="${headerRowStyle}">
+            <th style="${thStyle}">Domain</th>
+            <th style="${thStyle}">Class</th>
+            <th style="${thStyle}">Type</th>
+            <th style="${thStyle}">Value</th>
+          </tr>
+        </thead>
+        <tbody>`
+
+      allQuadARecordsForRepo.forEach((record) => {
+        html += `
+                <tr style="${tdStyle}">
+                  <td style="${tdStyle}" >${record.domain}</td>
+                  <td style="${tdStyle}">${record.class}</td>
+                  <td style="${tdStyle}">${record.type}</td>
+                  <td style="${tdStyle}">${record.value}</td>
+                </tr>`
+      })
+
+      html += `
+        </tbody>
+      </table>`
+    }
+  })
+
+  html += `<p style="${bodyFooterStyle}">This email was sent from the Isomer CMS backend.</p>`
+
   return html
 }
 

--- a/src/types/dig.ts
+++ b/src/types/dig.ts
@@ -1,0 +1,25 @@
+export type DigResponse = {
+  question: string[][]
+  answer?: {
+    domain: string
+    ttl: string
+    class: string
+    type: DigType
+    value: string
+  }[]
+  time?: number
+  server?: string
+  datetime?: string
+  size?: number
+}
+
+export type DigType =
+  | "A"
+  | "AAAA"
+  | "CNAME"
+  | "MX"
+  | "NS"
+  | "PTR"
+  | "SOA"
+  | "SRV"
+  | "TXT"

--- a/src/types/node-dig-dns/node-dig-dns.d.ts
+++ b/src/types/node-dig-dns/node-dig-dns.d.ts
@@ -1,0 +1,1 @@
+declare module "node-dig-dns"


### PR DESCRIPTION
## Problem

Currently, during site launch, if there exists AAAA records for a domain, it must be dropped. There has been some instances when this was not dropped and it conflicts with our process.

Closes IS-109

## Solution

We perform a dig command to check for AAAA records associated with a domain and add these records into the email we send to Ops to remind them that these records must be dropped.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

## Tests

<!-- What tests should be run to confirm functionality? -->

## Deploy Notes

**New dependencies**:

- `node-dig-dns` : helps perform dig on node.js runtime and returns response as a JSON

## Test plan

Step 0: Set your export MOCK_AMPLIFY_DOMAIN_ASSOCIATION_CALLS="true"
Step 1. Run this from server.js to trigger a fake formsg response, with appropriate values for the emails and repos you have setup

const formResponses = [
  {
    submissionId: "",
    requesterEmail: "REQUESTER@open.gov.sg",
    repoName: "test-amplify",
    primaryDomain: "google.com",
    redirectionDomain: "www.google.com",
    agencyEmail: "AGENCY@open.gov.sg",
  },
  {
    submissionId: "",
    requesterEmail: "REQUESTER@open.gov.sg",
    repoName: "test-site",
    primaryDomain: "yahoo.com",
    redirectionDomain: "www.isomer.gov.sg",
    agencyEmail: "AGENCY@open.gov.sg",
  },
]

formsgSiteLaunchRouter.handleSiteLaunchResults(formResponses, "test")

Step 2: Refer to terminal output for resulting email content

Example of output (previewed on VSCode):
![Screenshot 2023-05-10 at 8 15 05 PM](https://github.com/isomerpages/isomercms-backend/assets/5507822/e3a4a6b6-e125-465b-a69e-986ec4a36be1)

