### PR TITLE
fix(headerinterpreter): use custom interpreter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "bcrypt": "^5.1.0",
         "bluebird": "^3.7.2",
         "body-parser": "^1.19.2",
+        "cache-parser": "^1.2.4",
         "cloudmersive-virus-api-client": "^1.2.7",
         "connect-session-sequelize": "^7.1.5",
         "convict": "^6.2.4",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "bcrypt": "^5.1.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.2",
+    "cache-parser": "^1.2.4",
     "cloudmersive-virus-api-client": "^1.2.7",
     "connect-session-sequelize": "^7.1.5",
     "convict": "^6.2.4",

--- a/src/services/api/AxiosInstance.ts
+++ b/src/services/api/AxiosInstance.ts
@@ -29,6 +29,7 @@ const requestFormatter = async (axiosConfig: AxiosRequestConfig) => {
   if (isEmailLoginUser) {
     const accessToken = await getAccessToken()
     axiosConfig.headers = {
+      ...(axiosConfig.headers ?? {}),
       Authorization: `token ${accessToken}`,
     }
     tracer.use("http", {

--- a/src/services/api/AxiosInstance.ts
+++ b/src/services/api/AxiosInstance.ts
@@ -8,6 +8,8 @@ import logger from "@logger/logger"
 import { getAccessToken } from "@utils/token-retrieval-utils"
 import tracer from "@utils/tracer"
 
+import { headerInterpreter } from "@root/utils/headerInterpreter"
+
 // Env vars
 const GITHUB_ORG_NAME = config.get("github.orgName")
 
@@ -79,6 +81,7 @@ const isomerRepoAxiosInstance = setupCache(
   {
     interpretHeader: true,
     etag: true,
+    headerInterpreter,
   }
 )
 isomerRepoAxiosInstance.interceptors.request.use(requestFormatter)

--- a/src/services/api/AxiosInstance.ts
+++ b/src/services/api/AxiosInstance.ts
@@ -8,7 +8,7 @@ import logger from "@logger/logger"
 import { getAccessToken } from "@utils/token-retrieval-utils"
 import tracer from "@utils/tracer"
 
-import { headerInterpreter } from "@root/utils/headerInterpreter"
+import { customHeaderInterpreter } from "@root/utils/headerInterpreter"
 
 // Env vars
 const GITHUB_ORG_NAME = config.get("github.orgName")
@@ -81,7 +81,7 @@ const isomerRepoAxiosInstance = setupCache(
   {
     interpretHeader: true,
     etag: true,
-    headerInterpreter,
+    headerInterpreter: customHeaderInterpreter,
   }
 )
 isomerRepoAxiosInstance.interceptors.request.use(requestFormatter)

--- a/src/utils/headerInterpreter.ts
+++ b/src/utils/headerInterpreter.ts
@@ -1,0 +1,47 @@
+import { Header, HeadersInterpreter } from "axios-cache-interceptor"
+import { parse } from "cache-parser"
+
+// NOTE: Taken with reference to https://github.com/arthurfiorette/axios-cache-interceptor/blob/v0.9.2/src/header/interpreter.ts
+// The change made is to remove the `maxAge` condition, which is not suitable because
+// we want to revalidate on update.
+// An alternative is to invalidate the cache on `update` but
+// this requires an exhaustive search through our codebase.
+// This incurs an extra network call on every update, which is not ideal but in 304
+// this is an empty request.
+// eslint-disable-next-line import/prefer-default-export
+export const headerInterpreter: HeadersInterpreter = (headers) => {
+  if (!headers) return "not enough headers"
+
+  const cacheControl = headers[Header.CacheControl]
+
+  if (cacheControl) {
+    const { noCache, noStore, mustRevalidate, maxAge, immutable } = parse(
+      String(cacheControl)
+    )
+
+    // Header told that this response should not be cached.
+    if (noCache || noStore) {
+      return "dont cache"
+    }
+
+    if (immutable) {
+      // 1 year is sufficient, as Infinity may cause more problems.
+      // It might not be the best way, but a year is better than none.
+      return 1000 * 60 * 60 * 24 * 365
+    }
+
+    // Already out of date, for cache can be saved, but must be requested again
+    if (mustRevalidate || maxAge) {
+      return 0
+    }
+  }
+
+  const expires = headers[Header.Expires]
+
+  if (expires) {
+    const milliseconds = Date.parse(String(expires)) - Date.now()
+    return milliseconds >= 0 ? milliseconds : "dont cache"
+  }
+
+  return "not enough headers"
+}

--- a/src/utils/headerInterpreter.ts
+++ b/src/utils/headerInterpreter.ts
@@ -9,7 +9,7 @@ import { parse } from "cache-parser"
 // This incurs an extra network call on every update, which is not ideal but in 304
 // this is an empty request.
 // eslint-disable-next-line import/prefer-default-export
-export const headerInterpreter: HeadersInterpreter = (headers) => {
+export const customHeaderInterpreter: HeadersInterpreter = (headers) => {
   if (!headers) return "not enough headers"
 
   const cacheControl = headers[Header.CacheControl]


### PR DESCRIPTION
## Problem
Currently, Isomer uses a huge amount of tokens due to not caching. This leads to scaling issue, where our github token limits are quickly reached and users are unable to access the CMS.

Closes [IS-172]

## Solution
1. use an external package `axios-cache-interceptor` to utilise ETags for cache. See [here](https://www.notion.so/opengov/A-brief-primer-on-ETags-94669d1abed44dcbb02ee0ffc36d0a7d?pvs=4) for info on etags. 
    - note that this is using **in memory** storage. the implications are that: we could potentially have some requests that **could be cached** but are not (current ETag value is 1 -> user A edits -> ETag value now 2 -> other instance doesn't knows -> queries from other instance -> ETag value updated)
    - potential for stale reads - github will tell us if the old etag value is outdated or not (ie, return 200) and the time to live (ttl) of the response using the `maxAge` header ((in this case, 60s) but we have opted to remove this behaviour and revalidate. this is to avoid github returning 409s when we attempt to update using the old `sha`
    - usage of a custom `headerInterpreter` - the change made compared to the default one is that we don't use the `maxAge` property on the request and instead default to a `mustRevalidate` behaviour

## Tests
1. first, add a `console.log` for `remainingRequests` into `respHandler` for `AxiosInstance.ts`, so that we know how much requests are remaining 
3. next, issue a `GET` request to the `e2e-test-repo`'s homepage (`curl --request GET \
  --url http://localhost:8081/v2/sites/e2e-test-repo/homepage`) 
4. observe the # of requests remaining. 
5. repeat steps 2-3; the # of requests remaining should be **unchanged**
6. make an edit on the [homepage](https://github.com/isomerpages/e2e-test-repo/blob/staging/index.md) 
7. repeat steps 2-3, the # of requests should **decrease**
8. update the page **again**
9. do steps 2-3, the request should succeed and the # of requests should **decrease**
10. wait for 60s and reload the page 
11. the request should succeed and the # of requests should **stay constant**

**New dependencies**:
- `axios-cache-interceptor` : interceptor for axios to use etags. the current backing storage is in memory.

**Deploy notes**
1. `axios` got upgraded from `0.21.x` to `0.25.0` 
    - list of breaking changes here 
    - went through most of [them](https://github.com/axios/axios/blob/main/CHANGELOG.md#0250-january-18-2022), mostly typing changes. 
2. had to use `0.9.2` as a minimum for `axios-cache-interceptor`
    - see compat chart [here](https://axios-cache-interceptor.js.org/v0/guide/getting-started)
    - this is because of 2 reasons - `ETag` functionality only added in `0.6` + their import for `object-code` is an outdated one, which doesn't get fixed till `0.9.2`. 

[IS-172]: https://isomeropengov.atlassian.net/browse/IS-172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ