### PR TITLE
fix(sites): unwrap result instead of returning

### DIFF
--- a/src/routes/v2/authenticated/__tests__/Sites.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/Sites.spec.ts
@@ -1,5 +1,5 @@
 import express from "express"
-import { ok } from "neverthrow"
+import { ok, okAsync } from "neverthrow"
 import request from "supertest"
 
 import type { AuthorizationMiddleware } from "@middleware/authorization"
@@ -115,7 +115,7 @@ describe("Sites Router", () => {
   describe("getSiteUrl", () => {
     it("returns the site's site URL", async () => {
       const siteUrl = "prod-url"
-      mockSitesService.getSiteUrl.mockResolvedValueOnce(siteUrl)
+      mockSitesService.getSiteUrl.mockReturnValueOnce(okAsync(siteUrl))
 
       const resp = await request(app)
         .get(`/${mockSiteName}/siteUrl`)

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -92,15 +92,10 @@ export class SitesRouter {
     { userWithSiteSessionData: UserWithSiteSessionData }
   > = async (req, res) => {
     const { userWithSiteSessionData } = res.locals
-    const possibleSiteUrl = await this.sitesService.getSiteUrl(
-      userWithSiteSessionData
-    )
-
-    // Check for error and throw
-    if (possibleSiteUrl instanceof BaseIsomerError) {
-      return res.status(404).json({ message: possibleSiteUrl.message })
-    }
-    return res.status(200).json({ siteUrl: possibleSiteUrl })
+    return this.sitesService
+      .getSiteUrl(userWithSiteSessionData)
+      .map((siteUrl) => res.status(200).json({ siteUrl }))
+      .mapErr((err) => res.status(404).json({ message: err.message }))
   }
 
   getSiteInfo: RequestHandler<

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -8,7 +8,6 @@ import { attachReadRouteHandlerWrapper } from "@middleware/routeHandler"
 import UserWithSiteSessionData from "@classes/UserWithSiteSessionData"
 
 import type UserSessionData from "@root/classes/UserSessionData"
-import { BaseIsomerError } from "@root/errors/BaseError"
 import { attachSiteHandler } from "@root/middleware"
 import { StatsMiddleware } from "@root/middleware/stats"
 import type { RequestHandler } from "@root/types"


### PR DESCRIPTION
## Problem
Previously we weren't unwrapping the `Result` when we give a resp back to frontend, which results in an `Object object`. This leads to a error when we click the link to go to the live site.

Closes [IS-199]

## Solution
1. unwrap result

## Tests
1. go to the CMS
2. login via email
3. go to any site
4. make an edit
5. request a review and approve the PR (or just toggle state in db also ok)
6. publish the site
7. click on `go to live site` in the modal
8. you should be directed to the live site

[IS-199]: https://isomeropengov.atlassian.net/browse/IS-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ