### PR TITLE
fix(email): log mail status after reasonable delay

### DIFF
--- a/src/services/utilServices/MailClient.ts
+++ b/src/services/utilServices/MailClient.ts
@@ -79,7 +79,6 @@ class MailClient {
 
   logEmailStatus(verifyMailData: MailData) {
     const mailStatus = verifyMailData.status
-    let unknownMailStatus: never
     switch (mailStatus) {
       case MailStatus.Delivered:
       case MailStatus.Opened:
@@ -111,12 +110,13 @@ class MailClient {
           `Email to ${verifyMailData.recipient} rejected by recipient's mail server: ${verifyMailData}`
         )
         break
-      default:
-        unknownMailStatus = mailStatus
+      default: {
+        const unknownMailStatus: never = mailStatus
         logger.warn(
           `Email to ${verifyMailData.recipient} encounter unknown status: ${unknownMailStatus}`
         )
         break
+      }
     }
   }
 }

--- a/src/services/utilServices/MailClient.ts
+++ b/src/services/utilServices/MailClient.ts
@@ -87,33 +87,33 @@ class MailClient {
         break
       case MailStatus.Unsent:
         if (verifyMailData.error_code === BLACKLISTED_RECIPIENT_ERROR_CODE) {
-          logger.error(
+          logger.warn(
             `Email to blacklisted recipient ${verifyMailData.recipient} not accepted: ${verifyMailData}`
           )
         } else {
-          logger.error(
+          logger.warn(
             `Email to ${verifyMailData.recipient} not accepted: ${verifyMailData}`
           )
         }
         break
       case MailStatus.Accepted:
-        logger.error(
+        logger.warn(
           `Email to ${verifyMailData.recipient} not sent: ${verifyMailData}`
         )
         break
       case MailStatus.Sent:
-        logger.error(
+        logger.warn(
           `Email to ${verifyMailData.recipient} not delivered: ${verifyMailData}`
         )
         break
       case MailStatus.Bounced:
-        logger.error(
+        logger.warn(
           `Email to ${verifyMailData.recipient} rejected by recipient's mail server: ${verifyMailData}`
         )
         break
       default:
         unknownMailStatus = mailStatus
-        logger.error(
+        logger.warn(
           `Email to ${verifyMailData.recipient} encounter unknown status: ${unknownMailStatus}`
         )
         break

--- a/src/services/utilServices/MailClient.ts
+++ b/src/services/utilServices/MailClient.ts
@@ -5,6 +5,13 @@ import { config } from "@config/config"
 import logger from "@logger/logger"
 
 const POSTMAN_API_URL = "https://api.postman.gov.sg/v1"
+const MAIL_VERIFICATION_DELAY = 60000 // 60 seconds
+
+type MailData = {
+  id: string
+  recipient: string
+  status: string
+}
 
 class MailClient {
   POSTMAN_API_KEY: string
@@ -28,14 +35,55 @@ class MailClient {
     }
 
     try {
-      await axios.post(endpoint, email, {
+      const sendMailResponse = await axios.post(endpoint, email, {
         headers: {
           Authorization: `Bearer ${this.POSTMAN_API_KEY}`,
         },
       })
+      this.verifyMail(sendMailResponse.data)
     } catch (err) {
       logger.error(`Error occurred when sending email to ${recipient}: ${err}`)
       throw new Error("Failed to send email.")
+    }
+  }
+
+  async verifyMail(sendMailData: MailData): Promise<void> {
+    const endpoint = `${POSTMAN_API_URL}/transactional/email/${sendMailData.id}`
+    await new Promise((res) => setTimeout(res, MAIL_VERIFICATION_DELAY))
+    const verifyMailResponse = await axios.get(endpoint, {
+      headers: {
+        Authorization: `Bearer ${this.POSTMAN_API_KEY}`,
+      },
+    })
+    this.logEmailStatus(verifyMailResponse.data)
+  }
+
+  logEmailStatus(verifyMailData: MailData) {
+    const mailStatus = verifyMailData.status
+    switch (mailStatus) {
+      case "UNSENT":
+        logger.error(
+          `Email to ${verifyMailData.recipient} not accepted: ${verifyMailData}`
+        )
+        break
+      case "ACCEPTED":
+        logger.error(
+          `Email to ${verifyMailData.recipient} not sent: ${verifyMailData}`
+        )
+        break
+      case "SENT":
+        logger.error(
+          `Email to ${verifyMailData.recipient} not delivered: ${verifyMailData}`
+        )
+        break
+      case "BOUNCED":
+        logger.error(
+          `Email to ${verifyMailData.recipient} rejected by recipient's mail server: ${verifyMailData}`
+        )
+        break
+      default:
+        logger.info(`Email delivered to ${verifyMailData.recipient}`)
+        break
     }
   }
 }

--- a/src/services/utilServices/MailClient.ts
+++ b/src/services/utilServices/MailClient.ts
@@ -55,7 +55,12 @@ class MailClient {
         Authorization: `Bearer ${this.POSTMAN_API_KEY}`,
       },
     })
-    this.logEmailStatus(verifyMailResponse.data)
+    // NOTE: For tests where the main routine has already ended, mockAxios is terminated
+    // and will return undefined for verifyMailResponse. In order to pass the test, we
+    // need to check if it is a valid response. This should not happen in application.
+    if (verifyMailResponse) {
+      this.logEmailStatus(verifyMailResponse.data)
+    }
   }
 
   logEmailStatus(verifyMailData: MailData) {

--- a/src/services/utilServices/MailClient.ts
+++ b/src/services/utilServices/MailClient.ts
@@ -25,7 +25,7 @@ class MailClient {
     subject: string,
     body: string
   ): Promise<void> {
-    const endpoint = `${POSTMAN_API_URL}/transactional/email/send`
+    const sendEndpoint = `${POSTMAN_API_URL}/transactional/email/send`
     const email = {
       subject,
       from: "IsomerCMS <donotreply@mail.postman.gov.sg>",
@@ -35,7 +35,7 @@ class MailClient {
     }
 
     try {
-      const sendMailResponse = await axios.post<MailData>(endpoint, email, {
+      const sendMailResponse = await axios.post<MailData>(sendEndpoint, email, {
         headers: {
           Authorization: `Bearer ${this.POSTMAN_API_KEY}`,
         },
@@ -48,9 +48,9 @@ class MailClient {
   }
 
   async verifyMail(sendMailData: MailData): Promise<void> {
-    const endpoint = `${POSTMAN_API_URL}/transactional/email/${sendMailData.id}`
+    const verfyEndpoint = `${POSTMAN_API_URL}/transactional/email/${sendMailData.id}`
     await new Promise((res) => setTimeout(res, MAIL_VERIFICATION_DELAY))
-    const verifyMailResponse = await axios.get<MailData>(endpoint, {
+    const verifyMailResponse = await axios.get<MailData>(verfyEndpoint, {
       headers: {
         Authorization: `Bearer ${this.POSTMAN_API_KEY}`,
       },

--- a/src/services/utilServices/MailClient.ts
+++ b/src/services/utilServices/MailClient.ts
@@ -35,7 +35,7 @@ class MailClient {
     }
 
     try {
-      const sendMailResponse = await axios.post(endpoint, email, {
+      const sendMailResponse = await axios.post<MailData>(endpoint, email, {
         headers: {
           Authorization: `Bearer ${this.POSTMAN_API_KEY}`,
         },
@@ -50,7 +50,7 @@ class MailClient {
   async verifyMail(sendMailData: MailData): Promise<void> {
     const endpoint = `${POSTMAN_API_URL}/transactional/email/${sendMailData.id}`
     await new Promise((res) => setTimeout(res, MAIL_VERIFICATION_DELAY))
-    const verifyMailResponse = await axios.get(endpoint, {
+    const verifyMailResponse = await axios.get<MailData>(endpoint, {
       headers: {
         Authorization: `Bearer ${this.POSTMAN_API_KEY}`,
       },


### PR DESCRIPTION
## Problem

Postman API send mail post request to endpoint `/transactional/email/send` returns status code 201 indicating the request has been created, but does not guarantee that the email will be sent and delivered. 

Closes IS-135

## Solution

After a reasonable delay, verify with Postman that the mail has been delivered. If otherwise, log the status of the email to be tracked. 

**Improvements**:

- After a 1 minute delay, send a get request to endpoint `/transactional/email/{id}` for the status of the sent email.
- Log the status of the email. If the email has yet to be delivered, log the full email data from Postman.

**Notes**:
This change will cause `Users.spec.ts` to encounter warnings for remaining asynchronous operations after the tests are complete. This is because `MailClient.ts` has a separate routine for verification of email statuses which has a delay of 1 minute. Waiting for that long will cause the tests to timeout. useFakeTimers() have been experimented with, but behaviour seem to be buggy and cause all tests to fail. Hence, am currently sticking with the warning and letting the tests pass.