### PR TITLE
chore: update site creation to block squash and merge

### DIFF
--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -159,6 +159,7 @@ export default class ReposService {
       org: ISOMER_GITHUB_ORGANIZATION_NAME,
       name: repoName,
       private: false,
+      allow_squash_merge: false,
     })
 
   setRepoAndTeamPermissions = async (


### PR DESCRIPTION
This PR introduces a minor change to site creation to add in the blocking of squash and merge - the reason for this is to prevent users from accidentally using squash and merge to merge prs, which would cause issues in future when attempting to merge staging to master again. See https://github.com/isomerpages/isomer-tooling/pull/47 for the one off fix for existing repos