### PR TITLE
feat(stats): track gh calls

### DIFF
--- a/src/middleware/stats.ts
+++ b/src/middleware/stats.ts
@@ -37,10 +37,6 @@ export class StatsMiddleware {
 
   countDbUsers = wrapAsRequestHandler(() => this.statsService.countDbUsers())
 
-  countGithubSites = wrapAsRequestHandler(() =>
-    this.statsService.countGithubSites()
-  )
-
   countMigratedSites = wrapAsRequestHandler(() =>
     this.statsService.countMigratedSites()
   )

--- a/src/routes/v2/authenticated/__tests__/Sites.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/Sites.spec.ts
@@ -35,7 +35,6 @@ describe("Sites Router", () => {
   }
 
   const mockStatsMiddleware = {
-    countGithubSites: jest.fn(),
     countMigratedSites: jest.fn(),
   }
 

--- a/src/services/api/AxiosInstance.ts
+++ b/src/services/api/AxiosInstance.ts
@@ -79,10 +79,6 @@ const respHandler = (response: AxiosResponse) => {
 }
 
 const githubApiInterceptor = (resp: AxiosResponse) => {
-  const isEmailUser = getIsEmailUserFromAuthMessage(
-    resp.config.headers?.Authorization
-  )
-
   if (
     resp.status !== 304 &&
     resp.config.url?.includes(GITHUB_EXPERIMENTAL_TRIAL_SITE) &&
@@ -90,8 +86,7 @@ const githubApiInterceptor = (resp: AxiosResponse) => {
   ) {
     statsService.incrementGithubApiCall(
       resp.config.method,
-      GITHUB_EXPERIMENTAL_TRIAL_SITE,
-      isEmailUser ? "email" : "github"
+      GITHUB_EXPERIMENTAL_TRIAL_SITE
     )
   }
   return resp

--- a/src/services/infra/StatsService.ts
+++ b/src/services/infra/StatsService.ts
@@ -1,4 +1,5 @@
 /* eslint-disable import/prefer-default-export */
+import { Method } from "axios"
 import StatsDClient, { StatsD } from "hot-shots"
 import _ from "lodash"
 import { ModelStatic } from "sequelize"
@@ -103,6 +104,20 @@ export class StatsService {
   trackEmailLogins = () => {
     this.statsD.increment("users.email.login", {
       version: Versions.V2,
+    })
+  }
+
+  incrementGithubApiCall = (
+    method: Method,
+    site: string,
+    userType: "email" | "github"
+  ) => {
+    this.statsD.increment("users.github.api", {
+      site,
+      // NOTE: Allowed to pass in lowercase,
+      // standardised to uppercase for consistency
+      method: method.toUpperCase(),
+      userType,
     })
   }
 }

--- a/src/services/infra/StatsService.ts
+++ b/src/services/infra/StatsService.ts
@@ -1,22 +1,13 @@
 /* eslint-disable import/prefer-default-export */
 import { Method } from "axios"
 import StatsDClient, { StatsD } from "hot-shots"
-import _ from "lodash"
 import { ModelStatic } from "sequelize"
 
 import { config } from "@config/config"
 
-import {
-  Versions,
-  GH_MAX_REPO_COUNT,
-  GITHUB_ORG_REPOS_ENDPOINT,
-  ISOMERPAGES_REPO_PAGE_COUNT,
-  VersionNumber,
-} from "@constants/index"
+import { Versions, VersionNumber } from "@constants/index"
 
 import { AccessToken, Site, User } from "@root/database/models"
-
-import { genericGitHubAxiosInstance } from "../api/AxiosInstance"
 
 export class StatsService {
   private readonly statsD: StatsD
@@ -59,30 +50,6 @@ export class StatsService {
     this.statsD.distribution("users.email.current", numUsers, 1, {
       version: Versions.V2,
     })
-  }
-
-  countGithubSites = async () => {
-    const accessToken = await this.accessTokenRepo.findOne()
-    // NOTE: Cannot submit metrics if we are unable to get said metric
-    if (!accessToken) return
-
-    const sitesArr = await Promise.all(
-      _.fill(Array(ISOMERPAGES_REPO_PAGE_COUNT), null)
-        .map((__, idx) => ({
-          per_page: GH_MAX_REPO_COUNT,
-          sort: "full_name",
-          page: idx + 1,
-        }))
-        .map((params) =>
-          genericGitHubAxiosInstance
-            .get<unknown[]>(GITHUB_ORG_REPOS_ENDPOINT, {
-              params,
-            })
-            .then(({ data }) => data)
-        )
-    )
-
-    this.statsD.distribution("sites.github.all", sitesArr.flat().length, 1)
   }
 
   countMigratedSites = async () => {

--- a/src/services/infra/StatsService.ts
+++ b/src/services/infra/StatsService.ts
@@ -107,17 +107,12 @@ export class StatsService {
     })
   }
 
-  incrementGithubApiCall = (
-    method: Method,
-    site: string,
-    userType: "email" | "github"
-  ) => {
+  incrementGithubApiCall = (method: Method, site: string) => {
     this.statsD.increment("users.github.api", {
       site,
       // NOTE: Allowed to pass in lowercase,
       // standardised to uppercase for consistency
       method: method.toUpperCase(),
-      userType,
     })
   }
 }


### PR DESCRIPTION
## Problem
Adds metric tracking for `pa-corp`.

## Solution
1. add `statsD` call for new endpoint
2. get the trial site as a `const` in code - **not very tied to this**, we could do either env var or db table instead of this but my understanding is that the trial site is unlikely to change + we are implementing ld soon, which makes the extra effort not worth.

see the data [here](https://app.datadoghq.com/dashboard/8tj-6k5-p2v/isomercms?fullscreen_end_ts=1690257331702&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1689652531702&fullscreen_widget=116425520844967&from_ts=1689647396729&to_ts=1690252196729&live=true) 

## Tests
- [ ] go to `pa-corp` 
- [ ] make an edit
- [ ] refresh
- [ ] go back to datadog 
- [ ] number shuold have changed (might have to wait abit)