### PR TITLE
fix(requestschema): change to allow for 16 digits for fb pixel

### DIFF
--- a/src/routes/v2/authenticatedSites/__tests__/Settings.spec.js
+++ b/src/routes/v2/authenticatedSites/__tests__/Settings.spec.js
@@ -113,5 +113,19 @@ describe("Settings Router", () => {
       expect(mockSettingsService.retrieveSettingsFiles).toHaveBeenCalled()
       expect(mockSettingsService.updateSettingsFiles).toHaveBeenCalled()
     })
+    it("should allow for facebook pixel values of length 16", async () => {
+      // Arrange
+      // NOTE: Old fb pixel values are 16 characters long
+      const params = {
+        "facebook-pixel": `${updatedFbPixelValue}0`,
+      }
+
+      // Act
+      await request(app).post(`/${siteName}/settings`).send(params).expect(200)
+
+      // Assert
+      expect(mockSettingsService.retrieveSettingsFiles).toHaveBeenCalled()
+      expect(mockSettingsService.updateSettingsFiles).toHaveBeenCalled()
+    })
   })
 })

--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -250,7 +250,7 @@ const UpdateSettingsRequestSchema = Joi.object().keys({
   }),
   favicon: Joi.string(),
   "facebook-pixel": Joi.string()
-    .regex(/^[0-9]{15}$/)
+    .regex(/^[0-9]{15,16}$/)
     .allow(""),
   google_analytics: Joi.string().allow(""),
   google_analytics_ga4: Joi.string().allow(""),


### PR DESCRIPTION
## Problem
see [here](https://github.com/isomerpages/isomercms-frontend/pull/1306)

## Solution
1. change request schema 
