### PR TITLE
fix: review request placeholder files

### DIFF
--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -527,7 +527,6 @@ export class ReviewsRouter {
           stagingLink
         )
       )
-    console.log(possibleReviewRequest)
 
     // NOTE: This method call (`getFullReviewRequest`) should be
     // in the result also but as it returns a promise at the moment,

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -527,6 +527,7 @@ export class ReviewsRouter {
           stagingLink
         )
       )
+    console.log(possibleReviewRequest)
 
     // NOTE: This method call (`getFullReviewRequest`) should be
     // in the result also but as it returns a promise at the moment,

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -152,6 +152,9 @@ export default class ReviewRequestService {
           )
         )
       )
+      .andThen((items) =>
+        okAsync(items.filter((item) => item.type !== "placeholder"))
+      )
 
   private compareDiffWithMappings = (
     sessionData: UserWithSiteSessionData,
@@ -736,18 +739,10 @@ export default class ReviewRequestService {
         // Refer here for details; https://docs.github.com/en/rest/commits/commits#compare-two-commits
         // Note that we need a triple dot (...) between base and head refs
         this.compareDiff(userWithSiteSessionData, stagingLink).map(
-          (changedItems) => {
-            const displayedFiles = changedItems.filter(
-              (
-                changedItem
-              ): changedItem is WithEditMeta<DisplayedEditedItemDto> =>
-                changedItem.type !== "placeholder"
-            )
-            return {
-              ...rest,
-              changedItems: displayedFiles,
-            }
-          }
+          (changedItems) => ({
+            ...rest,
+            changedItems,
+          })
         )
       )
   }

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -125,7 +125,10 @@ export default class ReviewRequestService {
   compareDiff = (
     userWithSiteSessionData: UserWithSiteSessionData,
     stagingLink: StagingPermalink
-  ): ResultAsync<WithEditMeta<EditedItemDto>[], NetworkError | DatabaseError> =>
+  ): ResultAsync<
+    WithEditMeta<DisplayedEditedItemDto>[],
+    NetworkError | DatabaseError
+  > =>
     ResultAsync.fromPromise(
       this.apiService.getCommitDiff(userWithSiteSessionData.siteName),
       // TODO: Write a handler for github errors to our own internal errors
@@ -152,8 +155,11 @@ export default class ReviewRequestService {
           )
         )
       )
-      .andThen((items) =>
-        okAsync(items.filter((item) => item.type !== "placeholder"))
+      .map((changedItems) =>
+        changedItems.filter(
+          (changedItem): changedItem is WithEditMeta<DisplayedEditedItemDto> =>
+            changedItem.type !== "placeholder"
+        )
       )
 
   private compareDiffWithMappings = (


### PR DESCRIPTION
This PR fixes an issue where compareDiff was not filtering placeholder files. This affected any review requests which involved placeholder files, as our frontend does not handle that specific file type. To fix this, we moved the filter from `compareFullReviewRequest` to `compareDiff`, which is called by both relevant endpoints.

## Tests 
- [ ] create a review request when the only file changes are placeholder files which are hidden
- [ ] FE should block creation of review request
- [ ] created a review request when there are file changes other than placeholder files, but is subsequently removed, leaving only placeholder file changes in the review request
- [ ] FE shows 0 file changes but does not block closing and merging for review request
- [ ] server should not throw any error