### PR TITLE
Fix: siteLaunchEmailNotification

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -57,3 +57,4 @@ export const ISOMER_ADMIN_REPOS = [
 export const INACTIVE_USER_THRESHOLD_DAYS = 60
 export const GITHUB_ORG_REPOS_ENDPOINT = `https://api.github.com/orgs/${ISOMER_GITHUB_ORG_NAME}/repos`
 export const REDIRECTION_SERVER_IP = config.get("redirectionServer.elasticIp")
+export const ISOMER_ADMIN_EMAIL = "admin@isomer.gov.sg"

--- a/src/routes/formsgSiteLaunch.ts
+++ b/src/routes/formsgSiteLaunch.ts
@@ -10,6 +10,7 @@ import InitializationError from "@errors/InitializationError"
 
 import { getField, getFieldsFromTable } from "@utils/formsg-utils"
 
+import { ISOMER_ADMIN_EMAIL } from "@root/constants"
 import { attachFormSGHandler } from "@root/middleware"
 import { mailer } from "@root/services/utilServices/MailClient"
 import {
@@ -31,8 +32,6 @@ export interface FormsgRouterProps {
   usersService: UsersService
   infraService: InfraService
 }
-
-const ISOMER_ADMIN_EMAIL = "admin@isomer.gov.sg"
 
 interface FormResponsesProps {
   submissionId: string

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -22,6 +22,7 @@ import {
   JobStatus,
   RedirectionTypes,
   REDIRECTION_SERVER_IP,
+  ISOMER_ADMIN_EMAIL,
 } from "@root/constants"
 import MissingSiteError from "@root/errors/MissingSiteError"
 import MissingUserEmailError from "@root/errors/MissingUserEmailError"
@@ -614,10 +615,8 @@ export default class InfraService {
       emailDetails = failureEmailDetails
     }
 
-    await mailer.sendMail(
-      message.requestorEmail,
-      emailDetails.subject,
-      emailDetails.body
-    )
+    const targetEmail = isSuccess ? message.requestorEmail : ISOMER_ADMIN_EMAIL
+
+    await mailer.sendMail(targetEmail, emailDetails.subject, emailDetails.body)
   }
 }


### PR DESCRIPTION
## Problem

When site launch fails, it contains error message that is useful for us to consume. This might confuse end users if they were to receive such an email. 
Ideally, if there are any error messages, the user should be given some info if it is recoverable, else it should ping us for manual remediation. 

## Solution

As a first cut, the failure email heads straights to admin@isomer.gov.sg, so that we are able to take a look at it during launch. 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

