### PR TITLE
feat: fetch only latest open PR from DB

### DIFF
--- a/src/middleware/notificationOnEditHandler.ts
+++ b/src/middleware/notificationOnEditHandler.ts
@@ -55,7 +55,7 @@ export class NotificationOnEditHandler {
     const site = await this.sitesService.getBySiteName(siteName)
     const users = await this.collaboratorsService.list(siteName, userId)
     if (site.isErr()) throw new Error("Site should always exist")
-    const reviewRequests = await this.reviewRequestService.listReviewRequest(
+    const reviewRequests = await this.reviewRequestService.listValidReviewRequests(
       userWithSiteSessionData,
       site.value
     )

--- a/src/routes/v2/authenticated/__tests__/review.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/review.spec.ts
@@ -35,7 +35,7 @@ describe("Review Requests Router", () => {
     getComments: jest.fn(),
     getFullReviewRequest: jest.fn(),
     getReviewRequest: jest.fn(),
-    listReviewRequest: jest.fn(),
+    listValidReviewRequests: jest.fn(),
     markAllReviewRequestsAsViewed: jest.fn(),
     markReviewRequestAsViewed: jest.fn(),
     mergeReviewRequest: jest.fn(),
@@ -336,7 +336,7 @@ describe("Review Requests Router", () => {
       const mockReviews = ["review1", "review2"]
 
       mockCollaboratorsService.getRole.mockResolvedValueOnce("role")
-      mockReviewRequestService.listReviewRequest.mockResolvedValueOnce(
+      mockReviewRequestService.listValidReviewRequests.mockResolvedValueOnce(
         mockReviews
       )
 
@@ -348,9 +348,9 @@ describe("Review Requests Router", () => {
       expect(response.body).toEqual({ reviews: mockReviews })
       expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
       expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
-      expect(mockReviewRequestService.listReviewRequest).toHaveBeenCalledTimes(
-        1
-      )
+      expect(
+        mockReviewRequestService.listValidReviewRequests
+      ).toHaveBeenCalledTimes(1)
     })
 
     it("should return 404 if the site does not exist", async () => {
@@ -368,7 +368,9 @@ describe("Review Requests Router", () => {
       expect(response.status).toEqual(404)
       expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
       expect(mockCollaboratorsService.getRole).not.toHaveBeenCalled()
-      expect(mockReviewRequestService.listReviewRequest).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.listValidReviewRequests
+      ).not.toHaveBeenCalled()
     })
 
     it("should return 404 if user is not a site collaborator", async () => {
@@ -383,7 +385,9 @@ describe("Review Requests Router", () => {
       expect(response.status).toEqual(404)
       expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
       expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
-      expect(mockReviewRequestService.listReviewRequest).not.toHaveBeenCalled()
+      expect(
+        mockReviewRequestService.listValidReviewRequests
+      ).not.toHaveBeenCalled()
     })
   })
 

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -328,7 +328,7 @@ export class ReviewsRouter {
     }
 
     // Step 3: Fetch data and return
-    const reviews = await this.reviewRequestService.listReviewRequest(
+    const reviews = await this.reviewRequestService.listValidReviewRequests(
       userWithSiteSessionData,
       site.value
     )

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -247,7 +247,7 @@ export default class ReviewRequestService {
 
     // NOTE: Doing this so that we can easily change back to using
     // findAll once ready
-    const requests = [request]
+    const requests = request ? [request] : []
 
     // NOTE: This has a max of 30 pull requests
     // and returns only open pull requests.

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -217,7 +217,7 @@ export default class ReviewRequestService {
     return pullRequestNumber
   }
 
-  listReviewRequest = async (
+  listValidReviewRequests = async (
     sessionData: UserWithSiteSessionData,
     site: Site
   ): Promise<DashboardReviewRequestDto[]> => {

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -224,9 +224,13 @@ export default class ReviewRequestService {
     const { siteName, isomerUserId: userId } = sessionData
 
     // Find all review requests associated with the site
-    const requests = await this.repository.findAll({
+    // TODO: Note this needs to be findAll when we reach a stage of allowing
+    // multiple open PRs simultaneously
+    // Current behaviour returns the newest Open PR based on created_at field
+    const request = await this.repository.findOne({
       where: {
         siteId: site.id,
+        reviewStatus: ReviewRequestStatus.Open,
       },
       include: [
         {
@@ -238,7 +242,12 @@ export default class ReviewRequestService {
           as: "requestor",
         },
       ],
+      order: [["created_at", "DESC"]],
     })
+
+    // NOTE: Doing this so that we can easily change back to using
+    // findAll once ready
+    const requests = [request]
 
     // NOTE: This has a max of 30 pull requests
     // and returns only open pull requests.

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -1,7 +1,7 @@
 import { AxiosResponse } from "axios"
 import _ from "lodash"
 import { errAsync, okAsync, ResultAsync } from "neverthrow"
-import { ModelStatic } from "sequelize"
+import { ModelStatic, Op } from "sequelize"
 
 import UserWithSiteSessionData from "@classes/UserWithSiteSessionData"
 
@@ -230,7 +230,12 @@ export default class ReviewRequestService {
     const request = await this.repository.findOne({
       where: {
         siteId: site.id,
-        reviewStatus: ReviewRequestStatus.Open,
+        [Op.or]: [
+          {
+            reviewStatus: ReviewRequestStatus.Open,
+          },
+          { reviewStatus: ReviewRequestStatus.Approved },
+        ],
       },
       include: [
         {

--- a/src/services/review/__tests__/ReviewRequestService.spec.ts
+++ b/src/services/review/__tests__/ReviewRequestService.spec.ts
@@ -529,9 +529,9 @@ describe("ReviewRequestService", () => {
           firstView: true,
         },
       ]
-      MockReviewRequestRepository.findAll.mockResolvedValueOnce([
-        MOCK_REVIEW_REQUEST_ONE,
-      ])
+      MockReviewRequestRepository.findOne.mockResolvedValueOnce(
+        MOCK_REVIEW_REQUEST_ONE
+      )
       MockReviewApi.getPullRequest.mockResolvedValueOnce(MOCK_PULL_REQUEST_ONE)
       MockReviewRequestViewRepository.count.mockResolvedValueOnce(0)
       MockReviewApi.getComments.mockResolvedValueOnce([
@@ -554,7 +554,7 @@ describe("ReviewRequestService", () => {
 
       // Assert
       expect(actual).toEqual(expected)
-      expect(MockReviewRequestRepository.findAll).toHaveBeenCalled()
+      expect(MockReviewRequestRepository.findOne).toHaveBeenCalled()
       expect(MockReviewApi.getPullRequest).toHaveBeenCalledWith(
         mockUserWithSiteSessionData.siteName,
         MOCK_REVIEW_REQUEST_ONE.reviewMeta.pullRequestNumber
@@ -588,9 +588,9 @@ describe("ReviewRequestService", () => {
           firstView: false,
         },
       ]
-      MockReviewRequestRepository.findAll.mockResolvedValueOnce([
-        MOCK_REVIEW_REQUEST_ONE,
-      ])
+      MockReviewRequestRepository.findOne.mockResolvedValueOnce(
+        MOCK_REVIEW_REQUEST_ONE
+      )
       MockReviewApi.getPullRequest.mockResolvedValueOnce(MOCK_PULL_REQUEST_ONE)
       MockReviewRequestViewRepository.count.mockResolvedValueOnce(1)
       MockReviewApi.getComments.mockResolvedValueOnce([
@@ -615,7 +615,7 @@ describe("ReviewRequestService", () => {
 
       // Assert
       expect(actual).toEqual(expected)
-      expect(MockReviewRequestRepository.findAll).toHaveBeenCalled()
+      expect(MockReviewRequestRepository.findOne).toHaveBeenCalled()
       expect(MockReviewApi.getPullRequest).toHaveBeenCalledWith(
         mockUserWithSiteSessionData.siteName,
         MOCK_REVIEW_REQUEST_ONE.reviewMeta.pullRequestNumber
@@ -649,9 +649,9 @@ describe("ReviewRequestService", () => {
           firstView: false,
         },
       ]
-      MockReviewRequestRepository.findAll.mockResolvedValueOnce([
-        MOCK_REVIEW_REQUEST_ONE,
-      ])
+      MockReviewRequestRepository.findOne.mockResolvedValueOnce(
+        MOCK_REVIEW_REQUEST_ONE
+      )
       MockReviewApi.getPullRequest.mockResolvedValueOnce(MOCK_PULL_REQUEST_ONE)
       MockReviewRequestViewRepository.count.mockResolvedValueOnce(1)
       MockReviewApi.getComments.mockResolvedValueOnce([])
@@ -667,7 +667,7 @@ describe("ReviewRequestService", () => {
 
       // Assert
       expect(actual).toEqual(expected)
-      expect(MockReviewRequestRepository.findAll).toHaveBeenCalled()
+      expect(MockReviewRequestRepository.findOne).toHaveBeenCalled()
       expect(MockReviewApi.getPullRequest).toHaveBeenCalledWith(
         mockUserWithSiteSessionData.siteName,
         MOCK_REVIEW_REQUEST_ONE.reviewMeta.pullRequestNumber

--- a/src/services/review/__tests__/ReviewRequestService.spec.ts
+++ b/src/services/review/__tests__/ReviewRequestService.spec.ts
@@ -547,7 +547,7 @@ describe("ReviewRequestService", () => {
       })
 
       // Act
-      const actual = await ReviewRequestService.listReviewRequest(
+      const actual = await ReviewRequestService.listValidReviewRequests(
         mockUserWithSiteSessionData,
         mockSiteOrmResponseWithAllCollaborators as Attributes<Site>
       )
@@ -608,7 +608,7 @@ describe("ReviewRequestService", () => {
       })
 
       // Act
-      const actual = await ReviewRequestService.listReviewRequest(
+      const actual = await ReviewRequestService.listValidReviewRequests(
         mockUserWithSiteSessionData,
         mockSiteOrmResponseWithAllCollaborators as Attributes<Site>
       )
@@ -660,7 +660,7 @@ describe("ReviewRequestService", () => {
       )
 
       // Act
-      const actual = await ReviewRequestService.listReviewRequest(
+      const actual = await ReviewRequestService.listValidReviewRequests(
         mockUserWithSiteSessionData,
         mockSiteOrmResponseWithAllCollaborators as Attributes<Site>
       )


### PR DESCRIPTION
## Problem

Currently we are fetching all the PRs (Open + Closed) from our DB. Then we do a for-loop over every PR to get its meta, number of comments etc. from Github API. 

This causes unnecessary calls to Github. In line with our effort to reduce Github API calls, and with the fact that there could be at most 1 open PR for a repo (so far), we can further streamline this.

Closes IS-171

## Solution

We only retrieve the latest (newest by createdAt timestamp) PR that is in "OPEN" or "APPROVED" state. 

Since we may have more than 1 Open PR in future, the changes allow for us to revert back to using `findAll` in a relatively simple way.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

## Test Cases 

**Site dashboard**
- should show only 1 open or approved review request

**Workspace**
- should show the review request alert when there's a review request open

**site edit header (this is used widely)**
- should disable the review request button when there's an open review request
approved review redirect (used widely)

- should redirect when there's an approved review request
more broadly, we want to test for this property (can't think of good test cases off the top of my head):

essentially, if there's an open/approved RR, we can't raise any more RR
