### PR TITLE
Revert "chore(e2e): change naming for clarity (#857)"

### DIFF
--- a/src/services/middlewareServices/AuthenticationMiddlewareService.ts
+++ b/src/services/middlewareServices/AuthenticationMiddlewareService.ts
@@ -65,7 +65,7 @@ export type VerifyAccessProps = UnverifiedSession & {
 const E2E_USERS = {
   Email: {
     Admin: "Email admin",
-    Contributor: "Email contributor",
+    Collaborator: "Email collaborator",
   },
   Github: {
     User: "Github user",
@@ -79,7 +79,7 @@ type TestUserTypes =
 // NOTE: Precondition to use this function is that the user type is valid.
 const getUserType = (userType: string): TestUserTypes => {
   if (userType === E2E_USERS.Email.Admin) return userType
-  if (userType === E2E_USERS.Email.Contributor) return userType
+  if (userType === E2E_USERS.Email.Collaborator) return userType
   if (userType === E2E_USERS.Github.User) return userType
   throw new Error(`Invalid user type: ${userType}`)
 }
@@ -147,7 +147,7 @@ export const extractE2eUserInfo = async (
   switch (userType) {
     case E2E_USERS.Email.Admin:
       return generateE2eEmailUser(CollaboratorRoles.Admin, site, email)
-    case E2E_USERS.Email.Contributor:
+    case E2E_USERS.Email.Collaborator:
       return generateE2eEmailUser(CollaboratorRoles.Contributor, site, email)
     case E2E_USERS.Github.User:
       return generateGithubUser()
@@ -188,7 +188,7 @@ export default class AuthenticationMiddlewareService {
     const isEmailE2eAccess =
       (repo === E2E_EMAIL_TEST_SITE.repo || repo === E2E_TEST_REPO) &&
       (userType === E2E_USERS.Email.Admin ||
-        userType === E2E_USERS.Email.Contributor)
+        userType === E2E_USERS.Email.Collaborator)
     const isGithubE2eAccess =
       repo === E2E_TEST_REPO && userType === "Github user"
 

--- a/src/services/middlewareServices/__tests__/AuthenticationMiddlewareService.spec.ts
+++ b/src/services/middlewareServices/__tests__/AuthenticationMiddlewareService.spec.ts
@@ -19,7 +19,7 @@ const {
 } = auth
 
 const E2E_EMAIL_ADMIN_ISOMER_ID = "1"
-const E2E_EMAIL_CONTRI_ISOMER_ID = "2"
+const E2E_EMAIL_COLLAB_ISOMER_ID = "2"
 
 const MOCK_E2E_EMAIL = "MOCK@TEST.GOV.SG"
 
@@ -70,13 +70,13 @@ const E2E_EMAIL_COLLAB_PROPS: VerifyAccessProps = {
   // NOTE: Actual users won't have cookies - instead, they will use our session
   cookies: {
     isomercmsE2E: config.get("cypress.e2eTestSecret"),
-    e2eUserType: "Email contributor",
+    e2eUserType: "Email collaborator",
     site: "",
     email: "",
   },
   userInfo: {
     // NOTE: email users won't have github related fields
-    isomerUserId: E2E_EMAIL_CONTRI_ISOMER_ID,
+    isomerUserId: E2E_EMAIL_COLLAB_ISOMER_ID,
     email: MOCK_E2E_EMAIL,
   },
   url: E2E_EMAIL_REPO_URL,


### PR DESCRIPTION
This reverts commit 119476a9a88cbcaa70532560e5bbbc5c40718185.

## Problem

I shot myself in the foot here @.@ 

The pain point I was trying to alleviate here was that `setEmailSessionDefaults` in the fe forces `collab@e2e.gov.sg` to be a contributor role, and my (wrong) assumption was that we were trying to maintain that invariant, so I thought it would be better to name it as such for clarity. After talking with chin, realised that we intend to make this collab also have the admin role if needed (or at least the intention behind this design is), which makes the changes introduced in #1362 confusing as I can now have a contributor who has admin rights. 


## Solution

Revert changes. Tbh, it doesnt really solve the pain point I intended to solve, but I have a separate PR for this coming up! 
