### PR TITLE
Fix/restrict privatisation to email login

### DIFF
--- a/src/routes/v2/authenticatedSites/__tests__/Settings.spec.js
+++ b/src/routes/v2/authenticatedSites/__tests__/Settings.spec.js
@@ -32,8 +32,11 @@ describe("Settings Router", () => {
     extractNavFields: SettingsService.extractNavFields,
   }
 
+  const mockAuthorizationMiddleware = jest.fn()
+
   const router = new SettingsRouter({
     settingsService: mockSettingsService,
+    authorizationMiddleware: mockAuthorizationMiddleware,
   })
 
   const subrouter = express()

--- a/src/routes/v2/authenticatedSites/index.js
+++ b/src/routes/v2/authenticatedSites/index.js
@@ -187,7 +187,10 @@ const getAuthenticatedSitesSubrouter = ({
   })
   const contactUsV2Router = new ContactUsRouter({ contactUsPageService })
   const homepageV2Router = new HomepageRouter({ homepagePageService })
-  const settingsV2Router = new SettingsRouter({ settingsService })
+  const settingsV2Router = new SettingsRouter({
+    settingsService,
+    authorizationMiddleware,
+  })
   const navigationV2Router = new NavigationRouter({
     navigationYmlService: navYmlService,
   })

--- a/src/routes/v2/authenticatedSites/settings.js
+++ b/src/routes/v2/authenticatedSites/settings.js
@@ -20,7 +20,8 @@ const { isPasswordValid } = require("@root/validators/validators")
 const { SettingsService } = require("@services/configServices/SettingsService")
 
 class SettingsRouter {
-  constructor({ settingsService }) {
+  constructor({ settingsService, authorizationMiddleware }) {
+    this.authorizationMiddleware = authorizationMiddleware
     this.settingsService = settingsService
     // We need to bind all methods because we don't invoke them from the class directly
     autoBind(this)
@@ -129,10 +130,12 @@ class SettingsRouter {
     router.post("/", attachRollbackRouteHandlerWrapper(this.updateSettingsPage))
     router.get(
       "/repo-password",
+      this.authorizationMiddleware.verifyIsEmailUser,
       attachReadRouteHandlerWrapper(this.getRepoPassword)
     )
     router.post(
       "/repo-password",
+      this.authorizationMiddleware.verifyIsEmailUser,
       attachWriteRouteHandlerWrapper(this.updateRepoPassword)
     )
 


### PR DESCRIPTION
This PR adds an additional restriction to the repo privatisation feature such that only email login users can see the feature - this is due to the prerequisite of restricting github access before being able to convert repos to private, as private repos are unable to set additional branch protection rules, meaning the PR approval requirement can be bypassed. To be reviewed in conjunction with PR #[1344](https://github.com/isomerpages/isomercms-frontend/pull/1344) on the isomercms-frontend repo.