### PR TITLE
fix(tsconfig): ignore build files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,5 +41,5 @@
     "require": ["tsconfig-paths/register"],
     "transpileOnly": true
   },
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "build"]
 }


### PR DESCRIPTION
## Problem

I keep getting this error that ts files will over ride build files. 

## Solution

Adding `build` dir to be excluded in this to prevent the errors, but I am not sure if this is the correct way to go about doing this. 
