### PR TITLE
Feat/IS-169 add site lastUpdated with caching

### DIFF
--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -41,6 +41,7 @@ import { UnlinkedPageService } from "@root/services/fileServices/MdPageServices/
 import { CollectionYmlService } from "@root/services/fileServices/YmlFileServices/CollectionYmlService"
 import { ConfigService } from "@root/services/fileServices/YmlFileServices/ConfigService"
 import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/FooterYmlService"
+import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import { GitHubService } from "@services/db/GitHubService"
 import * as ReviewApi from "@services/db/review"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
@@ -119,6 +120,11 @@ const reviewRequestService = new ReviewRequestService(
   pageService,
   configService
 )
+// Using a mock SitesCacheService as the actual service has setInterval
+// which causes tests to not exit.
+const MockSitesCacheService = {
+  getLastUpdated: jest.fn(),
+}
 const sitesService = new SitesService({
   siteRepository: Site,
   gitHubService: (mockGithubService as unknown) as GitHubService,
@@ -126,6 +132,7 @@ const sitesService = new SitesService({
   usersService,
   isomerAdminsService: (jest.fn() as unknown) as IsomerAdminsService,
   reviewRequestService,
+  sitesCacheService: (MockSitesCacheService as unknown) as SitesCacheService,
 })
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,

--- a/src/integration/Notifications.spec.ts
+++ b/src/integration/Notifications.spec.ts
@@ -47,6 +47,7 @@ import { ConfigService } from "@root/services/fileServices/YmlFileServices/Confi
 import { ConfigYmlService } from "@root/services/fileServices/YmlFileServices/ConfigYmlService"
 import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/FooterYmlService"
 import CollaboratorsService from "@root/services/identity/CollaboratorsService"
+import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import SitesService from "@root/services/identity/SitesService"
 import ReviewRequestService from "@root/services/review/ReviewRequestService"
 import * as ReviewApi from "@services/db/review"
@@ -112,6 +113,11 @@ const reviewRequestService = new ReviewRequestService(
   pageService,
   configService
 )
+// Using a mock SitesCacheService as the actual service has setInterval
+// which causes tests to not exit.
+const MockSitesCacheService = {
+  getLastUpdated: jest.fn(),
+}
 const sitesService = new SitesService({
   siteRepository: Site,
   gitHubService,
@@ -119,6 +125,7 @@ const sitesService = new SitesService({
   usersService,
   isomerAdminsService,
   reviewRequestService,
+  sitesCacheService: (MockSitesCacheService as unknown) as SitesCacheService,
 })
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,

--- a/src/integration/Privatisation.spec.ts
+++ b/src/integration/Privatisation.spec.ts
@@ -58,6 +58,7 @@ import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/Fo
 import { NavYmlService } from "@root/services/fileServices/YmlFileServices/NavYmlService"
 import CollaboratorsService from "@root/services/identity/CollaboratorsService"
 import DeploymentsService from "@root/services/identity/DeploymentsService"
+import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import AuthorizationMiddlewareService from "@root/services/middlewareServices/AuthorizationMiddlewareService"
 import { GitHubService } from "@services/db/GitHubService"
 import * as ReviewApi from "@services/db/review"
@@ -141,6 +142,11 @@ const reviewRequestService = new ReviewRequestService(
   pageService,
   configService
 )
+// Using a mock SitesCacheService as the actual service has setInterval
+// which causes tests to not exit.
+const MockSitesCacheService = {
+  getLastUpdated: jest.fn(),
+}
 const sitesService = new SitesService({
   siteRepository: Site,
   gitHubService,
@@ -148,6 +154,7 @@ const sitesService = new SitesService({
   usersService,
   isomerAdminsService,
   reviewRequestService,
+  sitesCacheService: (MockSitesCacheService as unknown) as SitesCacheService,
 })
 const navYmlService = new NavYmlService({
   gitHubService,

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -85,6 +85,7 @@ import { UnlinkedPageService } from "@root/services/fileServices/MdPageServices/
 import { CollectionYmlService } from "@root/services/fileServices/YmlFileServices/CollectionYmlService"
 import { ConfigService } from "@root/services/fileServices/YmlFileServices/ConfigService"
 import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/FooterYmlService"
+import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import { ReviewRequestDto } from "@root/types/dto/review"
 import { GitHubService } from "@services/db/GitHubService"
 import * as ReviewApi from "@services/db/review"
@@ -144,6 +145,11 @@ const reviewRequestService = new ReviewRequestService(
   pageService,
   configService
 )
+// Using a mock SitesCacheService as the actual service has setInterval
+// which causes tests to not exit.
+const MockSitesCacheService = {
+  getLastUpdated: jest.fn(),
+}
 const sitesService = new SitesService({
   siteRepository: Site,
   gitHubService,
@@ -151,6 +157,7 @@ const sitesService = new SitesService({
   usersService,
   isomerAdminsService,
   reviewRequestService,
+  sitesCacheService: (MockSitesCacheService as unknown) as SitesCacheService,
 })
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,

--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -44,6 +44,7 @@ import LaunchClient from "@root/services/identity/LaunchClient"
 import LaunchesService from "@root/services/identity/LaunchesService"
 import QueueService from "@root/services/identity/QueueService"
 import ReposService from "@root/services/identity/ReposService"
+import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import SitesService from "@root/services/identity/SitesService"
 import DynamoDBDocClient from "@root/services/infra/DynamoDBClient"
 import DynamoDBService from "@root/services/infra/DynamoDBService"
@@ -111,6 +112,11 @@ const reviewRequestService = new ReviewRequestService(
   pageService,
   configService
 )
+// Using a mock SitesCacheService as the actual service has setInterval
+// which causes tests to not exit.
+const MockSitesCacheService = {
+  getLastUpdated: jest.fn(),
+}
 const sitesService = new SitesService({
   siteRepository: Site,
   gitHubService,
@@ -118,6 +124,7 @@ const sitesService = new SitesService({
   usersService,
   isomerAdminsService,
   reviewRequestService,
+  sitesCacheService: (MockSitesCacheService as unknown) as SitesCacheService,
 })
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,

--- a/src/routes/v2/authenticated/__tests__/Sites.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/Sites.spec.ts
@@ -89,7 +89,7 @@ describe("Sites Router", () => {
   describe("getLastUpdated", () => {
     it("returns the last updated time", async () => {
       const lastUpdated = "last-updated"
-      mockSitesService.getLastUpdated.mockResolvedValueOnce(lastUpdated)
+      mockSitesService.getLastUpdated.mockReturnValueOnce(lastUpdated)
 
       const resp = await request(app)
         .get(`/${mockSiteName}/lastUpdated`)

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -70,7 +70,7 @@ export class SitesRouter {
     { userWithSiteSessionData: UserWithSiteSessionData }
   > = async (req, res) => {
     const { userWithSiteSessionData } = res.locals
-    const lastUpdated = await this.sitesService.getLastUpdated(
+    const lastUpdated = this.sitesService.getLastUpdated(
       userWithSiteSessionData
     )
     return res.status(200).json({ lastUpdated })

--- a/src/server.js
+++ b/src/server.js
@@ -56,6 +56,7 @@ import {
 import DeploymentsService from "@services/identity/DeploymentsService"
 import QueueService from "@services/identity/QueueService"
 import ReposService from "@services/identity/ReposService"
+import { SitesCacheService } from "@services/identity/SitesCacheService"
 import SitesService from "@services/identity/SitesService"
 import InfraService from "@services/infra/InfraService"
 import { statsService } from "@services/infra/StatsService"
@@ -191,6 +192,8 @@ const reviewRequestService = new ReviewRequestService(
   pageService,
   new ConfigService()
 )
+const sitesCacheService = new SitesCacheService()
+
 const sitesService = new SitesService({
   siteRepository: Site,
   gitHubService,
@@ -198,6 +201,7 @@ const sitesService = new SitesService({
   usersService,
   isomerAdminsService,
   reviewRequestService,
+  sitesCacheService,
 })
 const reposService = new ReposService({ repository: Repo })
 const deploymentsService = new DeploymentsService({

--- a/src/server.js
+++ b/src/server.js
@@ -192,7 +192,8 @@ const reviewRequestService = new ReviewRequestService(
   pageService,
   new ConfigService()
 )
-const sitesCacheService = new SitesCacheService()
+const cacheRefreshInterval = 1000 * 60 * 5 // 5 minutes
+const sitesCacheService = new SitesCacheService(cacheRefreshInterval)
 
 const sitesService = new SitesService({
   siteRepository: Site,

--- a/src/services/db/TokenService.ts
+++ b/src/services/db/TokenService.ts
@@ -322,10 +322,10 @@ export class TokenService {
     if (this.initialized) {
       return okAsync(true)
     }
-    this.initialized = true
     return resetStrandedTokens(this.tokenDB).andThen(() =>
       queryActiveTokens(this.tokenDB).map((activeTokensData) => {
         this.activeTokensData = activeTokensData
+        this.initialized = true
         return false
       })
     )

--- a/src/services/identity/SitesCacheService.ts
+++ b/src/services/identity/SitesCacheService.ts
@@ -14,8 +14,6 @@ import type { GitHubRepositoryData, RepositoryData } from "@root/types/repoInfo"
 // Changes are polled at fixed intervals, stored in cache, and served
 // to avoid long load time from live querying.
 
-const REPO_DATA_REFRESH_INTERVAL = 60 * 1000 // 1 minutes
-
 export async function getAllRepoData(
   accessToken: string | undefined
 ): Promise<RepositoryData[]> {
@@ -76,10 +74,13 @@ export async function getAllRepoData(
 export class SitesCacheService {
   private repoDataCache: RepositoryData[]
 
-  constructor() {
+  private refreshInterval: number
+
+  constructor(refreshInterval: number) {
     this.repoDataCache = []
+    this.refreshInterval = refreshInterval
     this.renewCache()
-    setInterval(() => this.renewCache(), REPO_DATA_REFRESH_INTERVAL)
+    setInterval(() => this.renewCache(), this.refreshInterval)
   }
 
   private async renewCache() {

--- a/src/services/identity/__tests__/SitesService.spec.ts
+++ b/src/services/identity/__tests__/SitesService.spec.ts
@@ -1033,14 +1033,16 @@ describe("SitesService", () => {
 
   describe("getLastUpdated", () => {
     it("Checks when site was last updated", async () => {
-      MockGithubService.getRepoInfo.mockResolvedValueOnce(repoInfo)
+      MockSitesCacheService.getLastUpdated.mockResolvedValueOnce(
+        repoInfo.pushed_at
+      )
 
       await expect(
         SitesService.getLastUpdated(mockUserWithSiteSessionData)
       ).resolves.toEqual(repoInfo.pushed_at)
 
-      expect(MockGithubService.getRepoInfo).toHaveBeenCalledWith(
-        mockUserWithSiteSessionData
+      expect(MockSitesCacheService.getLastUpdated).toHaveBeenCalledWith(
+        mockUserWithSiteSessionData.siteName
       )
     })
   })

--- a/src/services/identity/__tests__/SitesService.spec.ts
+++ b/src/services/identity/__tests__/SitesService.spec.ts
@@ -49,6 +49,7 @@ import { SiteInfo } from "@root/types/siteInfo"
 import { GitHubService } from "@services/db/GitHubService"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
 import IsomerAdminsService from "@services/identity/IsomerAdminsService"
+import { SitesCacheService } from "@services/identity/SitesCacheService"
 import _SitesService from "@services/identity/SitesService"
 import UsersService from "@services/identity/UsersService"
 
@@ -79,6 +80,10 @@ const MockReviewRequestService = {
   getLatestMergedReviewRequest: jest.fn(),
 }
 
+const MockSitesCacheService = {
+  getLastUpdated: jest.fn(),
+}
+
 const SitesService = new _SitesService({
   siteRepository: (MockRepository as unknown) as ModelStatic<Site>,
   gitHubService: (MockGithubService as unknown) as GitHubService,
@@ -86,6 +91,7 @@ const SitesService = new _SitesService({
   usersService: (MockUsersService as unknown) as UsersService,
   isomerAdminsService: (MockIsomerAdminsService as unknown) as IsomerAdminsService,
   reviewRequestService: (MockReviewRequestService as unknown) as ReviewRequestService,
+  sitesCacheService: (MockSitesCacheService as unknown) as SitesCacheService,
 })
 
 const SpySitesService = {

--- a/src/services/utilServices/RepoCache.ts
+++ b/src/services/utilServices/RepoCache.ts
@@ -1,0 +1,89 @@
+import _ from "lodash"
+
+import {
+  ISOMERPAGES_REPO_PAGE_COUNT,
+  GH_MAX_REPO_COUNT,
+  ISOMER_ADMIN_REPOS,
+  GITHUB_ORG_REPOS_ENDPOINT,
+} from "@root/constants"
+import { genericGitHubAxiosInstance } from "@root/services/api/AxiosInstance"
+import type { GitHubRepositoryData, RepositoryData } from "@root/types/repoInfo"
+
+const CACHE_REFRESH_INTERVAL = 60 * 1000 // 1 minutes
+
+export async function getAllRepoData(
+  accessToken: string | undefined
+): Promise<RepositoryData[]> {
+  // Simultaneously retrieve all isomerpages repos
+  const paramsArr = _.fill(Array(ISOMERPAGES_REPO_PAGE_COUNT), null).map(
+    (__, idx) => ({
+      per_page: GH_MAX_REPO_COUNT,
+      sort: "full_name",
+      page: idx + 1,
+    })
+  )
+
+  const allSites = await Promise.all(
+    paramsArr.map(async (params) => {
+      const {
+        data: respData,
+      }: {
+        data: GitHubRepositoryData[]
+      } = await genericGitHubAxiosInstance.get(
+        GITHUB_ORG_REPOS_ENDPOINT,
+        accessToken
+          ? {
+              headers: { Authorization: `token ${accessToken}` },
+              params,
+            }
+          : { params }
+      )
+      return respData
+        .map((gitHubRepoData) => {
+          const {
+            pushed_at: updatedAt,
+            permissions,
+            name,
+            private: isPrivate,
+          } = gitHubRepoData
+
+          return {
+            lastUpdated: updatedAt,
+            permissions,
+            repoName: name,
+            isPrivate,
+          } as RepositoryData
+        })
+        .filter((repoData) => {
+          if (!repoData || !repoData.permissions) {
+            return false
+          }
+          return (
+            repoData.permissions.push === true &&
+            !ISOMER_ADMIN_REPOS.includes(repoData.repoName)
+          )
+        })
+    })
+  )
+  return _.flatten(allSites)
+}
+
+export class RepositoryDataCache {
+  private allRepositoryDataCache: RepositoryData[]
+
+  constructor() {
+    this.allRepositoryDataCache = []
+    this.renewCache()
+    setInterval(() => this.renewCache(), CACHE_REFRESH_INTERVAL)
+  }
+
+  async renewCache() {
+    this.allRepositoryDataCache = await getAllRepoData(undefined)
+  }
+
+  getLastUpdated(repoName: string) {
+    return this.allRepositoryDataCache.find(
+      (repoData) => repoData.repoName === repoName
+    )?.lastUpdated
+  }
+}


### PR DESCRIPTION
## Problem

`lastUpdated` field for site info has been removed from backend and frontend dashboard for email login users due to excessive token use.  Querying `lastUpdated` for each individual site cost 1 token use each which is too expensive for commonly visited such as dashboard. 

Closes IS-169

## Solution

`lastUpdated` along with other repo info can be queried in bulk through Github endpoint. Each query allow a maximum of 100 repos and cost only 1 token use. It would take only 10 token uses to get repo info of all sites under `isomerpages` (pageCount 10 for up to 1000 repos). Hence, we can query all repos info at regular intervals and store in a cache to be served on request. Currently, its set to refresh at once per 5 minutes, and with a maximum of 5 instances, which will lead to 10 * 12 * 5 = 600 token uses per hour. This is 600 / 50000 = 1.2% of the total token capacity, which does not contribute significantly to reaching token limits.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

## Tests

Visiting the sites dashboard as an email login user should show `lastUpdated` information. 

## Note

The primary motivation for this solution is reduce load on the database instance. As more users are onboarded onto email-based login, it can be expected that sites read queries and updates can take up significant database CPU usage. However, if in the case that database size is scaled up in the future, this solution can be dropped in favour of directly reading and writing to database. 