### PR TITLE
feat(dynamo db): integrate with dynamo db

### DIFF
--- a/microservices/site-launch/shared/types.ts
+++ b/microservices/site-launch/shared/types.ts
@@ -72,7 +72,7 @@ export function isSiteLaunchMessage(obj: unknown): obj is SiteLaunchMessage {
           message.status.state === "failure" ||
           message.status.state === "pending") &&
         typeof message.status.message === "string" &&
-        Object.values(SiteLaunchLambdaStatus).includes(
+        Object.keys(SiteLaunchLambdaStatus).includes(
           message.status.message as SiteLaunchLambdaStatus
         ))) &&
     (typeof message.statusMetadata === "undefined" ||

--- a/microservices/site-launch/shared/types.ts
+++ b/microservices/site-launch/shared/types.ts
@@ -40,7 +40,7 @@ export interface SiteLaunchMessage {
 }
 
 export function isSiteLaunchMessage(obj: unknown): obj is SiteLaunchMessage {
-  if (typeof obj !== "object" || obj === null) {
+  if (!obj) {
     return false
   }
 

--- a/microservices/site-launch/shared/types.ts
+++ b/microservices/site-launch/shared/types.ts
@@ -38,3 +38,44 @@ export interface SiteLaunchMessage {
   status?: SiteLaunchStatus
   statusMetadata?: string
 }
+
+export function isSiteLaunchMessage(obj: unknown): obj is SiteLaunchMessage {
+  if (typeof obj !== "object" || obj === null) {
+    return false
+  }
+
+  const message = obj as SiteLaunchMessage
+
+  return (
+    typeof message.repoName === "string" &&
+    typeof message.appId === "string" &&
+    typeof message.primaryDomainSource === "string" &&
+    typeof message.primaryDomainTarget === "string" &&
+    typeof message.domainValidationSource === "string" &&
+    typeof message.domainValidationTarget === "string" &&
+    typeof message.requestorEmail === "string" &&
+    typeof message.agencyEmail === "string" &&
+    (typeof message.githubRedirectionUrl === "undefined" ||
+      typeof message.githubRedirectionUrl === "string") &&
+    (typeof message.redirectionDomain === "undefined" ||
+      (Array.isArray(message.redirectionDomain) &&
+        message.redirectionDomain.every(
+          (rd) =>
+            typeof rd.source === "string" &&
+            typeof rd.target === "string" &&
+            typeof rd.type === "string"
+        ))) &&
+    (typeof message.status === "undefined" ||
+      (typeof message.status === "object" &&
+        typeof message.status.state === "string" &&
+        (message.status.state === "success" ||
+          message.status.state === "failure" ||
+          message.status.state === "pending") &&
+        typeof message.status.message === "string" &&
+        Object.values(SiteLaunchLambdaStatus).includes(
+          message.status.message as SiteLaunchLambdaStatus
+        ))) &&
+    (typeof message.statusMetadata === "undefined" ||
+      typeof message.statusMetadata === "string")
+  )
+}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -201,9 +201,9 @@ const config = convict({
         format: "required-string",
         default: "",
       },
-      areQueuesDeprecated: {
+      ffDeprecateSiteQueues: {
         doc: "Whether the queues are deprecated",
-        env: "ARE_QUEUES_DEPRECATED",
+        env: "FF_DEPRECATE_SITE_QUEUES",
         format: "required-boolean",
         default: false,
       },

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -185,7 +185,7 @@ const config = convict({
         doc: "Amazon Resource Name (ARN) of the Step Functions state machine",
         env: "STEP_FUNCTIONS_ARN",
         format: "required-string",
-        default: "",
+        default: "SiteLaunchStepFunctions-dev",
       },
     },
     sqs: {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -180,6 +180,14 @@ const config = convict({
         default: "site-launch",
       },
     },
+    stepFunctions: {
+      stepFunctionsArn: {
+        doc: "Amazon Resource Name (ARN) of the Step Functions state machine",
+        env: "STEP_FUNCTIONS_ARN",
+        format: "required-string",
+        default: "",
+      },
+    },
     sqs: {
       incomingQueueUrl: {
         doc: "URL of the incoming SQS queue",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -137,13 +137,13 @@ const config = convict({
     },
   },
   aws: {
+    region: {
+      doc: "AWS region",
+      env: "AWS_REGION",
+      format: "required-string",
+      default: "ap-southeast-1",
+    },
     amplify: {
-      region: {
-        doc: "AWS region",
-        env: "AWS_REGION",
-        format: "required-string",
-        default: "ap-southeast-1",
-      },
       accountNumber: {
         doc: "AWS account number (microservices)",
         env: "AWS_ACCOUNT_NUMBER",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -201,7 +201,7 @@ const config = convict({
         format: "required-string",
         default: "",
       },
-      featureFlag: {
+      featureFlags: {
         shouldDeprecateSiteQueues: {
           doc: "Whether the queues are deprecated",
           env: "FF_DEPRECATE_SITE_QUEUES",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -201,6 +201,12 @@ const config = convict({
         format: "required-string",
         default: "",
       },
+      areQueuesDeprecated: {
+        doc: "Whether the queues are deprecated",
+        env: "ARE_QUEUES_DEPRECATED",
+        format: "required-boolean",
+        default: false,
+      },
     },
   },
   github: {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -201,11 +201,13 @@ const config = convict({
         format: "required-string",
         default: "",
       },
-      ffDeprecateSiteQueues: {
-        doc: "Whether the queues are deprecated",
-        env: "FF_DEPRECATE_SITE_QUEUES",
-        format: "required-boolean",
-        default: false,
+      featureFlag: {
+        shouldDeprecateSiteQueues: {
+          doc: "Whether the queues are deprecated",
+          env: "FF_DEPRECATE_SITE_QUEUES",
+          format: "required-boolean",
+          default: false,
+        },
       },
     },
   },

--- a/src/server.js
+++ b/src/server.js
@@ -209,7 +209,9 @@ const launchesService = new LaunchesService({
 })
 const queueService = new QueueService()
 const stepFunctionsService = new StepFunctionsService()
-const dynamoDBService = new DynamoDBService(new DynamoDBDocClient())
+const dynamoDBService = new DynamoDBService({
+  dynamoDBClient: new DynamoDBDocClient(),
+})
 
 const identityAuthService = getIdentityAuthService(gitHubService)
 const collaboratorsService = new CollaboratorsService({

--- a/src/server.js
+++ b/src/server.js
@@ -43,6 +43,7 @@ import { SubcollectionPageService } from "@root/services/fileServices/MdPageServ
 import { UnlinkedPageService } from "@root/services/fileServices/MdPageServices/UnlinkedPageService"
 import { CollectionYmlService } from "@root/services/fileServices/YmlFileServices/CollectionYmlService"
 import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/FooterYmlService"
+import DynamoDBService from "@root/services/infra/DynamoDBService"
 import { isomerRepoAxiosInstance } from "@services/api/AxiosInstance"
 import { ResourceRoomDirectoryService } from "@services/directoryServices/ResourceRoomDirectoryService"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
@@ -58,6 +59,7 @@ import ReposService from "@services/identity/ReposService"
 import SitesService from "@services/identity/SitesService"
 import InfraService from "@services/infra/InfraService"
 import { statsService } from "@services/infra/StatsService"
+import StepFunctionsService from "@services/infra/StepFunctionsService"
 import ReviewRequestService from "@services/review/ReviewRequestService"
 
 import { apiLogger } from "./middleware/apiLogger"
@@ -71,6 +73,7 @@ import { PageService } from "./services/fileServices/MdPageServices/PageService"
 import CollaboratorsService from "./services/identity/CollaboratorsService"
 import LaunchClient from "./services/identity/LaunchClient"
 import LaunchesService from "./services/identity/LaunchesService"
+import DynamoDBDocClient from "./services/infra/DynamoDBClient"
 import { rateLimiter } from "./services/utilServices/RateLimiter"
 import { isSecure } from "./utils/auth-utils"
 
@@ -205,6 +208,8 @@ const launchesService = new LaunchesService({
   launchClient,
 })
 const queueService = new QueueService()
+const stepFunctionsService = new StepFunctionsService()
+const dynamoDBService = new DynamoDBService(new DynamoDBDocClient())
 
 const identityAuthService = getIdentityAuthService(gitHubService)
 const collaboratorsService = new CollaboratorsService({
@@ -222,9 +227,11 @@ const infraService = new InfraService({
   launchesService,
   queueService,
   collaboratorsService,
+  stepFunctionsService,
+  dynamoDBService,
 })
-// poller for incoming queue
-infraService.pollQueue()
+// poller site launch updates
+infraService.pollMessages()
 
 const authenticationMiddleware = getAuthenticationMiddleware()
 const authorizationMiddleware = getAuthorizationMiddleware({

--- a/src/services/infra/DynamoDBClient.ts
+++ b/src/services/infra/DynamoDBClient.ts
@@ -1,15 +1,11 @@
-import { DynamoDBClient } from "@aws-sdk/client-dynamodb"
+import { DynamoDBClient, ScanCommandOutput } from "@aws-sdk/client-dynamodb"
 import {
   DynamoDBDocumentClient,
   PutCommand,
-  GetCommand,
-  UpdateCommand,
   DeleteCommand,
-  UpdateCommandInput,
   PutCommandOutput,
-  UpdateCommandOutput,
   DeleteCommandOutput,
-  GetCommandOutput,
+  ScanCommand,
 } from "@aws-sdk/lib-dynamodb"
 import autoBind from "auto-bind"
 
@@ -52,7 +48,7 @@ export default class DynamoDBDocClient {
 
   private withLogger = async <T>(
     promise: Promise<T>,
-    type: "create" | "get" | "delete" | "update"
+    type: "create" | "scan" | "delete" | "update"
   ): Promise<T> => {
     try {
       return await promise
@@ -82,38 +78,13 @@ export default class DynamoDBDocClient {
     )
   }
 
-  getItem = async (
-    tableName: string,
-    key: string
-  ): Promise<GetCommandOutput> => {
+  getAllItems = async (tableName: string): Promise<ScanCommandOutput> => {
     const params = {
       TableName: tableName,
-      Key: { appId: key },
-    }
-
-    return this.withLogger(
-      this.dynamoDBDocClient.send(new GetCommand(params)),
-      "get"
-    )
-  }
-
-  updateItem = async ({
-    TableName,
-    Key,
-    UpdateExpression,
-    ExpressionAttributeNames,
-    ExpressionAttributeValues,
-  }: UpdateParams): Promise<UpdateCommandOutput> => {
-    const params: UpdateCommandInput = {
-      TableName,
-      Key,
-      UpdateExpression,
-      ExpressionAttributeNames,
-      ExpressionAttributeValues,
     }
     return this.withLogger(
-      this.dynamoDBDocClient.send(new UpdateCommand(params)),
-      "update"
+      this.dynamoDBDocClient.send(new ScanCommand(params)),
+      "scan"
     )
   }
 

--- a/src/services/infra/DynamoDBClient.ts
+++ b/src/services/infra/DynamoDBClient.ts
@@ -39,7 +39,7 @@ export default class DynamoDBDocClient {
     }
 
     this.dynamoDBDocClient = DynamoDBDocumentClient.from(
-      new DynamoDBClient({ region: config.get("aws.amplify.region") }),
+      new DynamoDBClient({ region: config.get("aws.region") }),
       { marshallOptions, unmarshallOptions }
     )
 

--- a/src/services/infra/DynamoDBService.ts
+++ b/src/services/infra/DynamoDBService.ts
@@ -1,82 +1,45 @@
-import {
-  DeleteCommandOutput,
-  GetCommandOutput,
-  UpdateCommandOutput,
-} from "@aws-sdk/lib-dynamodb"
+import { DeleteCommandOutput } from "@aws-sdk/lib-dynamodb"
 import autoBind from "auto-bind"
 
 import { config } from "@config/config"
 
 import { SiteLaunchMessage } from "@root/../microservices/site-launch/shared/types"
 
-import DynamoDBClient, { UpdateParams } from "./DynamoDBClient"
+import DynamoDBClient from "./DynamoDBClient"
 
-const MOCK_LAUNCH: SiteLaunchMessage = {
-  repoName: "my-repo",
-  appId: "my-app",
-  primaryDomainSource: "example.com",
-  primaryDomainTarget: "myapp.example.com",
-  domainValidationSource: "example.com",
-  domainValidationTarget: "myapp.example.com",
-  requestorEmail: "john@example.com",
-  agencyEmail: "agency@example.com",
-  githubRedirectionUrl: "https://github.com/my-repo",
-  redirectionDomain: [
-    {
-      source: "example.com",
-      target: "myapp.example.com",
-      type: "A",
-    },
-  ],
-  status: { state: "pending", message: "PENDING_DURING_SITE_LAUNCH" },
-}
 export default class DynamoDBService {
   private readonly dynamoDBClient: DynamoDBClient
 
   private readonly TABLE_NAME: string
 
-  constructor() {
-    this.dynamoDBClient = new DynamoDBClient()
+  constructor(dynamoDBClient: DynamoDBClient) {
+    this.dynamoDBClient = dynamoDBClient
     this.TABLE_NAME = config.get("aws.dynamodb.siteLaunchTableName")
     autoBind(this)
   }
 
   async createItem(message: SiteLaunchMessage): Promise<void> {
-    await this.dynamoDBClient.createItem(this.TABLE_NAME, MOCK_LAUNCH)
+    await this.dynamoDBClient.createItem(this.TABLE_NAME, message)
   }
 
-  async getItem(message: SiteLaunchMessage): Promise<GetCommandOutput> {
-    return this.dynamoDBClient.getItem(this.TABLE_NAME, MOCK_LAUNCH.appId)
-  }
+  async getAllSuccessOrFailureLaunches(): Promise<SiteLaunchMessage[]> {
+    const entries = ((await this.dynamoDBClient.getAllItems(this.TABLE_NAME))
+      .Items as unknown) as SiteLaunchMessage[]
 
-  async updateItem(message: SiteLaunchMessage): Promise<UpdateCommandOutput> {
-    // TODO: delete mocking after integration in IS-186
-    MOCK_LAUNCH.status = { state: "success", message: "SUCCESS_SITE_LIVE" }
-    const updateParams: UpdateParams = {
-      TableName: this.TABLE_NAME,
-      Key: { appId: MOCK_LAUNCH.appId },
-      // The update expression to apply to the item,
-      // in this case setting the "status" attribute to a value
-      UpdateExpression:
-        "set #status.#state = :state, #status.#message = :message",
-      ExpressionAttributeNames: {
-        "#status": "status",
-        "#state": "state",
-        "#message": "message",
-      },
-      // A map of expression attribute values used in the update expression,
-      // in this case mapping ":state" to the value of the Launch status state and ":message" to the value of the Launch status message
-      ExpressionAttributeValues: {
-        ":state": MOCK_LAUNCH.status.state,
-        ":message": MOCK_LAUNCH.status.message,
-      },
-    }
-    return this.dynamoDBClient.updateItem(updateParams)
+    const successEntries =
+      entries?.filter(
+        (entry) =>
+          entry.status?.state === "success" || entry.status?.state === "failure"
+      ) || []
+
+    // Delete after retrieving the items
+    Promise.all(successEntries.map((entry) => this.deleteItem(entry)))
+    return successEntries
   }
 
   async deleteItem(message: SiteLaunchMessage): Promise<DeleteCommandOutput> {
     return this.dynamoDBClient.deleteItem(this.TABLE_NAME, {
-      appId: MOCK_LAUNCH.appId,
+      appId: message.appId,
     })
   }
 }

--- a/src/services/infra/DynamoDBService.ts
+++ b/src/services/infra/DynamoDBService.ts
@@ -22,7 +22,7 @@ export default class DynamoDBService {
     await this.dynamoDBClient.createItem(this.TABLE_NAME, message)
   }
 
-  async getAllSuccessOrFailureLaunches(): Promise<SiteLaunchMessage[]> {
+  async getAllCompletedLaunches(): Promise<SiteLaunchMessage[]> {
     const entries = ((await this.dynamoDBClient.getAllItems(this.TABLE_NAME))
       .Items as unknown) as SiteLaunchMessage[]
 

--- a/src/services/infra/DynamoDBService.ts
+++ b/src/services/infra/DynamoDBService.ts
@@ -16,9 +16,15 @@ export default class DynamoDBService {
 
   private readonly TABLE_NAME: string
 
-  constructor(dynamoDBClient: DynamoDBClient) {
+  constructor({
+    dynamoDBClient,
+    dynamoDbTableName = config.get("aws.dynamodb.siteLaunchTableName"),
+  }: {
+    dynamoDBClient: DynamoDBClient
+    dynamoDbTableName?: string
+  }) {
     this.dynamoDBClient = dynamoDBClient
-    this.TABLE_NAME = config.get("aws.dynamodb.siteLaunchTableName")
+    this.TABLE_NAME = dynamoDbTableName
     autoBind(this)
   }
 

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -54,7 +54,7 @@ type CreateSiteParams = {
   isEmailLogin: boolean
 }
 
-const ARE_QUEUES_DEPRECIATED = false
+const ARE_QUEUES_DEPRECATED = config.get("aws.sqs.areQueuesDeprecated")
 export default class InfraService {
   private readonly sitesService: InfraServiceProps["sitesService"]
 
@@ -384,7 +384,7 @@ export default class InfraService {
         message.redirectionDomain = [redirectionDomainObject]
       }
 
-      if (ARE_QUEUES_DEPRECIATED) {
+      if (ARE_QUEUES_DEPRECATED) {
         this.dynamoDBService.createItem(message)
         this.stepFunctionsService.triggerFlow(message)
       } else {
@@ -402,8 +402,8 @@ export default class InfraService {
   }
 
   siteUpdate = async () => {
-    const messages = ARE_QUEUES_DEPRECIATED
-      ? await this.dynamoDBService.getAllSuccessOrFailureLaunches()
+    const messages = ARE_QUEUES_DEPRECATED
+      ? await this.dynamoDBService.getAllCompletedLaunches()
       : await this.queueService.pollMessages()
     await Promise.all(
       messages.map(async (message) => {

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -55,7 +55,7 @@ type CreateSiteParams = {
 }
 
 const DEPRECATE_SITE_QUEUES = config.get(
-  "aws.sqs.featureFlag.shouldDeprecateSiteQueues"
+  "aws.sqs.featureFlags.shouldDeprecateSiteQueues"
 )
 export default class InfraService {
   private readonly sitesService: InfraServiceProps["sitesService"]

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -387,10 +387,10 @@ export default class InfraService {
       }
 
       if (DEPRECATE_SITE_QUEUES) {
-        this.dynamoDBService.createItem(message)
-        this.stepFunctionsService.triggerFlow(message)
+        await this.dynamoDBService.createItem(message)
+        await this.stepFunctionsService.triggerFlow(message)
       } else {
-        this.queueService.sendMessage(message)
+        await this.queueService.sendMessage(message)
       }
       return okAsync(newLaunchParams)
     } catch (error) {

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -54,7 +54,9 @@ type CreateSiteParams = {
   isEmailLogin: boolean
 }
 
-const DEPRECATE_SITE_QUEUES = config.get("aws.sqs.ffDeprecateSiteQueues")
+const DEPRECATE_SITE_QUEUES = config.get(
+  "aws.sqs.featureFlag.shouldDeprecateSiteQueues"
+)
 export default class InfraService {
   private readonly sitesService: InfraServiceProps["sitesService"]
 

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -54,7 +54,7 @@ type CreateSiteParams = {
   isEmailLogin: boolean
 }
 
-const ARE_QUEUES_DEPRECATED = config.get("aws.sqs.areQueuesDeprecated")
+const DEPRECATE_SITE_QUEUES = config.get("aws.sqs.ffDeprecateSiteQueues")
 export default class InfraService {
   private readonly sitesService: InfraServiceProps["sitesService"]
 
@@ -384,7 +384,7 @@ export default class InfraService {
         message.redirectionDomain = [redirectionDomainObject]
       }
 
-      if (ARE_QUEUES_DEPRECATED) {
+      if (DEPRECATE_SITE_QUEUES) {
         this.dynamoDBService.createItem(message)
         this.stepFunctionsService.triggerFlow(message)
       } else {
@@ -402,7 +402,7 @@ export default class InfraService {
   }
 
   siteUpdate = async () => {
-    const messages = ARE_QUEUES_DEPRECATED
+    const messages = DEPRECATE_SITE_QUEUES
       ? await this.dynamoDBService.getAllCompletedLaunches()
       : await this.queueService.pollMessages()
     await Promise.all(

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -54,7 +54,7 @@ type CreateSiteParams = {
   isEmailLogin: boolean
 }
 
-const ARE_QUEUES_DEPRECIATED = true
+const ARE_QUEUES_DEPRECIATED = false
 export default class InfraService {
   private readonly sitesService: InfraServiceProps["sitesService"]
 

--- a/src/services/infra/StepFunctionsService.ts
+++ b/src/services/infra/StepFunctionsService.ts
@@ -1,12 +1,14 @@
 import { StepFunctions } from "aws-sdk"
 
+import config from "@root/config/config"
+
 import { SiteLaunchMessage } from "../../../microservices/site-launch/shared/types"
 
 export default class StepFunctionsService {
   private client: StepFunctions
 
   constructor(private stateMachineArn: string) {
-    this.client = new StepFunctions({ region: "ap-southeast-1" })
+    this.client = new StepFunctions({ region: config.get("aws.region") })
   }
 
   async triggerFlow(

--- a/src/services/infra/StepFunctionsService.ts
+++ b/src/services/infra/StepFunctionsService.ts
@@ -1,0 +1,22 @@
+import { StepFunctions } from "aws-sdk"
+
+import { SiteLaunchMessage } from "../../../microservices/site-launch/shared/types"
+
+export default class StepFunctionsService {
+  private client: StepFunctions
+
+  constructor(private stateMachineArn: string) {
+    this.client = new StepFunctions({ region: "ap-southeast-1" })
+  }
+
+  async triggerFlow(
+    message: SiteLaunchMessage
+  ): Promise<StepFunctions.StartExecutionOutput> {
+    const params: StepFunctions.StartExecutionInput = {
+      stateMachineArn: this.stateMachineArn,
+      input: JSON.stringify(message),
+    }
+    const response = await this.client.startExecution(params).promise()
+    return response
+  }
+}

--- a/src/services/infra/__tests__/DynamoDBService.spec.ts
+++ b/src/services/infra/__tests__/DynamoDBService.spec.ts
@@ -50,7 +50,7 @@ const mockDynamoDBClient = {
 }
 
 const dynamoDBClient = (mockDynamoDBClient as unknown) as DynamoDBClient
-const dynamoDBService = new DynamoDBService(dynamoDBClient)
+const dynamoDBService = new DynamoDBService({ dynamoDBClient })
 
 const spyDynamoDBService = {
   deleteItem: jest.spyOn(dynamoDBService, "deleteItem"),

--- a/src/services/infra/__tests__/DynamoDBService.spec.ts
+++ b/src/services/infra/__tests__/DynamoDBService.spec.ts
@@ -1,0 +1,100 @@
+import { ScanCommandOutput } from "@aws-sdk/lib-dynamodb"
+
+import { SiteLaunchMessage } from "@root/../microservices/site-launch/shared/types"
+import DynamoDBClient from "@services/infra/DynamoDBClient"
+import DynamoDBService from "@services/infra/DynamoDBService"
+
+jest.mock("@services/infra/DynamoDBClient")
+
+const mockLaunch: SiteLaunchMessage = {
+  repoName: "my-repo",
+  appId: "my-app",
+  primaryDomainSource: "example.com",
+  primaryDomainTarget: "myapp.example.com",
+  domainValidationSource: "example.com",
+  domainValidationTarget: "myapp.example.com",
+  requestorEmail: "john@example.com",
+  agencyEmail: "agency@example.com",
+  githubRedirectionUrl: "https://github.com/my-repo",
+  redirectionDomain: [
+    {
+      source: "example.com",
+      target: "myapp.example.com",
+      type: "A",
+    },
+  ],
+  status: { state: "pending", message: "PENDING_DURING_SITE_LAUNCH" },
+}
+
+const mockSuccessLaunch: SiteLaunchMessage = {
+  ...mockLaunch,
+  appId: "success-app-id",
+  status: { state: "success", message: "SUCCESS_SITE_LIVE" },
+}
+
+const mockFailureLaunch: SiteLaunchMessage = {
+  ...mockLaunch,
+  appId: "failure-app-id",
+  status: {
+    state: "failure",
+    message: "FAILURE_WRONG_CLOUDFRONT_DISTRIBUTION",
+  },
+}
+
+const tableName = "site-launch"
+const mockDynamoDBClient = {
+  createItem: jest.fn(),
+  getAllItems: jest.fn(),
+  deleteItem: jest.fn(),
+  withLogger: jest.fn(),
+}
+
+const dynamoDBClient = (mockDynamoDBClient as unknown) as DynamoDBClient
+const dynamoDBService = new DynamoDBService(dynamoDBClient)
+
+const spyDynamoDBService = {
+  deleteItem: jest.spyOn(dynamoDBService, "deleteItem"),
+}
+describe("DynamoDBService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  describe("createItem", () => {
+    it("should call the createItem method of the DynamoDBClient with the correct arguments", async () => {
+      await dynamoDBService.createItem(mockLaunch)
+      expect(dynamoDBClient.createItem).toHaveBeenCalledWith(
+        tableName,
+        mockLaunch
+      )
+    })
+  })
+
+  describe("getAllSuccessOrFailureLaunches", () => {
+    it("should call the getAllItems method of the DynamoDBClient with the correct arguments", async () => {
+      const scanCommandOutput: ScanCommandOutput = {
+        $metadata: { httpStatusCode: 200 },
+        Items: [mockSuccessLaunch, mockLaunch, mockFailureLaunch],
+      }
+      mockDynamoDBClient.getAllItems.mockReturnValueOnce(scanCommandOutput)
+      const result: SiteLaunchMessage[] = await dynamoDBService.getAllSuccessOrFailureLaunches()
+      expect(dynamoDBClient.getAllItems).toHaveBeenCalledWith(tableName)
+      expect(spyDynamoDBService.deleteItem).toHaveBeenCalledWith(
+        mockSuccessLaunch
+      )
+      expect(spyDynamoDBService.deleteItem).toHaveBeenCalledWith(
+        mockFailureLaunch
+      )
+      expect(result).toEqual([mockSuccessLaunch, mockFailureLaunch])
+    })
+  })
+
+  describe("deleteItem", () => {
+    it("should call the deleteItem method of the DynamoDBClient with the correct arguments", async () => {
+      await dynamoDBService.deleteItem(mockLaunch)
+      expect(dynamoDBClient.deleteItem).toHaveBeenCalledWith(tableName, {
+        appId: "my-app",
+      })
+      expect(dynamoDBClient.deleteItem).not.toThrow()
+    })
+  })
+})

--- a/src/services/infra/__tests__/DynamoDBService.spec.ts
+++ b/src/services/infra/__tests__/DynamoDBService.spec.ts
@@ -76,7 +76,7 @@ describe("DynamoDBService", () => {
         Items: [mockSuccessLaunch, mockLaunch, mockFailureLaunch],
       }
       mockDynamoDBClient.getAllItems.mockReturnValueOnce(scanCommandOutput)
-      const result: SiteLaunchMessage[] = await dynamoDBService.getAllSuccessOrFailureLaunches()
+      const result: SiteLaunchMessage[] = await dynamoDBService.getAllCompletedLaunches()
       expect(dynamoDBClient.getAllItems).toHaveBeenCalledWith(tableName)
       expect(spyDynamoDBService.deleteItem).toHaveBeenCalledWith(
         mockSuccessLaunch


### PR DESCRIPTION
## Problem

This is the first PR in the effort to remove the usage of queues in our backend. 

Doesn't fully close IS-186, but am putting a feature flag in the spirit of merging some work into prod first. 

## Solution

The flag `ARE_QUEUES_DEPRECIATED` in `InfraService.ts` will determine whether or not to use the existing queues or use the dynamodbs vs queues for the site launch process. Idea is after the integration work in the infra side + enough testing, we can swap swap the value of the flag for one site launch process, and then if there are no issues for a while in production, we can remove this feature flag + queues related code altogether. 


**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

**Reviewer Notes**
I am not sure if its only me but the typing given in the AWS SDK for dynamo DB is abit off ._. 
I have given a screenshot in the related comment below + added test cases to explicitly codify the expected behaviour that we expect from the `dynamoDBDocClient.send(new ScanCommand(params))` call. Open to feedback on this. 

*Steps to replicate the error thrown by ts* 

1. Add this code in `server.js`:
```
import DynamoDBService from "@root/services/infra/DynamoDBService"
const dynamoDbService = new DynamoDBService(new DynamoDBDocClient())
const dynamoDBTests = async () => {
  // put item in dynamoDb
  const createResult = await dynamoDbService.createItem({
    repoName: "my-repo",
    appId: "my-app",
    primaryDomainSource: "example.com",
    primaryDomainTarget: "myapp.example.com",
    domainValidationSource: "example.com",
    domainValidationTarget: "myapp.example.com",
    requestorEmail: "john@example.com",
    agencyEmail: "agency@example.com",
    githubRedirectionUrl: "https://github.com/my-repo",
    redirectionDomain: [
      {
        source: "example.com",
        target: "myapp.example.com",
        type: "A",
      },
    ],
    status: { state: "pending", message: "PENDING_DURING_SITE_LAUNCH" },
  })

  const updateResult = await dynamoDbService.getAllCompletedLaunches()
  console.log("result: ", updateResult.$metadata.httpStatusCode)
  // delete item from dynamoDB
}
dynamoDBTests()
  .then(() => {
    logger.info("Successfully connected to DynamoDB")
  })
  .catch((err) => {
    logger.error(`Unable to connect to DynamoDB: ${err}`)
  })

```
2. Log over the returned entry in DynamoDBService.ts
```
async getAllCompletedLaunches(): Promise<SiteLaunchMessage[]> {
    const entries = ((await this.dynamoDBClient.getAllItems(this.TABLE_NAME))
      .Items as unknown) as SiteLaunchMessage[]
    const entriesWithSDKTypeCast : Record<string, AttributeValue>[] | undefined= (
      await this.dynamoDBClient.getAllItems(this.TABLE_NAME)
    ).Items

    console.log("entries", entries)
    console.log("entriesWithSDKTypeCast", entriesWithSDKTypeCast)
```

Note that the returned object is not of the declared type `Record<string, AttributeValue>[] | undefined`
<img width="509" alt="Screenshot 2023-05-22 at 9 25 28 AM" src="https://github.com/isomerpages/isomercms-backend/assets/42832651/2f06b1c4-9e47-4987-b0bf-cfc1d9e64414">



**New environment variables**:

- `STEP_FUNCTIONS_ARN` : arn for step functions //todo add in 1pw post-approval of this PR
- ARE_QUEUES_DEPRECATED: Whether the queues are deprecated //todo add in 1pw post-approval of this PR

**Tests**

added a file `DynamoDBService.spec.ts` for tests 