### PR TITLE
fix(config): change arn from required-string to string

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -184,8 +184,8 @@ const config = convict({
       stepFunctionsArn: {
         doc: "Amazon Resource Name (ARN) of the Step Functions state machine",
         env: "STEP_FUNCTIONS_ARN",
-        format: "string",
-        default: "",
+        format: "required-string",
+        default: "mock-arn",
       },
     },
     sqs: {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -184,7 +184,7 @@ const config = convict({
       stepFunctionsArn: {
         doc: "Amazon Resource Name (ARN) of the Step Functions state machine",
         env: "STEP_FUNCTIONS_ARN",
-        format: "required-string",
+        format: "string",
         default: "",
       },
     },


### PR DESCRIPTION
## Problem
ARN was `required-string` previously but had an empty default, leading to crashes on startup. this changes it to be a `string` instead.

## Solution
1. `required-string` -> `string`