### PR TITLE
chore(aws region): shift from const -> env var

### DIFF
--- a/src/logger/cloudwatch.logger.ts
+++ b/src/logger/cloudwatch.logger.ts
@@ -3,7 +3,7 @@ import Bluebird from "bluebird"
 import winston from "winston"
 import WinstonCloudwatch from "winston-cloudwatch"
 
-import { config } from "@root/config/config"
+import { config } from "@config/config"
 
 import { consoleLogger } from "./console.logger"
 import { LogMethod, Loggable } from "./logger.types"

--- a/src/logger/cloudwatch.logger.ts
+++ b/src/logger/cloudwatch.logger.ts
@@ -3,6 +3,8 @@ import Bluebird from "bluebird"
 import winston from "winston"
 import WinstonCloudwatch from "winston-cloudwatch"
 
+import { config } from "@root/config/config"
+
 import { consoleLogger } from "./console.logger"
 import { LogMethod, Loggable } from "./logger.types"
 
@@ -15,7 +17,7 @@ const withConsoleError = (logFn: LogMethod) => (message: Loggable): void => {
 }
 
 // AWS
-const AWS_REGION_NAME = "ap-southeast-1"
+const AWS_REGION_NAME = config.get("aws.region")
 AWS.config.update({ region: AWS_REGION_NAME })
 const awsMetadata = new AWS.MetadataService()
 const metadataRequest = Bluebird.promisify<string, string>(

--- a/src/services/identity/LaunchClient.ts
+++ b/src/services/identity/LaunchClient.ts
@@ -49,7 +49,7 @@ class LaunchClient {
   private readonly mockDomainAssociations: Map<string, SubDomainSetting[]>
 
   constructor() {
-    const AWS_REGION = "ap-southeast-1"
+    const AWS_REGION = config.get("aws.region")
     this.amplifyClient = new AmplifyClient({
       region: AWS_REGION,
     })

--- a/src/utils/mutex-utils.js
+++ b/src/utils/mutex-utils.js
@@ -15,7 +15,7 @@ const IS_DEV = NODE_ENV === "dev" || NODE_ENV === "test" || NODE_ENV === "vapt"
 const mockMutexObj = {}
 
 // Dynamodb constants
-const AWS_REGION_NAME = "ap-southeast-1"
+const AWS_REGION_NAME = config.get("aws.region")
 AWS.config.update({ region: AWS_REGION_NAME })
 const docClient = new AWS.DynamoDB.DocumentClient()
 


### PR DESCRIPTION
## Problem
`AWS_REGION` was previously referred to as either `const` in code or env var. this streamlines it to getting it from env vars (through convict). 


## Solution
1. use `config.get(aws.region)`
    - `logger` in `microservices` not migrated due to it drawing in imports
