### PR TITLE
Fix: make email lowercase

### DIFF
--- a/src/routes/formsgSiteCreation.ts
+++ b/src/routes/formsgSiteCreation.ts
@@ -89,6 +89,16 @@ export class FormsgRouter {
       }
       let foundOwner
       if (isEmailLogin) {
+        if (!ownerEmail) {
+          const err = `An owner email is required for email login`
+          await this.sendCreateError(
+            requesterEmail,
+            repoName,
+            submissionId,
+            err
+          )
+          return res.sendStatus(200)
+        }
         foundOwner = await this.usersService.findOrCreateByEmail(ownerEmail)
       }
       // 3. Use service to create site

--- a/src/routes/v2/authenticated/users.ts
+++ b/src/routes/v2/authenticated/users.ts
@@ -68,13 +68,14 @@ export class UsersRouter {
     const { email, otp } = req.body
     const { userSessionData } = res.locals
     const userId = userSessionData.isomerUserId
+    const parsedEmail = email.toLowerCase()
 
-    const isOtpValid = await this.usersService.verifyEmailOtp(email, otp)
+    const isOtpValid = await this.usersService.verifyEmailOtp(parsedEmail, otp)
     if (!isOtpValid) {
       throw new BadRequestError("Invalid OTP")
     }
 
-    await this.usersService.updateUserByIsomerId(userId, { email })
+    await this.usersService.updateUserByIsomerId(userId, { email: parsedEmail })
     res.sendStatus(200)
   }
 

--- a/src/services/identity/CollaboratorsService.ts
+++ b/src/services/identity/CollaboratorsService.ts
@@ -125,7 +125,12 @@ class CollaboratorsService {
     )
   }
 
-  create = async (siteName: string, email: string, acknowledged: boolean) => {
+  create = async (
+    siteName: string,
+    unparsedEmail: string,
+    acknowledged: boolean
+  ) => {
+    const email = unparsedEmail.toLowerCase()
     if (!email || !validator.isEmail(email)) {
       return new BadRequestError(
         "That doesn't look like a valid email. Try a gov.sg or other whitelisted email."

--- a/src/services/identity/UsersService.ts
+++ b/src/services/identity/UsersService.ts
@@ -168,7 +168,7 @@ class UsersService {
     return user
   }
 
-  async findOrCreateByEmail(email: string | undefined) {
+  async findOrCreateByEmail(email: string) {
     const parsedEmail = email.toLowerCase()
     const [user] = await this.repository.findOrCreate({
       where: { email: parsedEmail },


### PR DESCRIPTION
## Problem

This PR fixes an issue with our email verification process for github users. Previously, for users who were logging in via Github for the first time, they would need to verify and associate their email to their isomer user. However, this input was not parsed in any way, so users would be able to include capitalisation in their associated email. This caused issues when users later tried to login via email - as we forcefully lowercase the email in this case, users were no longer able to access their original isomer user and a new user was created for them instead.

In order to make our behaviour more consistent, we're opting to lowercase all references to email. We will also need to convert some existing isomer user entries - these users have multiple accounts mapped to the same email with a different casing, and we should ideally combine these users once this PR has been merged.

### Tests

- [ ] Create a fresh github user with no attached email user, and associate an email with capitalisation via the github login flow
  - [ ] Check that the user's associated email in the DB is in lowercase
- [ ] Go to a website with a different user in email login, and try to associate the email in the above step (but capitalised in places) - this should still work

### After merging
- [ ] Run through the list of user entries, and search for duplicate entries using ```SELECT id, email
FROM "users"
WHERE LOWER(TRIM(email)) IN 
(
SELECT LOWER(TRIM(email))
FROM "users"
GROUP BY LOWER(TRIM(email))
HAVING count(*) > 1
)``` - we should combine the users in this list and their associated sites