### PR TITLE
Fix/facebook pixel

### DIFF
--- a/src/fixtures/config.js
+++ b/src/fixtures/config.js
@@ -54,7 +54,7 @@ prod: https://e2e-test-repo-prod.netlify.app
 resources_name: resources
 is_government: false
 shareicon: /images/isomer-logo.svg
-facebook-pixel: 12345
+facebook-pixel: "12345"
 google_analytics: UA-39345131-33
 google_analytics_ga4: GA-test
 linkedin-insights: "12345"
@@ -111,7 +111,7 @@ const configContent = {
   resources_name: "resources",
   is_government: false,
   shareicon: "/images/isomer-logo.svg",
-  "facebook-pixel": 12345,
+  "facebook-pixel": "12345",
   google_analytics: "UA-39345131-33",
   google_analytics_ga4: "GA-test",
   "linkedin-insights": "12345",

--- a/src/fixtures/config.js
+++ b/src/fixtures/config.js
@@ -54,7 +54,7 @@ prod: https://e2e-test-repo-prod.netlify.app
 resources_name: resources
 is_government: false
 shareicon: /images/isomer-logo.svg
-facebook-pixel: "12345"
+facebook-pixel: "123456789012345"
 google_analytics: UA-39345131-33
 google_analytics_ga4: GA-test
 linkedin-insights: "12345"
@@ -111,7 +111,7 @@ const configContent = {
   resources_name: "resources",
   is_government: false,
   shareicon: "/images/isomer-logo.svg",
-  "facebook-pixel": "12345",
+  "facebook-pixel": "123456789012345",
   google_analytics: "UA-39345131-33",
   google_analytics_ga4: "GA-test",
   "linkedin-insights": "12345",

--- a/src/fixtures/config.js
+++ b/src/fixtures/config.js
@@ -54,7 +54,7 @@ prod: https://e2e-test-repo-prod.netlify.app
 resources_name: resources
 is_government: false
 shareicon: /images/isomer-logo.svg
-facebook-pixel: "true"
+facebook-pixel: 12345
 google_analytics: UA-39345131-33
 google_analytics_ga4: GA-test
 linkedin-insights: "12345"
@@ -111,7 +111,7 @@ const configContent = {
   resources_name: "resources",
   is_government: false,
   shareicon: "/images/isomer-logo.svg",
-  "facebook-pixel": "true",
+  "facebook-pixel": 12345,
   google_analytics: "UA-39345131-33",
   google_analytics_ga4: "GA-test",
   "linkedin-insights": "12345",

--- a/src/routes/v2/authenticatedSites/__tests__/Settings.spec.js
+++ b/src/routes/v2/authenticatedSites/__tests__/Settings.spec.js
@@ -92,7 +92,10 @@ describe("Settings Router", () => {
       homepage,
     })
 
-    const updatedFbPixelValue = `${configContent["facebook-pixel"]}test`
+    const updatedFbPixelValue = parseInt(
+      `${configContent["facebook-pixel"]}0`,
+      10
+    )
     const updatedTitleValue = `${configContent.title}test`
     const updatedFaq = `${footerContent.faq}test`
     const updatedLogo = `${navigationContent.logo}test`

--- a/src/routes/v2/authenticatedSites/__tests__/Settings.spec.js
+++ b/src/routes/v2/authenticatedSites/__tests__/Settings.spec.js
@@ -92,10 +92,7 @@ describe("Settings Router", () => {
       homepage,
     })
 
-    const updatedFbPixelValue = parseInt(
-      `${configContent["facebook-pixel"]}0`,
-      10
-    )
+    const updatedFbPixelValue = `${configContent["facebook-pixel"]}0`
     const updatedTitleValue = `${configContent.title}test`
     const updatedFaq = `${footerContent.faq}test`
     const updatedLogo = `${navigationContent.logo}test`

--- a/src/routes/v2/authenticatedSites/__tests__/Settings.spec.js
+++ b/src/routes/v2/authenticatedSites/__tests__/Settings.spec.js
@@ -92,7 +92,7 @@ describe("Settings Router", () => {
       homepage,
     })
 
-    const updatedFbPixelValue = `${configContent["facebook-pixel"]}0`
+    const updatedFbPixelValue = `123456789012340`
     const updatedTitleValue = `${configContent.title}test`
     const updatedFaq = `${footerContent.faq}test`
     const updatedLogo = `${navigationContent.logo}test`

--- a/src/services/configServices/__tests__/SettingsService.spec.js
+++ b/src/services/configServices/__tests__/SettingsService.spec.js
@@ -97,7 +97,10 @@ describe("Settings Service", () => {
     mockNavYmlService.read.mockResolvedValue(navigation)
     mockHomepagePageService.read.mockResolvedValue(homepage)
 
-    const updatedFbPixelValue = `${configContent["facebook-pixel"]}test`
+    const updatedFbPixelValue = parseInt(
+      `${configContent["facebook-pixel"]}0`,
+      10
+    )
     const updatedTitleValue = `${configContent.title}test`
     const updatedDescriptionValue = `${configContent.description}test`
     const updatedFaq = `${footerContent.faq}test`

--- a/src/services/configServices/__tests__/SettingsService.spec.js
+++ b/src/services/configServices/__tests__/SettingsService.spec.js
@@ -97,7 +97,7 @@ describe("Settings Service", () => {
     mockNavYmlService.read.mockResolvedValue(navigation)
     mockHomepagePageService.read.mockResolvedValue(homepage)
 
-    const updatedFbPixelValue = `${configContent["facebook-pixel"]}0`
+    const updatedFbPixelValue = `123456789012340`
     const updatedTitleValue = `${configContent.title}test`
     const updatedDescriptionValue = `${configContent.description}test`
     const updatedFaq = `${footerContent.faq}test`

--- a/src/services/configServices/__tests__/SettingsService.spec.js
+++ b/src/services/configServices/__tests__/SettingsService.spec.js
@@ -97,10 +97,7 @@ describe("Settings Service", () => {
     mockNavYmlService.read.mockResolvedValue(navigation)
     mockHomepagePageService.read.mockResolvedValue(homepage)
 
-    const updatedFbPixelValue = parseInt(
-      `${configContent["facebook-pixel"]}0`,
-      10
-    )
+    const updatedFbPixelValue = `${configContent["facebook-pixel"]}0`
     const updatedTitleValue = `${configContent.title}test`
     const updatedDescriptionValue = `${configContent.description}test`
     const updatedFaq = `${footerContent.faq}test`

--- a/src/services/fileServices/YmlFileServices/ConfigYmlService.js
+++ b/src/services/fileServices/YmlFileServices/ConfigYmlService.js
@@ -20,10 +20,10 @@ class ConfigYmlService {
     const sanitisedContent = sanitizedYamlParse(unparsedContent)
     const sanitisedFacebookPixel =
       !!sanitisedContent["facebook-pixel"] &&
-      parseInt(sanitisedContent["facebook-pixel"], 10)
+      sanitisedContent["facebook-pixel"].toString()
     const content = {
       ...sanitisedContent,
-      "facebook-pixel": sanitisedFacebookPixel || null,
+      "facebook-pixel": sanitisedFacebookPixel || "",
     }
     return { content, sha }
   }

--- a/src/services/fileServices/YmlFileServices/ConfigYmlService.js
+++ b/src/services/fileServices/YmlFileServices/ConfigYmlService.js
@@ -19,7 +19,7 @@ class ConfigYmlService {
     )
     const sanitisedContent = sanitizedYamlParse(unparsedContent)
     const sanitisedFacebookPixel =
-      sanitisedContent["facebook-pixel"] &&
+      !!sanitisedContent["facebook-pixel"] &&
       parseInt(sanitisedContent["facebook-pixel"], 10)
     const content = {
       ...sanitisedContent,

--- a/src/services/fileServices/YmlFileServices/ConfigYmlService.js
+++ b/src/services/fileServices/YmlFileServices/ConfigYmlService.js
@@ -18,11 +18,12 @@ class ConfigYmlService {
       }
     )
     const sanitisedContent = sanitizedYamlParse(unparsedContent)
+    const sanitisedFacebookPixel =
+      sanitisedContent["facebook-pixel"] &&
+      parseInt(sanitisedContent["facebook-pixel"], 10)
     const content = {
       ...sanitisedContent,
-      "facebook-pixel": sanitisedContent["facebook-pixel"]
-        ? parseInt(sanitisedContent["facebook-pixel"], 10)
-        : null,
+      "facebook-pixel": sanitisedFacebookPixel || null,
     }
     return { content, sha }
   }

--- a/src/services/fileServices/YmlFileServices/ConfigYmlService.js
+++ b/src/services/fileServices/YmlFileServices/ConfigYmlService.js
@@ -17,7 +17,13 @@ class ConfigYmlService {
         fileName: CONFIG_FILE_NAME,
       }
     )
-    const content = sanitizedYamlParse(unparsedContent)
+    const sanitisedContent = sanitizedYamlParse(unparsedContent)
+    const content = {
+      ...sanitisedContent,
+      "facebook-pixel": sanitisedContent["facebook-pixel"]
+        ? parseInt(sanitisedContent["facebook-pixel"], 10)
+        : null,
+    }
     return { content, sha }
   }
 

--- a/src/types/configYml.ts
+++ b/src/types/configYml.ts
@@ -3,5 +3,5 @@ import { ProdPermalink, StagingPermalink } from "./pages"
 export type ConfigYmlData = {
   staging?: StagingPermalink
   prod?: ProdPermalink
-  "facebook-pixel": number | null
+  "facebook-pixel": string
 }

--- a/src/types/configYml.ts
+++ b/src/types/configYml.ts
@@ -3,4 +3,5 @@ import { ProdPermalink, StagingPermalink } from "./pages"
 export type ConfigYmlData = {
   staging?: StagingPermalink
   prod?: ProdPermalink
+  "facebook-pixel": number | null
 }

--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -249,7 +249,9 @@ const UpdateSettingsRequestSchema = Joi.object().keys({
     ),
   }),
   favicon: Joi.string(),
-  "facebook-pixel": Joi.string().allow(""),
+  "facebook-pixel": Joi.string()
+    .regex(/^[0-9]{15}$/)
+    .allow(""),
   google_analytics: Joi.string().allow(""),
   google_analytics_ga4: Joi.string().allow(""),
   "linkedin-insights": Joi.string().allow(""),

--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -249,7 +249,7 @@ const UpdateSettingsRequestSchema = Joi.object().keys({
     ),
   }),
   favicon: Joi.string(),
-  "facebook-pixel": Joi.string().allow(""),
+  "facebook-pixel": Joi.number().unsafe().allow(null),
   google_analytics: Joi.string().allow(""),
   google_analytics_ga4: Joi.string().allow(""),
   "linkedin-insights": Joi.string().allow(""),

--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -249,7 +249,7 @@ const UpdateSettingsRequestSchema = Joi.object().keys({
     ),
   }),
   favicon: Joi.string(),
-  "facebook-pixel": Joi.number().unsafe().allow(null),
+  "facebook-pixel": Joi.string().allow(""),
   google_analytics: Joi.string().allow(""),
   google_analytics_ga4: Joi.string().allow(""),
   "linkedin-insights": Joi.string().allow(""),


### PR DESCRIPTION
## Problem

This PR fixes an issue where users with facebook-pixel values (pre-cms) could not edit their settings page. The issue was that the facebook-pixel value is always a 15 digit number, and sites which edited via github would have entered it as such - we would thus be reading and attempting to write facebook-pixel values as a number, while our request schema specified a string.

The fix for this is to parse the value as a string on read, in order to account for users who may have inserted the `facebook-pixel` value as a number (e.g. `facebook-pixel: 12345`).

This PR is to be reviewed in conjunction with PR #[1282](https://github.com/isomerpages/isomercms-frontend/pull/1282) on the isomercms-frontend repo.