### PR TITLE
fix(directory): default to empty array

### DIFF
--- a/src/classes/Directory.js
+++ b/src/classes/Directory.js
@@ -107,9 +107,6 @@ class Directory {
         }
       })
 
-      console.log("===", filesOrDirs)
-      console.log("=== compacted", _.compact(filesOrDirs))
-
       return _.compact(filesOrDirs)
     }
 

--- a/src/classes/Directory.js
+++ b/src/classes/Directory.js
@@ -84,7 +84,7 @@ class Directory {
           `Path ${this.dirType.getFolderName()} was invalid!`
         )
       }
-      return {}
+      return []
     }
 
     if (this.dirType instanceof FolderType) {
@@ -106,6 +106,9 @@ class Directory {
           type,
         }
       })
+
+      console.log("===", filesOrDirs)
+      console.log("=== compacted", _.compact(filesOrDirs))
 
       return _.compact(filesOrDirs)
     }


### PR DESCRIPTION
## Problem
`Directory.list` can return an empty object. However, our frontend expects an empty array (it calls `val.map`), which causes it to crash on an empty object returned. 

## Solution
Change the default empty object return to empty array. this is safe because the call sites for `Directory.list` uses a `.reduce` with `[]` as the base acc, showing that they expect empty array (`<Collection | Subfolder>.js`). The callsite in `directory.js` also uses an empty array as the base if there's an error thrown during `.list` (this bug might appear there too). 

## Testing
- [ ] Deploy this branch to `staging` (or run it on local w/ your FE)
- [ ] go to `moe-cantonmenpri` 
- [ ] go to nav bar
- [ ] it should load successfully