### PR TITLE
chore(types): add warning message about changing the shape here

### DIFF
--- a/microservices/site-launch/shared/types.ts
+++ b/microservices/site-launch/shared/types.ts
@@ -1,3 +1,5 @@
+//! NOTE: Needs to be similar to https://github.com/isomerpages/isomer-infra/blob/main/src/lambdaFunctions/shared/model.ts
+//! Any changes to the types here should be reflected there as well
 export enum SiteLaunchLambdaType {
   GENERAL_DOMAIN_VALIDATION = "general-domain-validation",
   PRIMARY_DOMAIN_VALIDATION = "primary-domain-validation",


### PR DESCRIPTION
## Problem

There is an duplicate of type definitions in this repo and infra. While this is not ideal, this was chosen to keep the infra repo private. There lies a risk when devs work on this feature that might change this shape and break corresponding infra. 


## Solution

Add a comment to warn dev not to change type def. 

