### PR TITLE
IS-212 - Migrate collection page service to new error format

### DIFF
--- a/src/classes/File.js
+++ b/src/classes/File.js
@@ -52,7 +52,7 @@ class File {
     if (resp.status !== 200) {
       if (resp.status === 404)
         throw new NotFoundError("Directory does not exist")
-      throw new BaseIsomerError(resp)
+      throw new BaseIsomerError({ message: resp })
     }
 
     const files = resp.data

--- a/src/classes/MediaFile.js
+++ b/src/classes/MediaFile.js
@@ -78,7 +78,7 @@ class MediaFile {
     if (resp.status !== 200) {
       if (resp.status === 404)
         throw new NotFoundError("Media Directory does not exist")
-      throw new BaseIsomerError(resp)
+      throw new BaseIsomerError({ message: resp })
     }
 
     return resp.data

--- a/src/errors/AuthError.js
+++ b/src/errors/AuthError.js
@@ -3,7 +3,7 @@ const { BaseIsomerError } = require("@errors/BaseError")
 
 class AuthError extends BaseIsomerError {
   constructor(message) {
-    super(401, message)
+    super({ status: 401, code: "AuthError", message })
   }
 }
 

--- a/src/errors/BadRequestError.js
+++ b/src/errors/BadRequestError.js
@@ -2,8 +2,8 @@
 const { BaseIsomerError } = require("@errors/BaseError")
 
 class BadRequestError extends BaseIsomerError {
-  constructor(message) {
-    super(400, message)
+  constructor(message, meta = {}) {
+    super({ status: 400, code: "BadRequestError", message, meta })
   }
 }
 

--- a/src/errors/BadRequestError.js
+++ b/src/errors/BadRequestError.js
@@ -1,14 +1,14 @@
 // Import base error
 const { BaseIsomerError } = require("@errors/BaseError")
 
-const { ComponentTypes } = require("./IsomerError")
+const { ComponentTypes, FileCodes } = require("./IsomerError")
 
 class BadRequestError extends BaseIsomerError {
   constructor(
     message,
     meta = {},
     componentCode = ComponentTypes.Other,
-    fileCode = "000"
+    fileCode = FileCodes.Undefined
   ) {
     super({
       status: 400,

--- a/src/errors/BadRequestError.js
+++ b/src/errors/BadRequestError.js
@@ -1,9 +1,23 @@
 // Import base error
 const { BaseIsomerError } = require("@errors/BaseError")
 
+const { ComponentTypes } = require("./IsomerError")
+
 class BadRequestError extends BaseIsomerError {
-  constructor(message, meta = {}) {
-    super({ status: 400, code: "BadRequestError", message, meta })
+  constructor(
+    message,
+    meta = {},
+    componentCode = ComponentTypes.Other,
+    fileCode = "000"
+  ) {
+    super({
+      status: 400,
+      code: "BadRequestError",
+      message,
+      meta,
+      componentCode,
+      fileCode,
+    })
   }
 }
 

--- a/src/errors/BaseError.ts
+++ b/src/errors/BaseError.ts
@@ -1,4 +1,4 @@
-import { IsomerInternalError } from "./IsomerError"
+import { ComponentTypes, IsomerInternalError } from "./IsomerError"
 
 class BaseIsomerError extends Error implements IsomerInternalError {
   name: string
@@ -11,12 +11,31 @@ class BaseIsomerError extends Error implements IsomerInternalError {
 
   isIsomerError = true
 
-  constructor(status = 500, message = "Something went wrong") {
+  meta: Record<string, unknown>
+
+  isV2Err = false
+
+  componentCode: string
+
+  fileCode: string
+
+  constructor({
+    status = 500,
+    code = "BaseError",
+    message = "Something went wrong",
+    meta = {},
+    componentCode = ComponentTypes.Other,
+    fileCode = "000",
+  }) {
     super()
     Error.captureStackTrace(this, this.constructor)
     this.name = this.constructor.name
+    this.code = code
     this.status = status
     this.message = message
+    this.meta = meta
+    this.componentCode = componentCode
+    this.fileCode = fileCode
   }
 }
 

--- a/src/errors/BaseError.ts
+++ b/src/errors/BaseError.ts
@@ -7,17 +7,17 @@ class BaseIsomerError extends Error implements IsomerInternalError {
 
   message: string
 
-  code = "BaseError"
+  code = "BaseError" // name of the error
 
   isIsomerError = true
 
-  meta: Record<string, unknown>
+  meta: Record<string, unknown> // additional properties that provides context for the error
 
-  isV2Err = false
+  isV2Err = false // indicates if this is the new error format
 
-  componentCode: string
+  componentCode: string // a selection from ComponentTypes
 
-  fileCode: string
+  fileCode: string // a selection from FileCodes
 
   constructor({
     status = 500,

--- a/src/errors/ConfigParseError.ts
+++ b/src/errors/ConfigParseError.ts
@@ -2,6 +2,10 @@ import { BaseIsomerError } from "@root/errors/BaseError"
 
 export default class ConfigParseError extends BaseIsomerError {
   constructor(fileName: string) {
-    super(500, `The given file: ${fileName} was not a config file!`)
+    super({
+      status: 500,
+      code: "ConfigParseError",
+      message: `The given file: ${fileName} was not a config file!`,
+    })
   }
 }

--- a/src/errors/ConflictError.js
+++ b/src/errors/ConflictError.js
@@ -9,7 +9,7 @@ const protectedFolderConflictErrorMsg = (folderName) =>
 
 class ConflictError extends BaseIsomerError {
   constructor(message) {
-    super(409, message)
+    super({ status: 409, code: "ConflictError", message })
   }
 }
 module.exports = {

--- a/src/errors/DatabaseError.ts
+++ b/src/errors/DatabaseError.ts
@@ -2,6 +2,6 @@ import { BaseIsomerError } from "./BaseError"
 
 export default class DatabaseError extends BaseIsomerError {
   constructor(message = "Unable to retrieve data from database") {
-    super(500, message)
+    super({ status: 500, code: "DatabaseError", message })
   }
 }

--- a/src/errors/EmptyStringError.ts
+++ b/src/errors/EmptyStringError.ts
@@ -4,6 +4,6 @@ export default class EmptyStringError extends BaseIsomerError {
   constructor(
     message = "An empty string was provided for a method that requires a non-empty string"
   ) {
-    super(500, message)
+    super({ status: 500, code: "EmptyStringError", message })
   }
 }

--- a/src/errors/ForbiddenError.js
+++ b/src/errors/ForbiddenError.js
@@ -3,7 +3,11 @@ const { BaseIsomerError } = require("@errors/BaseError")
 
 class ForbiddenError extends BaseIsomerError {
   constructor(message) {
-    super(403, message || "Access forbidden")
+    super({
+      status: 403,
+      code: "ForbiddenError",
+      message: message || "Access forbidden",
+    })
   }
 }
 

--- a/src/errors/IsomerError.ts
+++ b/src/errors/IsomerError.ts
@@ -9,7 +9,28 @@ export interface IsomerInternalError {
   code: string
   message: string
   meta?: Record<string, unknown>
+  componentCode?: string
+  fileCode?: string
 }
+
+export const ComponentTypes = {
+  Service: "S",
+  Router: "R",
+  Controller: "C",
+  Model: "M",
+  Util: "U",
+  Other: "X",
+}
+
+export const FileCodes = {
+  CollectionPageService: "001",
+}
+
+const getErrCode = (
+  componentCode: string,
+  fileCode: string,
+  seqNum: number
+): string => `${componentCode}${fileCode}-${seqNum}`
 
 /* Namespace for Error functions */
 export const IsomerError = {

--- a/src/errors/IsomerError.ts
+++ b/src/errors/IsomerError.ts
@@ -9,8 +9,8 @@ export interface IsomerInternalError {
   code: string
   message: string
   meta?: Record<string, unknown>
-  componentCode?: string
-  fileCode?: string
+  componentCode: string
+  fileCode: string
 }
 
 export const ComponentTypes = {
@@ -26,17 +26,16 @@ export const FileCodes = {
   CollectionPageService: "001",
 }
 
-const getErrCode = (
+const getExternalCode = (
   componentCode: string,
   fileCode: string,
-  seqNum: number
-): string => `${componentCode}${fileCode}-${seqNum}`
+  errCode: string
+): string => `${componentCode}-${fileCode}-${errCode}`
 
 /* Namespace for Error functions */
 export const IsomerError = {
-  // TODO: Once we start implementing errors, we need to define the codes in the error files
   toExternalRepresentation: (e: IsomerInternalError): IsomerExternalError => ({
-    code: e.code,
+    code: getExternalCode(e.componentCode, e.fileCode, e.code),
     message: e.message,
   }),
   getLog: (error: IsomerInternalError): Record<string, unknown> => ({

--- a/src/errors/IsomerError.ts
+++ b/src/errors/IsomerError.ts
@@ -24,6 +24,7 @@ export const ComponentTypes = {
 
 export const FileCodes = {
   CollectionPageService: "001",
+  Undefined: "000",
 }
 
 const getExternalCode = (

--- a/src/errors/MediaTypeError.js
+++ b/src/errors/MediaTypeError.js
@@ -3,7 +3,7 @@ const { BaseIsomerError } = require("@errors/BaseError")
 
 class MediaTypeError extends BaseIsomerError {
   constructor(message) {
-    super(415, message)
+    super({ status: 415, code: "MediaTypeError", message })
   }
 }
 

--- a/src/errors/MissingResourceRoomError.ts
+++ b/src/errors/MissingResourceRoomError.ts
@@ -3,5 +3,6 @@ import { NotFoundError } from "./NotFoundError"
 export default class MissingResourceRoomError extends NotFoundError {
   constructor(message = "No resource room exists for the site") {
     super(message)
+    this.code = "MissingResourceRoomError"
   }
 }

--- a/src/errors/MissingSiteError.ts
+++ b/src/errors/MissingSiteError.ts
@@ -3,5 +3,6 @@ import { NotFoundError } from "./NotFoundError"
 export default class MissingSiteError extends NotFoundError {
   constructor(message = "The site could not be found in Isomer") {
     super(message)
+    this.code = "MissingSiteError"
   }
 }

--- a/src/errors/MissingUserEmailError.ts
+++ b/src/errors/MissingUserEmailError.ts
@@ -3,5 +3,6 @@ import { NotFoundError } from "./NotFoundError"
 export default class MissingUserEmailError extends NotFoundError {
   constructor(message = "No email exists for the specified user!") {
     super(message)
+    this.code = "MissingUserEmailError"
   }
 }

--- a/src/errors/MissingUserError.ts
+++ b/src/errors/MissingUserError.ts
@@ -3,5 +3,6 @@ import { NotFoundError } from "./NotFoundError"
 export default class MissingUserError extends NotFoundError {
   constructor(message = "The user could not be found in Isomer") {
     super(message)
+    this.code = "MissingUserError"
   }
 }

--- a/src/errors/NetworkError.ts
+++ b/src/errors/NetworkError.ts
@@ -4,6 +4,6 @@ export default class NetworkError extends BaseIsomerError {
   constructor(
     message = "An error occurred with the network whilst processing your request. Please try again later."
   ) {
-    super(500, message)
+    super({ status: 500, code: "NetworkError", message })
   }
 }

--- a/src/errors/NoAvailableTokenError.ts
+++ b/src/errors/NoAvailableTokenError.ts
@@ -7,7 +7,7 @@ export default class NoAvailableTokenError extends BaseIsomerError {
     message = "Unable to select token for request",
     timestamp = new Date()
   ) {
-    super(503, message)
+    super({ status: 503, code: "NoAvailableTokenError", message })
     this.timestamp = timestamp
   }
 }

--- a/src/errors/NotFoundError.js
+++ b/src/errors/NotFoundError.js
@@ -3,7 +3,7 @@ const { BaseIsomerError } = require("@errors/BaseError")
 
 class NotFoundError extends BaseIsomerError {
   constructor(message) {
-    super(404, message)
+    super({ status: 404, code: "NotFoundError", message })
   }
 }
 

--- a/src/errors/PageParseError.ts
+++ b/src/errors/PageParseError.ts
@@ -2,6 +2,10 @@ import { BaseIsomerError } from "@root/errors/BaseError"
 
 export default class PageParseError extends BaseIsomerError {
   constructor(fileName: string) {
-    super(500, `The given file: ${fileName} was not a page!`)
+    super({
+      status: 500,
+      code: "PageParseError",
+      message: `The given file: ${fileName} was not a page!`,
+    })
   }
 }

--- a/src/errors/RequestNotFoundError.ts
+++ b/src/errors/RequestNotFoundError.ts
@@ -3,5 +3,6 @@ import { NotFoundError } from "./NotFoundError"
 export default class RequestNotFoundError extends NotFoundError {
   constructor(message = "The specified review request could not be found!") {
     super(message)
+    this.code = "RequestNotFoundError"
   }
 }

--- a/src/errors/TokenParsingError.ts
+++ b/src/errors/TokenParsingError.ts
@@ -9,7 +9,7 @@ export default class TokenParsingError extends BaseIsomerError {
     response: AxiosResponse,
     message = "Unable parse token from axios response"
   ) {
-    super(422, message)
+    super({ status: 422, code: "TokenParsingError", message })
     this.response = response
   }
 }

--- a/src/errors/UnprocessableError.js
+++ b/src/errors/UnprocessableError.js
@@ -3,7 +3,7 @@ const { BaseIsomerError } = require("@errors/BaseError")
 
 class UnprocessableError extends BaseIsomerError {
   constructor(message) {
-    super(422, message)
+    super({ status: 422, code: "UnprocessableError", message })
   }
 }
 

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,4 +1,6 @@
 // Import dependencies
+const { IsomerError } = require("@root/errors/IsomerError")
+
 const _ = require("lodash")
 const { serializeError } = require("serialize-error")
 
@@ -30,6 +32,11 @@ function errorHandler(err, req, res, next) {
   // Error handling for custom errors
   if (err.isIsomerError) {
     logger.info(errMsg)
+    if (err.isV2Err) {
+      return res.status(err.status).json({
+        error: IsomerError.toExternalRepresentation(err),
+      })
+    }
     return res.status(err.status).json({
       error: {
         name: err.name,

--- a/src/services/fileServices/MdPageServices/CollectionPageService.js
+++ b/src/services/fileServices/MdPageServices/CollectionPageService.js
@@ -7,6 +7,8 @@ const {
 
 const { hasSpecialCharInTitle } = require("@validators/validators")
 
+const { ComponentTypes, FileCodes } = require("@root/errors/IsomerError")
+
 class CollectionPageService {
   constructor({ gitHubService, collectionYmlService }) {
     this.gitHubService = gitHubService
@@ -20,10 +22,16 @@ class CollectionPageService {
     if (
       !shouldIgnoreCheck &&
       hasSpecialCharInTitle({ title: fileName, isFile: true })
-    )
-      throw new BadRequestError(
-        `Special characters not allowed when creating files. Given name: ${fileName}`
+    ) {
+      const err = new BadRequestError(
+        `Special characters not allowed when creating files. Given name: ${fileName}`,
+        { fileName },
+        ComponentTypes.Service,
+        FileCodes.CollectionPageService
       )
+      err.isV2Err = true
+      throw err
+    }
     const parsedCollectionName = `_${collectionName}`
 
     await this.collectionYmlService.addItemToOrder(sessionData, {
@@ -95,10 +103,16 @@ class CollectionPageService {
     sessionData,
     { oldFileName, newFileName, collectionName, content, frontMatter, sha }
   ) {
-    if (hasSpecialCharInTitle({ title: newFileName, isFile: true }))
-      throw new BadRequestError(
-        `Special characters not allowed when renaming files. Given name: ${newFileName}`
+    if (hasSpecialCharInTitle({ title: newFileName, isFile: true })) {
+      const err = new BadRequestError(
+        `Special characters not allowed when renaming files. Given name: ${newFileName}`,
+        { fileName: newFileName },
+        ComponentTypes.Service,
+        FileCodes.CollectionPageService
       )
+      err.isV2Err = true
+      throw err
+    }
     const parsedCollectionName = `_${collectionName}`
 
     await this.collectionYmlService.updateItemInOrder(sessionData, {

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -44,13 +44,13 @@ const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000"
 // This is (at a glance), either a failure to read from github
 // or the parsing fails (we have a sentinel value of an empty string)
 const withErrorHandler = (promise: Promise<PageInfo>) =>
-  ResultAsync.fromPromise(promise, () => new BaseIsomerError()).andThen(
+  ResultAsync.fromPromise(promise, () => new BaseIsomerError({})).andThen(
     (data) =>
       // NOTE: This is a fail-safe check as `yaml.parse`
       // doesn't guarantee existence.
       data?.content?.frontMatter?.permalink
         ? ok(data)
-        : err(new BaseIsomerError())
+        : err(new BaseIsomerError({}))
   )
 
 const extractStagingPermalink = (stagingLink: string) => ({
@@ -342,7 +342,10 @@ export class PageService {
       default: {
         const unimplErr: never = pageName
         return errAsync(
-          new BaseIsomerError(500, `Unimplemented page type: ${unimplErr}`)
+          new BaseIsomerError({
+            status: 500,
+            message: `Unimplemented page type: ${unimplErr}`,
+          })
         )
       }
     }

--- a/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
+++ b/src/services/fileServices/MdPageServices/__tests__/PageService.spec.ts
@@ -499,7 +499,7 @@ describe("PageService", () => {
         kind: "UnlinkedPage",
       }
       mockUnlinkedPageService.read.mockRejectedValueOnce({})
-      const expected = err(new BaseIsomerError())
+      const expected = err(new BaseIsomerError({}))
 
       // Act
       const actual = await pageService.retrieveStagingPermalink(
@@ -525,7 +525,7 @@ describe("PageService", () => {
         kind: "UnlinkedPage",
       }
       mockUnlinkedPageService.read.mockRejectedValueOnce({})
-      const expected = err(new BaseIsomerError())
+      const expected = err(new BaseIsomerError({}))
 
       // Act
       const actual = await pageService.retrieveStagingPermalink(
@@ -575,7 +575,7 @@ describe("PageService", () => {
         kind: "ContactUsPage",
       }
       mockContactUsService.read.mockRejectedValueOnce({})
-      const expected = err(new BaseIsomerError())
+      const expected = err(new BaseIsomerError({}))
 
       // Act
       const actual = await pageService.retrieveStagingPermalink(
@@ -598,7 +598,7 @@ describe("PageService", () => {
         kind: "ContactUsPage",
       }
       mockContactUsService.read.mockRejectedValueOnce({})
-      const expected = err(new BaseIsomerError())
+      const expected = err(new BaseIsomerError({}))
 
       // Act
       const actual = await pageService.retrieveStagingPermalink(
@@ -646,7 +646,7 @@ describe("PageService", () => {
         kind: "Homepage",
       }
       mockHomepageService.read.mockRejectedValueOnce({})
-      const expected = err(new BaseIsomerError())
+      const expected = err(new BaseIsomerError({}))
 
       // Act
       const actual = await pageService.retrieveStagingPermalink(
@@ -669,7 +669,7 @@ describe("PageService", () => {
         kind: "Homepage",
       }
       mockHomepageService.read.mockRejectedValueOnce({})
-      const expected = err(new BaseIsomerError())
+      const expected = err(new BaseIsomerError({}))
 
       // Act
       const actual = await pageService.retrieveStagingPermalink(
@@ -726,7 +726,7 @@ describe("PageService", () => {
         resourceRoom: Brand.fromString(MOCK_RESOURCE_ROOM_NAME),
       }
       mockResourcePageService.read.mockRejectedValueOnce({})
-      const expected = err(new BaseIsomerError())
+      const expected = err(new BaseIsomerError({}))
 
       // Act
       const actual = await pageService.retrieveStagingPermalink(
@@ -756,7 +756,7 @@ describe("PageService", () => {
         resourceRoom: Brand.fromString(MOCK_RESOURCE_ROOM_NAME),
       }
       mockResourcePageService.read.mockRejectedValueOnce({})
-      const expected = err(new BaseIsomerError())
+      const expected = err(new BaseIsomerError({}))
 
       // Act
       const actual = await pageService.retrieveStagingPermalink(
@@ -818,7 +818,7 @@ describe("PageService", () => {
         subcollection: Brand.fromString(MOCK_SUBCOLLECTION_NAME),
       }
       mockSubcollectionPageService.read.mockRejectedValueOnce({})
-      const expected = err(new BaseIsomerError())
+      const expected = err(new BaseIsomerError({}))
 
       // Act
       const actual = await pageService.retrieveStagingPermalink(
@@ -848,7 +848,7 @@ describe("PageService", () => {
         subcollection: Brand.fromString(MOCK_SUBCOLLECTION_NAME),
       }
       mockSubcollectionPageService.read.mockRejectedValueOnce({})
-      const expected = err(new BaseIsomerError())
+      const expected = err(new BaseIsomerError({}))
 
       // Act
       const actual = await pageService.retrieveStagingPermalink(
@@ -907,7 +907,7 @@ describe("PageService", () => {
         collection: MOCK_COLLECTION_NAME,
       }
       mockCollectionPageService.read.mockRejectedValueOnce({})
-      const expected = err(new BaseIsomerError())
+      const expected = err(new BaseIsomerError({}))
 
       // Act
       const actual = await pageService.retrieveStagingPermalink(
@@ -935,7 +935,7 @@ describe("PageService", () => {
         collection: MOCK_COLLECTION_NAME,
       }
       mockCollectionPageService.read.mockRejectedValueOnce({})
-      const expected = err(new BaseIsomerError())
+      const expected = err(new BaseIsomerError({}))
 
       // Act
       const actual = await pageService.retrieveStagingPermalink(


### PR DESCRIPTION
## Problem

We are restructuring the error handling as per discussed RFC, starting with CollectionPageService

Closes IS-212

## Solution

This PR introduces named parameters for Base Isomer Error. Eventually all the errors should have this, but base error seemed to have the smallest surface area for a initial PR. But because of this change, all "child" classes of the base error will have a small change in their constructors where `super(...)` is called.

We are introducing new fields to the existing error classes - `meta`, `code`, `isV2err`, `componentCode` and `fileCode`.

The error handler is also doing a conditional check to convert the internal representation to external facing. For now, the external rep is just a combination of the `componentCode-fileCode-code`.

As the initial PR, I have modified CollectionPageService.js to this new format.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Tests

Run `npm run test` to ensure all tests are passing.

CollectionPageService is used within the workspace folder when you try to create or rename a folder. Example: http://localhost:3000/sites/{some-site}/folders/example-folder

The errors are thrown when the filename has special characters in them. However, these are already caught on FE. To simulate the BE response you need to copy a successful network request as a cURL and use Postman/Insomnia to import that and manually send a invalid file name in the body

![Screenshot 2023-06-15 at 10 31 26 PM](https://github.com/isomerpages/isomercms-backend/assets/5507822/9929d956-570a-4eb5-be9c-6b32446991a7)

The return response's code should be of format `componentCode-fileCode-code`.

In the event where a invalid filename request is sent from FE, returning the new external rep format will be handled by FE. As tested (by disabling validation on FE) - check this PR: https://github.com/isomerpages/isomercms-frontend/pull/1312

## Deploy notes
To deploy together with FE PR - https://github.com/isomerpages/isomercms-frontend/pull/1312
