### PR TITLE
fix: rearrange subcollections

### DIFF
--- a/src/services/directoryServices/SubcollectionDirectoryService.js
+++ b/src/services/directoryServices/SubcollectionDirectoryService.js
@@ -150,11 +150,11 @@ class SubcollectionDirectoryService {
       collectionName,
     })
     const insertPos = files.findIndex((fileName) =>
-      fileName.includes(`${subcollectionName}/`)
+      fileName.startsWith(`${subcollectionName}/`)
     )
     // We do this step separately to account for subcollections which may not have the .keep file
     const filteredFiles = files.filter(
-      (fileName) => !fileName.includes(`${subcollectionName}/`)
+      (fileName) => !fileName.startsWith(`${subcollectionName}/`)
     )
     filteredFiles.splice(insertPos, 0, ...newSubcollectionOrder)
 


### PR DESCRIPTION
This PR fixes a bug in which rearranging the order of a subcollection would something cause collection.yml information to disappear. This issue was caused by us using `includes` instead of `startsWith` to find the list of entries which belonged to the subcollection, which subsequently caused related names to disappear (e.g. changing the order of `Curriculum` would cause `Co Curriculum` to also match this criteria, and hence `Co Curriculum` would disappear)