### PR TITLE
fix(mediaFileServices): dont perform check on original file

### DIFF
--- a/src/services/fileServices/MdPageServices/MediaFileService.js
+++ b/src/services/fileServices/MdPageServices/MediaFileService.js
@@ -116,7 +116,6 @@ class MediaFileService {
     githubSessionData,
     { oldFileName, newFileName, directoryName, sha }
   ) {
-    this.mediaNameChecks({ directoryName, fileName: oldFileName })
     this.mediaNameChecks({ directoryName, fileName: newFileName })
     const oldExt = getFileExt(oldFileName)
     const newExt = getFileExt(newFileName)


### PR DESCRIPTION

## Problem

There exists older repos in which we are unable to rename the files in prod because constrains were placed on the previous file change

## Solution

disregard checks for the old file name


## Tests

I have replicated the files that the agency had trouble renaming and placed it in my repo. 
I was now able to [rename](https://github.com/isomerpages/kishore-test/commit/40f8115dc9fdb7f50639cd724b689efc654c3531) the files properly via cms 
