### PR TITLE
fix(review): add empty string when 404

### DIFF
--- a/src/services/db/review.ts
+++ b/src/services/db/review.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from "axios"
 import _ from "lodash"
 
 import { config } from "@config/config"
@@ -147,5 +148,13 @@ export const getBlob = async (
       headers: {
         Accept: "application/vnd.github.raw",
       },
+    })
+    .catch((err: AxiosError) => {
+      // NOTE: This happens when either an existing file in a folder is deleted
+      // or when the file is newly created inside a folder.
+      // This means that the upstream ref either before/after does not exist
+      // and would lead to 404, so we return an empty string instead.
+      if (err.isAxiosError && err?.response?.status === 404) return { data: "" }
+      throw err
     })
     .then(({ data }) => data)


### PR DESCRIPTION
## Problem
Previously, when we were retrieving files from github, we ran into 404s under 2 conditions: 

1. file didn't exist previously (in `master`) but did now (in `staging`) 
2. file existed previously (in `master`) but doesn't now (in `staging`).

because we rely on a `GET` request to github for both of `staging/master`, under either 1 of the above conditions, we will get a 404 which will in turn translate into a 500 on our end. 

## Solution
1. This fixes the issue by adding a default empty string return when it is a 404 error
    - the case where the file didn't exist previously + didn't exist now means that it won't be raised for comparison anyway.