### PR TITLE
feat(axios): add method to github api logs

### DIFF
--- a/src/services/api/AxiosInstance.ts
+++ b/src/services/api/AxiosInstance.ts
@@ -37,8 +37,11 @@ const requestFormatter = async (axiosConfig: AxiosRequestConfig) => {
           },
         },
       })
+      const requestMethod = axiosConfig.method
+        ? axiosConfig.method
+        : "undefined method"
       logger.info(
-        `Email login user made call to Github API: ${axiosConfig.url}`
+        `Email login user made ${requestMethod} call to Github API: ${axiosConfig.url}`
       )
       return {
         ...axiosConfig,
@@ -57,7 +60,12 @@ const requestFormatter = async (axiosConfig: AxiosRequestConfig) => {
       },
     },
   })
-  logger.info(`Github login user made call to Github API: ${axiosConfig.url}`)
+  const requestMethod = axiosConfig.method
+    ? axiosConfig.method
+    : "undefined method"
+  logger.info(
+    `Github login user made ${requestMethod} call to Github API: ${axiosConfig.url}`
+  )
   return {
     ...axiosConfig,
     headers: {

--- a/src/services/api/AxiosInstance.ts
+++ b/src/services/api/AxiosInstance.ts
@@ -37,9 +37,7 @@ const requestFormatter = async (axiosConfig: AxiosRequestConfig) => {
           },
         },
       })
-      const requestMethod = axiosConfig.method
-        ? axiosConfig.method
-        : "undefined method"
+      const requestMethod = axiosConfig.method ?? "undefined method"
       logger.info(
         `Email login user made ${requestMethod} call to Github API: ${axiosConfig.url}`
       )
@@ -60,9 +58,7 @@ const requestFormatter = async (axiosConfig: AxiosRequestConfig) => {
       },
     },
   })
-  const requestMethod = axiosConfig.method
-    ? axiosConfig.method
-    : "undefined method"
+  const requestMethod = axiosConfig.method ?? "undefined method"
   logger.info(
     `Github login user made ${requestMethod} call to Github API: ${axiosConfig.url}`
   )


### PR DESCRIPTION
## Problem

Currently our logs of requests to GitHub api only has the endpoint and not the request method. This presents difficulties in identifying which api its calling and whether its a read/write request.

Closes IS-366

## Solution

Add request method to GitHub api logs. 

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
