### PR TITLE
Fix: check if resources name is empty when creating new resource room

### DIFF
--- a/src/services/directoryServices/ResourceRoomDirectoryService.js
+++ b/src/services/directoryServices/ResourceRoomDirectoryService.js
@@ -51,7 +51,7 @@ class ResourceRoomDirectoryService {
       sessionData
     )
     // If resource room already exists, throw error
-    if ("resources_name" in configContent)
+    if ("resources_name" in configContent && configContent.resources_name)
       throw new ConflictError("Resource room already exists")
     configContent.resources_name = slugifiedResourceRoomName
     await this.configYmlService.update(sessionData, {


### PR DESCRIPTION
This PR fixes an issue where sites attempting to create a new resource room will fail if their `config.yml` has a `resource_room` param, even if it is blank. An additional check has been added to ensure that the param exists.