### PR TITLE
Fix: step functions env var

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -206,7 +206,7 @@ const config = convict({
           doc: "Whether the queues are deprecated",
           env: "FF_DEPRECATE_SITE_QUEUES",
           format: "required-boolean",
-          default: null,
+          default: false,
         },
       },
     },

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -185,7 +185,7 @@ const config = convict({
         doc: "Amazon Resource Name (ARN) of the Step Functions state machine",
         env: "STEP_FUNCTIONS_ARN",
         format: "required-string",
-        default: "SiteLaunchStepFunctions-dev",
+        default: "",
       },
     },
     sqs: {
@@ -206,7 +206,7 @@ const config = convict({
           doc: "Whether the queues are deprecated",
           env: "FF_DEPRECATE_SITE_QUEUES",
           format: "required-boolean",
-          default: false,
+          default: null,
         },
       },
     },

--- a/src/server.js
+++ b/src/server.js
@@ -210,7 +210,9 @@ const launchesService = new LaunchesService({
   launchClient,
 })
 const queueService = new QueueService()
-const stepFunctionsService = new StepFunctionsService()
+const stepFunctionsService = new StepFunctionsService(
+  config.get("aws.stepFunctions.stepFunctionsArn")
+)
 const dynamoDBService = new DynamoDBService({
   dynamoDBClient: new DynamoDBDocClient(),
 })


### PR DESCRIPTION
## Problem

the step functions arn was not injected in.

Additionally, the env vars are not present in prod :sadge:, but this should have be caught by config.


## Solution

changing the default values to warns devs if the end var does not exist. 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible


**New environment variables**:

- `FF_DEPRECATE_SITE_QUEUES = false`
- `STEP_FUNCTIONS_ARN = found in 1pw`

