### PR TITLE
ci(ci): add build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,24 @@ jobs:
       - run: npm run lint-fix
       - run: npm run format-fix
 
+  build:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+      - name: Load Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+      - run: npm ci
+      - run: npm run build
+      
   test:
     needs: lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem
last time no `build` step so ts type errors can be ignored if no tests.

## Solution
1. add ci step for build
    - not doing `lint -> build -> test` but `lint -> test` and `lint -> build` because it's faster + we can test w/ failing builds if the tests don't touch the files that hte build fails on