### PR TITLE
feat(stats): add metrics endpoint

### DIFF
--- a/src/routes/v2/authenticated/index.js
+++ b/src/routes/v2/authenticated/index.js
@@ -1,5 +1,6 @@
 import { attachSiteHandler } from "@root/middleware"
 
+import { MetricsRouter } from "./metrics"
 import { NotificationsRouter } from "./notifications"
 
 const express = require("express")
@@ -43,6 +44,7 @@ const getAuthenticatedSubrouter = ({
     authorizationMiddleware,
     notificationsService,
   })
+  const metricsRouter = new MetricsRouter({ authorizationMiddleware })
 
   const authenticatedSubrouter = express.Router({ mergeParams: true })
 
@@ -50,7 +52,7 @@ const getAuthenticatedSubrouter = ({
   // NOTE: apiLogger needs to be after `verifyJwt` as it logs the github username
   // which is only available after verifying that the jwt is valid
   authenticatedSubrouter.use(apiLogger)
-
+  authenticatedSubrouter.use("/metrics", metricsRouter.getRouter())
   authenticatedSubrouter.use(
     "/sites/:siteName/collaborators",
     collaboratorsRouter.getRouter()

--- a/src/routes/v2/authenticated/metrics.ts
+++ b/src/routes/v2/authenticated/metrics.ts
@@ -1,0 +1,61 @@
+import express from "express"
+
+import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
+import { AuthorizationMiddleware } from "@root/middleware/authorization"
+import MailClient, { mailer } from "@root/services/utilServices/MailClient"
+import { RequestHandler } from "@root/types"
+import { FeedbackDto } from "@root/types/dto/feedback"
+import { StatsService, statsService } from "@services/infra/StatsService"
+
+const getFeedbackHtml = ({
+  rating,
+  feedback,
+  userType,
+  email,
+}: FeedbackDto) => `
+    <h1>Feedback</h1>
+    <p><b>UserType: </b>${userType}</p>
+    <p><b>Email: </b>${email}</p>
+    <p><b>Rating: </b>${rating}</p>
+    <p><b>Feedback: </b>${feedback}</p>
+    
+`
+
+export interface MetricsRouterProps {
+  statsService: StatsService
+
+  mailClient: MailClient
+  authorizationMiddleware: AuthorizationMiddleware
+}
+
+export class MetricsRouter {
+  private readonly authorizationMiddleware
+
+  constructor({ authorizationMiddleware }: MetricsRouterProps) {
+    this.authorizationMiddleware = authorizationMiddleware
+  }
+
+  collateUserFeedback: RequestHandler<
+    never,
+    unknown,
+    FeedbackDto,
+    unknown,
+    { userWithSiteSessionData: UserWithSiteSessionData }
+  > = (req, res) => {
+    const { userType } = req.body
+    mailer.sendMail(
+      "admin@isomer.gov.sg",
+      "[METRICS] User feedback",
+      getFeedbackHtml(req.body)
+    )
+    statsService.trackNpsRating(req.body.rating, { userType })
+    res.status(200).send("OK")
+  }
+
+  getRouter() {
+    const router = express.Router({ mergeParams: true })
+
+    router.post("/feedback", this.collateUserFeedback)
+    return router
+  }
+}

--- a/src/routes/v2/authenticated/metrics.ts
+++ b/src/routes/v2/authenticated/metrics.ts
@@ -1,6 +1,7 @@
 import express from "express"
 
 import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
+import { ISOMER_ADMIN_EMAIL } from "@root/constants"
 import { AuthorizationMiddleware } from "@root/middleware/authorization"
 import MailClient, { mailer } from "@root/services/utilServices/MailClient"
 import { RequestHandler } from "@root/types"
@@ -17,8 +18,7 @@ const getFeedbackHtml = ({
     <p><b>UserType: </b>${userType}</p>
     <p><b>Email: </b>${email}</p>
     <p><b>Rating: </b>${rating}</p>
-    <p><b>Feedback: </b>${feedback}</p>
-    
+    <p><b>Feedback: </b>${feedback}</p>    
 `
 
 export interface MetricsRouterProps {
@@ -44,7 +44,7 @@ export class MetricsRouter {
   > = (req, res) => {
     const { userType } = req.body
     mailer.sendMail(
-      "admin@isomer.gov.sg",
+      ISOMER_ADMIN_EMAIL,
       "[METRICS] User feedback",
       getFeedbackHtml(req.body)
     )

--- a/src/routes/v2/authenticated/metrics.ts
+++ b/src/routes/v2/authenticated/metrics.ts
@@ -2,11 +2,10 @@ import express from "express"
 
 import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import { ISOMER_ADMIN_EMAIL } from "@root/constants"
-import { AuthorizationMiddleware } from "@root/middleware/authorization"
-import MailClient, { mailer } from "@root/services/utilServices/MailClient"
+import { mailer } from "@root/services/utilServices/MailClient"
 import { RequestHandler } from "@root/types"
 import { FeedbackDto } from "@root/types/dto/feedback"
-import { StatsService, statsService } from "@services/infra/StatsService"
+import { statsService } from "@services/infra/StatsService"
 
 const getFeedbackHtml = ({
   rating,
@@ -21,20 +20,8 @@ const getFeedbackHtml = ({
     <p><b>Feedback: </b>${feedback}</p>    
 `
 
-export interface MetricsRouterProps {
-  statsService: StatsService
-
-  mailClient: MailClient
-  authorizationMiddleware: AuthorizationMiddleware
-}
-
+// eslint-disable-next-line import/prefer-default-export
 export class MetricsRouter {
-  private readonly authorizationMiddleware
-
-  constructor({ authorizationMiddleware }: MetricsRouterProps) {
-    this.authorizationMiddleware = authorizationMiddleware
-  }
-
   collateUserFeedback: RequestHandler<
     never,
     unknown,

--- a/src/services/infra/StatsService.ts
+++ b/src/services/infra/StatsService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import { Method } from "axios"
-import StatsDClient, { StatsD, Tags } from "hot-shots"
+import StatsDClient, { StatsD } from "hot-shots"
 import { ModelStatic } from "sequelize"
 
 import { config } from "@config/config"

--- a/src/services/infra/StatsService.ts
+++ b/src/services/infra/StatsService.ts
@@ -9,6 +9,14 @@ import { Versions, VersionNumber } from "@constants/index"
 
 import { AccessToken, Site, User } from "@root/database/models"
 
+const getNpsVariant = (
+  rating: number
+): "promoter" | "passive" | "detractor" => {
+  if (rating >= 9) return "promoter"
+  if (rating >= 7) return "passive"
+  return "detractor"
+}
+
 export class StatsService {
   private readonly statsD: StatsD
 
@@ -68,8 +76,12 @@ export class StatsService {
     })
   }
 
-  trackNpsRating = (rating: number, tags: Tags) => {
-    this.statsD.distribution("users.feedback.nps", rating, 1, tags)
+  trackNpsRating = (rating: number, tags: Record<string, string>) => {
+    const npsVariant = getNpsVariant(rating)
+    this.statsD.distribution("users.feedback.nps", rating, 1, {
+      ...tags,
+      npsVariant,
+    })
   }
 
   trackEmailLogins = () => {

--- a/src/services/infra/StatsService.ts
+++ b/src/services/infra/StatsService.ts
@@ -9,9 +9,15 @@ import { Versions, VersionNumber } from "@constants/index"
 
 import { AccessToken, Site, User } from "@root/database/models"
 
-const getNpsVariant = (
-  rating: number
-): "promoter" | "passive" | "detractor" => {
+const NPS_VARIANTS = {
+  Promoter: "promoter",
+  Passive: "passive",
+  Detractor: "detractor",
+} as const
+
+type NpsVariant = typeof NPS_VARIANTS[keyof typeof NPS_VARIANTS]
+
+const getNpsVariant = (rating: number): NpsVariant => {
   if (rating >= 9) return "promoter"
   if (rating >= 7) return "passive"
   return "detractor"

--- a/src/services/infra/StatsService.ts
+++ b/src/services/infra/StatsService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import { Method } from "axios"
-import StatsDClient, { StatsD } from "hot-shots"
+import StatsDClient, { StatsD, Tags } from "hot-shots"
 import { ModelStatic } from "sequelize"
 
 import { config } from "@config/config"
@@ -66,6 +66,10 @@ export class StatsService {
     this.statsD.increment("users.github.login", {
       version,
     })
+  }
+
+  trackNpsRating = (rating: number, tags: Tags) => {
+    this.statsD.distribution("users.feedback.nps", rating, 1, tags)
   }
 
   trackEmailLogins = () => {

--- a/src/types/dto/feedback.ts
+++ b/src/types/dto/feedback.ts
@@ -1,0 +1,8 @@
+import { UserType } from "../user"
+
+export interface FeedbackDto {
+  rating: number
+  feedback: string
+  email: string
+  userType: UserType
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,6 @@
+export const UserTypes = {
+  Email: "email",
+  Github: "github",
+} as const
+
+export type UserType = typeof UserTypes[keyof typeof UserTypes]


### PR DESCRIPTION
## Problem
Adds metric endpoint for submitting user feedback.

## Solution
1. Written feedback is submitted to our (isomer admin) email. 
2. authentication is done via `verifyAccess` - no additional verification done because this implies that they are a site member already. not inclined to validate `req.body` (we _should_ tbh) as my baseline assumption is that our users aren't savvy enough to extract cookie and ping endpoint via tools (lmk if i shud tho). 
