### PR TITLE
chore(e2e): change naming for clarity

### DIFF
--- a/src/services/middlewareServices/AuthenticationMiddlewareService.ts
+++ b/src/services/middlewareServices/AuthenticationMiddlewareService.ts
@@ -65,7 +65,7 @@ export type VerifyAccessProps = UnverifiedSession & {
 const E2E_USERS = {
   Email: {
     Admin: "Email admin",
-    Collaborator: "Email collaborator",
+    Contributor: "Email contributor",
   },
   Github: {
     User: "Github user",
@@ -79,7 +79,7 @@ type TestUserTypes =
 // NOTE: Precondition to use this function is that the user type is valid.
 const getUserType = (userType: string): TestUserTypes => {
   if (userType === E2E_USERS.Email.Admin) return userType
-  if (userType === E2E_USERS.Email.Collaborator) return userType
+  if (userType === E2E_USERS.Email.Contributor) return userType
   if (userType === E2E_USERS.Github.User) return userType
   throw new Error(`Invalid user type: ${userType}`)
 }
@@ -147,7 +147,7 @@ export const extractE2eUserInfo = async (
   switch (userType) {
     case E2E_USERS.Email.Admin:
       return generateE2eEmailUser(CollaboratorRoles.Admin, site, email)
-    case E2E_USERS.Email.Collaborator:
+    case E2E_USERS.Email.Contributor:
       return generateE2eEmailUser(CollaboratorRoles.Contributor, site, email)
     case E2E_USERS.Github.User:
       return generateGithubUser()
@@ -188,7 +188,7 @@ export default class AuthenticationMiddlewareService {
     const isEmailE2eAccess =
       (repo === E2E_EMAIL_TEST_SITE.repo || repo === E2E_TEST_REPO) &&
       (userType === E2E_USERS.Email.Admin ||
-        userType === E2E_USERS.Email.Collaborator)
+        userType === E2E_USERS.Email.Contributor)
     const isGithubE2eAccess =
       repo === E2E_TEST_REPO && userType === "Github user"
 

--- a/src/services/middlewareServices/__tests__/AuthenticationMiddlewareService.spec.ts
+++ b/src/services/middlewareServices/__tests__/AuthenticationMiddlewareService.spec.ts
@@ -19,7 +19,7 @@ const {
 } = auth
 
 const E2E_EMAIL_ADMIN_ISOMER_ID = "1"
-const E2E_EMAIL_COLLAB_ISOMER_ID = "2"
+const E2E_EMAIL_CONTRI_ISOMER_ID = "2"
 
 const MOCK_E2E_EMAIL = "MOCK@TEST.GOV.SG"
 
@@ -70,13 +70,13 @@ const E2E_EMAIL_COLLAB_PROPS: VerifyAccessProps = {
   // NOTE: Actual users won't have cookies - instead, they will use our session
   cookies: {
     isomercmsE2E: config.get("cypress.e2eTestSecret"),
-    e2eUserType: "Email collaborator",
+    e2eUserType: "Email contributor",
     site: "",
     email: "",
   },
   userInfo: {
     // NOTE: email users won't have github related fields
-    isomerUserId: E2E_EMAIL_COLLAB_ISOMER_ID,
+    isomerUserId: E2E_EMAIL_CONTRI_ISOMER_ID,
     email: MOCK_E2E_EMAIL,
   },
   url: E2E_EMAIL_REPO_URL,


### PR DESCRIPTION
## Problem

The terms collaborator and contributor has semantic differences our our code base.
to be reviewed with [fe pr](https://github.com/isomerpages/isomercms-frontend/pull/1362)

## Solution

 Changing collab to contri naming here for calrity. 
**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Tests

Ran collaborator tests spec here, same result as last week during release. 
<img width="460" alt="Screenshot 2023-07-24 at 11 49 33 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/d121fce5-f411-4b98-9741-5bc308bf557b">
<img width="1134" alt="Screenshot 2023-07-24 at 11 49 25 AM" src="https://github.com/isomerpages/isomercms-frontend/assets/42832651/5aa4903b-88d6-45b2-ad31-5fdeef40390a">