### PR TITLE
fix(reviewRequestService): upsert in case of concurrent api calls

### DIFF
--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -119,7 +119,8 @@ const reviewRequestService = new ReviewRequestService(
   ReviewMeta,
   ReviewRequestView,
   pageService,
-  configService
+  configService,
+  sequelize
 )
 // Using a mock SitesCacheService as the actual service has setInterval
 // which causes tests to not exit.

--- a/src/integration/Notifications.spec.ts
+++ b/src/integration/Notifications.spec.ts
@@ -112,7 +112,8 @@ const reviewRequestService = new ReviewRequestService(
   ReviewMeta,
   ReviewRequestView,
   pageService,
-  configService
+  configService,
+  sequelize
 )
 // Using a mock SitesCacheService as the actual service has setInterval
 // which causes tests to not exit.

--- a/src/integration/Privatisation.spec.ts
+++ b/src/integration/Privatisation.spec.ts
@@ -141,7 +141,8 @@ const reviewRequestService = new ReviewRequestService(
   ReviewMeta,
   ReviewRequestView,
   pageService,
-  configService
+  configService,
+  sequelize
 )
 // Using a mock SitesCacheService as the actual service has setInterval
 // which causes tests to not exit.

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -144,7 +144,8 @@ const reviewRequestService = new ReviewRequestService(
   ReviewMeta,
   ReviewRequestView,
   pageService,
-  configService
+  configService,
+  sequelize
 )
 // Using a mock SitesCacheService as the actual service has setInterval
 // which causes tests to not exit.

--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -111,7 +111,8 @@ const reviewRequestService = new ReviewRequestService(
   ReviewMeta,
   ReviewRequestView,
   pageService,
-  configService
+  configService,
+  sequelize
 )
 // Using a mock SitesCacheService as the actual service has setInterval
 // which causes tests to not exit.

--- a/src/server.js
+++ b/src/server.js
@@ -194,7 +194,8 @@ const reviewRequestService = new ReviewRequestService(
   ReviewMeta,
   ReviewRequestView,
   pageService,
-  new ConfigService()
+  new ConfigService(),
+  sequelize
 )
 const cacheRefreshInterval = 1000 * 60 * 5 // 5 minutes
 const sitesCacheService = new SitesCacheService(cacheRefreshInterval)

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -512,7 +512,7 @@ export default class ReviewRequestService {
       // Using map here to allow creations to be done concurrently
       // But we do not actually need the result of the view creation
       requestIdsToMarkAsViewed.map(async (requestId) =>
-        this.reviewRequestView.create({
+        this.reviewRequestView.upsert({
           reviewRequestId: requestId,
           siteId: site.id,
           userId,

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -10,6 +10,7 @@ import {
   combine,
 } from "neverthrow"
 import { Op, ModelStatic } from "sequelize"
+import { Sequelize } from "sequelize-typescript"
 
 import UserWithSiteSessionData from "@classes/UserWithSiteSessionData"
 
@@ -31,6 +32,7 @@ import { NotFoundError } from "@root/errors/NotFoundError"
 import PageParseError from "@root/errors/PageParseError"
 import PlaceholderParseError from "@root/errors/PlaceholderParseError"
 import RequestNotFoundError from "@root/errors/RequestNotFoundError"
+import logger from "@root/logger/logger"
 import {
   BaseEditedItemDto,
   CommentItem,
@@ -102,6 +104,8 @@ export default class ReviewRequestService {
 
   private readonly configService: ConfigService
 
+  private readonly sequelize: Sequelize
+
   constructor(
     apiService: typeof ReviewApi,
     users: ModelStatic<User>,
@@ -110,7 +114,8 @@ export default class ReviewRequestService {
     reviewMeta: ModelStatic<ReviewMeta>,
     reviewRequestView: ModelStatic<ReviewRequestView>,
     pageService: PageService,
-    configService: ConfigService
+    configService: ConfigService,
+    sequelize: Sequelize
   ) {
     this.apiService = apiService
     this.users = users
@@ -120,6 +125,7 @@ export default class ReviewRequestService {
     this.reviewRequestView = reviewRequestView
     this.pageService = pageService
     this.configService = configService
+    this.sequelize = sequelize
   }
 
   compareDiff = (
@@ -481,47 +487,57 @@ export default class ReviewRequestService {
     sessionData: UserWithSiteSessionData,
     site: Site
   ): Promise<void> => {
-    const { isomerUserId: userId } = sessionData
-
-    const requestsViewed = await this.reviewRequestView.findAll({
-      where: {
-        siteId: site.id,
-        userId,
-      },
-    })
-
-    const allActiveRequests = await this.repository.findAll({
-      where: {
-        siteId: site.id,
-        // NOTE: Closed and merged review requests would not have an
-        // entry in the review request views table
-        reviewStatus: ["OPEN", "APPROVED"],
-      },
-    })
-
-    const requestIdsViewed = requestsViewed.map(
-      (request) => request.reviewRequestId
-    )
-    const allActiveRequestIds = allActiveRequests.map((request) => request.id)
-    const requestIdsToMarkAsViewed = _.difference(
-      allActiveRequestIds,
-      requestIdsViewed
-    )
-
-    await Promise.all(
-      // Using map here to allow creations to be done concurrently
-      // But we do not actually need the result of the view creation
-      requestIdsToMarkAsViewed.map(async (requestId) =>
-        this.reviewRequestView.upsert({
-          reviewRequestId: requestId,
-          siteId: site.id,
-          userId,
-          // This field represents the user opening the review request
-          // itself, which the user has not done so yet at this stage.
-          lastViewedAt: null,
+    try {
+      const { isomerUserId: userId } = sessionData
+      await this.sequelize.transaction(async (transaction) => {
+        const requestsViewed = await this.reviewRequestView.findAll({
+          where: {
+            siteId: site.id,
+            userId,
+          },
+          transaction,
         })
-      )
-    )
+
+        const allActiveRequests = await this.repository.findAll({
+          where: {
+            siteId: site.id,
+            reviewStatus: ["OPEN", "APPROVED"],
+          },
+          transaction,
+        })
+
+        const requestIdsViewed = requestsViewed.map(
+          (request) => request.reviewRequestId
+        )
+        const allActiveRequestIds = allActiveRequests.map(
+          (request) => request.id
+        )
+        const requestIdsToMarkAsViewed = _.difference(
+          allActiveRequestIds,
+          requestIdsViewed
+        )
+
+        await Promise.all(
+          requestIdsToMarkAsViewed.map(async (requestId) =>
+            this.reviewRequestView.create(
+              {
+                reviewRequestId: requestId,
+                siteId: site.id,
+                userId,
+                lastViewedAt: null,
+              },
+              { transaction }
+            )
+          )
+        )
+      })
+    } catch (error) {
+      // NOTE: If execution reaches this line, the transaction has already rolled back
+      logger.info({
+        message: "Failed to mark all review requests as viewed",
+        error,
+      })
+    }
   }
 
   updateReviewRequestLastViewedAt = async (

--- a/src/services/review/__tests__/ReviewRequestService.spec.ts
+++ b/src/services/review/__tests__/ReviewRequestService.spec.ts
@@ -774,7 +774,7 @@ describe("ReviewRequestService", () => {
       MockReviewRequestRepository.findAll.mockResolvedValueOnce([
         MOCK_REVIEW_REQUEST_ONE,
       ])
-      MockReviewRequestViewRepository.create.mockResolvedValueOnce(undefined)
+      MockReviewRequestViewRepository.upsert.mockResolvedValueOnce(undefined)
 
       // Act
       await ReviewRequestService.markAllReviewRequestsAsViewed(
@@ -785,7 +785,7 @@ describe("ReviewRequestService", () => {
       // Assert
       expect(MockReviewRequestViewRepository.findAll).toHaveBeenCalled()
       expect(MockReviewRequestRepository.findAll).toHaveBeenCalled()
-      expect(MockReviewRequestViewRepository.create).toHaveBeenCalledWith({
+      expect(MockReviewRequestViewRepository.upsert).toHaveBeenCalledWith({
         reviewRequestId: MOCK_REVIEW_REQUEST_ONE.id,
         siteId: mockSiteOrmResponseWithAllCollaborators.id,
         userId: mockUserWithSiteSessionData.isomerUserId,
@@ -801,7 +801,7 @@ describe("ReviewRequestService", () => {
       MockReviewRequestRepository.findAll.mockResolvedValueOnce([
         MOCK_REVIEW_REQUEST_ONE,
       ])
-      MockReviewRequestViewRepository.create.mockResolvedValueOnce(undefined)
+      MockReviewRequestViewRepository.upsert.mockResolvedValueOnce(undefined)
 
       // Act
       await ReviewRequestService.markAllReviewRequestsAsViewed(
@@ -812,7 +812,7 @@ describe("ReviewRequestService", () => {
       // Assert
       expect(MockReviewRequestViewRepository.findAll).toHaveBeenCalled()
       expect(MockReviewRequestRepository.findAll).toHaveBeenCalled()
-      expect(MockReviewRequestViewRepository.create).not.toHaveBeenCalled()
+      expect(MockReviewRequestViewRepository.upsert).not.toHaveBeenCalled()
     })
   })
 

--- a/src/services/review/__tests__/ReviewRequestService.spec.ts
+++ b/src/services/review/__tests__/ReviewRequestService.spec.ts
@@ -1,6 +1,7 @@
 import _ from "lodash"
 import { err, ok, okAsync } from "neverthrow"
 import { Attributes, ModelStatic } from "sequelize"
+import { Sequelize } from "sequelize-typescript"
 
 import {
   ReviewRequest,
@@ -52,7 +53,7 @@ import {
 import { mockUserWithSiteSessionData } from "@root/fixtures/sessionData"
 import { PageService } from "@root/services/fileServices/MdPageServices/PageService"
 import { ConfigService } from "@root/services/fileServices/YmlFileServices/ConfigService"
-import { EditedPageDto, GithubCommentData } from "@root/types/dto/review"
+import { GithubCommentData } from "@root/types/dto/review"
 import { Commit } from "@root/types/github"
 import * as ReviewApi from "@services/db/review"
 import _ReviewRequestService from "@services/review/ReviewRequestService"
@@ -114,6 +115,10 @@ const MockConfigService = {
   isConfigFile: jest.fn(),
 }
 
+const MockSequelize = {
+  transaction: jest.fn((transaction) => transaction()),
+}
+
 const ReviewRequestService = new _ReviewRequestService(
   (MockReviewApi as unknown) as typeof ReviewApi,
   (MockUsersRepository as unknown) as ModelStatic<User>,
@@ -122,7 +127,8 @@ const ReviewRequestService = new _ReviewRequestService(
   (MockReviewMetaRepository as unknown) as ModelStatic<ReviewMeta>,
   (MockReviewRequestViewRepository as unknown) as ModelStatic<ReviewRequestView>,
   (MockPageService as unknown) as PageService,
-  (MockConfigService as unknown) as ConfigService
+  (MockConfigService as unknown) as ConfigService,
+  (MockSequelize as unknown) as Sequelize
 )
 
 const SpyReviewRequestService = {
@@ -774,7 +780,7 @@ describe("ReviewRequestService", () => {
       MockReviewRequestRepository.findAll.mockResolvedValueOnce([
         MOCK_REVIEW_REQUEST_ONE,
       ])
-      MockReviewRequestViewRepository.upsert.mockResolvedValueOnce(undefined)
+      MockReviewRequestViewRepository.create.mockResolvedValueOnce(undefined)
 
       // Act
       await ReviewRequestService.markAllReviewRequestsAsViewed(
@@ -783,13 +789,10 @@ describe("ReviewRequestService", () => {
       )
 
       // Assert
-      expect(MockReviewRequestViewRepository.findAll).toHaveBeenCalled()
-      expect(MockReviewRequestRepository.findAll).toHaveBeenCalled()
-      expect(MockReviewRequestViewRepository.upsert).toHaveBeenCalledWith({
-        reviewRequestId: MOCK_REVIEW_REQUEST_ONE.id,
-        siteId: mockSiteOrmResponseWithAllCollaborators.id,
-        userId: mockUserWithSiteSessionData.isomerUserId,
-        lastViewedAt: null,
+      MockSequelize.transaction(() => {
+        expect(MockReviewRequestViewRepository.findAll).toHaveBeenCalled()
+        expect(MockReviewRequestRepository.findAll).toHaveBeenCalled()
+        expect(MockReviewRequestViewRepository.create).toHaveBeenCalled()
       })
     })
 


### PR DESCRIPTION
[wip i fixing test cases]
## Problem
[Credits to @caando for code changes] 
Currently, when calling the the route `/viewed` twice, this might lead to errors thrown in the backend. While the logic is sane, the reason why the errors occur is because there is a race condition when two threads attempt to create at the same time. 
<img width="925" alt="Screenshot 2023-07-26 at 10 16 01 AM" src="https://github.com/isomerpages/isomercms-backend/assets/42832651/fb1f6705-58f2-41bf-b7ce-237a992f6f33">

## Solution

`Upsert` rather than `create`. Note that the `comments.spec.ts` already needed these file changes to work. 

**Limitations**

~~This not the ideal way to solve race conditions. The ideal method is to create a lock and then keep the function `markAllReviewRequestsAsViewed` atomic. However, at this point of time, that might be over-engineering here as the only impact that could happen with unlikely concurrent calls to `markAllReviewRequestsAsViewed` is the dashboard does not turn blue to mark it as unread.~~ 

Following Chin's suggestion of using transactions, this limitation is no longer valid. 

## Tests 

e2e for notifications pass (failed without these changes) 
<img width="498" alt="Screenshot 2023-07-27 at 2 19 31 PM" src="https://github.com/isomerpages/isomercms-backend/assets/42832651/79b3a7db-363c-4847-b0e9-44787d4c1176">

**Misc** 
There is another issue of our `/viewed` being called twice, which is why this bug was noticed in the e2e testing in the first place. While that might incur separate effort to investigate, this PR intends to quick fix this regardless as this can still occur say when a user has 2 tabs open and refreshes them simultaneously. 

