### PR TITLE
feat: introduce types for isomer error

### DIFF
--- a/src/errors/BaseError.ts
+++ b/src/errors/BaseError.ts
@@ -1,7 +1,11 @@
 import { IsomerInternalError } from "./IsomerError"
 
 class BaseIsomerError extends Error implements IsomerInternalError {
+  name: string
+
   status: number
+
+  message: string
 
   code = "BaseError"
 

--- a/src/errors/BaseError.ts
+++ b/src/errors/BaseError.ts
@@ -1,7 +1,11 @@
-class BaseIsomerError extends Error {
+import { IsomerInternalError } from "./IsomerError"
+
+class BaseIsomerError extends Error implements IsomerInternalError {
   status: number
 
-  isIsomerError: true
+  code = "BaseError"
+
+  isIsomerError = true
 
   constructor(status = 500, message = "Something went wrong") {
     super()
@@ -9,7 +13,6 @@ class BaseIsomerError extends Error {
     this.name = this.constructor.name
     this.status = status
     this.message = message
-    this.isIsomerError = true
   }
 }
 

--- a/src/errors/BaseError.ts
+++ b/src/errors/BaseError.ts
@@ -1,7 +1,7 @@
 class BaseIsomerError extends Error {
   status: number
 
-  isIsomerError: boolean
+  isIsomerError: true
 
   constructor(status = 500, message = "Something went wrong") {
     super()

--- a/src/errors/BaseError.ts
+++ b/src/errors/BaseError.ts
@@ -1,10 +1,14 @@
 class BaseIsomerError extends Error {
-  constructor(status, message) {
+  status: number
+
+  isIsomerError: boolean
+
+  constructor(status = 500, message = "Something went wrong") {
     super()
     Error.captureStackTrace(this, this.constructor)
     this.name = this.constructor.name
-    this.status = status || 500
-    this.message = message || "Something went wrong"
+    this.status = status
+    this.message = message
     this.isIsomerError = true
   }
 }
@@ -12,3 +16,5 @@ class BaseIsomerError extends Error {
 module.exports = {
   BaseIsomerError,
 }
+
+export { BaseIsomerError }

--- a/src/errors/IsomerError.ts
+++ b/src/errors/IsomerError.ts
@@ -1,0 +1,24 @@
+/* External representation of Isomer errors - passed to frontend client */
+export interface IsomerExternalError {
+  code: string
+  message: string
+}
+
+/* Internal representation of Isomer errors - passed to frontend client */
+export interface IsomerInternalError {
+  code: string
+  message: string
+  meta?: Record<string, unknown>
+}
+
+/* Namespace for Error functions */
+export const IsomerError = {
+  // TODO: Once we start implementing errors, we need to define the codes in the error files
+  toExternalRepresentation: (e: IsomerInternalError): IsomerExternalError => ({
+    code: e.code,
+    message: e.message,
+  }),
+  getLog: (error: IsomerInternalError): Record<string, unknown> => ({
+    ...error,
+  }),
+}

--- a/src/errors/IsomerError.ts
+++ b/src/errors/IsomerError.ts
@@ -4,7 +4,7 @@ export interface IsomerExternalError {
   message: string
 }
 
-/* Internal representation of Isomer errors - passed to frontend client */
+/* Internal representation of Isomer errors - passed to log stream */
 export interface IsomerInternalError {
   code: string
   message: string


### PR DESCRIPTION
## Problem

This PR introduces the base types for Isomer Errors

Closes IS-210

## Solution

In contrast to the description of task, instead of overloading the logger's error method, we decided to treat logger and error distinctly

Current logger accept a Loggable which is a string or Record<string, unknown> which is a structured log format.

All errors and other types which can be logged will therefore provide a utility function that convert them to one of the above - string or a Record

Hence instead of the logger figuring out how to convert IsomerError and potentially other types in future, it will only accept fixed and predictable types

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible
