### PR TITLE
fix(site launch routes): fix bug

### DIFF
--- a/src/services/identity/LaunchesService.ts
+++ b/src/services/identity/LaunchesService.ts
@@ -13,6 +13,7 @@ import {
   JobStatus,
   RedirectionTypes,
   SiteStatus,
+  REDIRECTION_SERVER_IP,
 } from "@root/constants/constants"
 import SiteLaunchError from "@root/errors/SiteLaunchError"
 import { AmplifyError } from "@root/types/index"
@@ -204,8 +205,8 @@ export class LaunchesService {
           // we need to append the `www` to the primary domain
           // before displaying it to the user as the `source`
           source: doesRedirectionRecordExist
-            ? launchRecord.value.primaryDomainSource
-            : `www.${launchRecord.value.primaryDomainSource}`,
+            ? `www.${launchRecord.value.primaryDomainSource}`
+            : launchRecord.value.primaryDomainSource,
           target: launchRecord.value.primaryDomainTarget,
           type: RedirectionTypes.CNAME,
         },
@@ -218,8 +219,8 @@ export class LaunchesService {
           ? [
               {
                 source: redirectionRecord.value.source,
-                target: redirectionRecord.value.target,
-                type: RedirectionTypes.CNAME,
+                target: REDIRECTION_SERVER_IP,
+                type: RedirectionTypes.A,
               },
             ]
           : []),


### PR DESCRIPTION
## Problem

DNS records were not showing properly. Idk if this was due to github screwing up yesterday or I forgot to test them :( 
This feature despreately needs tests, Ill prioritise them after the E2E tests in next sprint :sadge: 

## Solution

Modify routes to return the correct values

## Tests
for now manual only, the FE generated DNS records return the correct values 

<img width="891" alt="Screenshot 2023-07-06 at 9 32 56 AM" src="https://github.com/isomerpages/isomercms-backend/assets/42832651/7de296f3-ac23-42a7-8412-211dc2bf43fd">
