### PR TITLE
fix(deploymentclient): fix config.get

### DIFF
--- a/src/services/identity/DeploymentClient.ts
+++ b/src/services/identity/DeploymentClient.ts
@@ -14,7 +14,7 @@ import { config } from "@config/config"
 
 import { AmplifyError } from "@root/types/index"
 
-const AWS_REGION = config.get("aws.amplify.region")
+const AWS_REGION = config.get("aws.region")
 const SYSTEM_GITHUB_TOKEN = config.get("github.systemToken")
 
 const AMPLIFY_BUILD_SPEC = `


### PR DESCRIPTION
## Problem
`DeploymentClient` was referring to `aws.amplify.region` which doesn't exist

## Solution
change to `aws.region`