### PR TITLE
feat(GGs): Add drop-in replacement RepoService

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -74,12 +74,6 @@ const config = convict({
       format: "required-string",
       default: "",
     },
-    whitelistRepos: {
-      doc: "Comma-separated list of whitelisted repos for local Git service",
-      env: "WHITELISTED_GIT_SERVICE_REPOS",
-      format: String,
-      default: "",
-    },
   },
   mutexTableName: {
     doc: "Name of the DynamoDB table used for mutexes",
@@ -408,6 +402,14 @@ const config = convict({
       doc: "URL to redirect to after authentication with sgID",
       env: "SGID_REDIRECT_URI",
       format: "required-string",
+      default: "",
+    },
+  },
+  featureFlags: {
+    whitelistRepos: {
+      doc: "Comma-separated list of whitelisted repos for local Git service",
+      env: "WHITELISTED_GIT_SERVICE_REPOS",
+      format: String,
       default: "",
     },
   },

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -406,7 +406,7 @@ const config = convict({
     },
   },
   featureFlags: {
-    whitelistRepos: {
+    ggsWhitelistedRepos: {
       doc: "Comma-separated list of whitelisted repos for local Git service",
       env: "WHITELISTED_GIT_SERVICE_REPOS",
       format: String,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -74,6 +74,12 @@ const config = convict({
       format: "required-string",
       default: "",
     },
+    whitelistRepos: {
+      doc: "Comma-separated list of whitelisted repos for local Git service",
+      env: "WHITELISTED_GIT_SERVICE_REPOS",
+      format: String,
+      default: "",
+    },
   },
   mutexTableName: {
     doc: "Name of the DynamoDB table used for mutexes",

--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -44,7 +44,7 @@ import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/Fo
 import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import { GitHubService } from "@services/db/GitHubService"
-import * as ReviewApi from "@services/db/review"
+import RepoService from "@services/db/RepoService"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
 import { getUsersService, notificationsService } from "@services/identity"
 import CollaboratorsService from "@services/identity/CollaboratorsService"
@@ -112,7 +112,7 @@ const pageService = new PageService({
 })
 const configService = new ConfigService()
 const reviewRequestService = new ReviewRequestService(
-  (mockGithubService as unknown) as typeof ReviewApi,
+  (mockGithubService as unknown) as RepoService,
   User,
   ReviewRequest,
   Reviewer,

--- a/src/integration/Notifications.spec.ts
+++ b/src/integration/Notifications.spec.ts
@@ -51,7 +51,7 @@ import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import SitesService from "@root/services/identity/SitesService"
 import ReviewRequestService from "@root/services/review/ReviewRequestService"
-import * as ReviewApi from "@services/db/review"
+import RepoService from "@services/db/RepoService"
 import {
   getIdentityAuthService,
   getUsersService,
@@ -105,7 +105,7 @@ const pageService = new PageService({
 })
 const configService = new ConfigService()
 const reviewRequestService = new ReviewRequestService(
-  (gitHubService as unknown) as typeof ReviewApi,
+  (gitHubService as unknown) as RepoService,
   User,
   ReviewRequest,
   Reviewer,

--- a/src/integration/Privatisation.spec.ts
+++ b/src/integration/Privatisation.spec.ts
@@ -62,7 +62,7 @@ import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import AuthorizationMiddlewareService from "@root/services/middlewareServices/AuthorizationMiddlewareService"
 import { GitHubService } from "@services/db/GitHubService"
-import * as ReviewApi from "@services/db/review"
+import RepoService from "@services/db/RepoService"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
 import { getIdentityAuthService, getUsersService } from "@services/identity"
 import IsomerAdminsService from "@services/identity/IsomerAdminsService"
@@ -134,7 +134,7 @@ const pageService = new PageService({
 })
 const configService = new ConfigService()
 const reviewRequestService = new ReviewRequestService(
-  (gitHubService as unknown) as typeof ReviewApi,
+  (gitHubService as unknown) as RepoService,
   User,
   ReviewRequest,
   Reviewer,

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -89,7 +89,7 @@ import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import { ReviewRequestDto } from "@root/types/dto/review"
 import { GitHubService } from "@services/db/GitHubService"
-import * as ReviewApi from "@services/db/review"
+import RepoService from "@services/db/RepoService"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
 import { getUsersService, notificationsService } from "@services/identity"
 import CollaboratorsService from "@services/identity/CollaboratorsService"
@@ -137,7 +137,7 @@ const pageService = new PageService({
 })
 const configService = new ConfigService()
 const reviewRequestService = new ReviewRequestService(
-  (gitHubService as unknown) as typeof ReviewApi,
+  (gitHubService as unknown) as RepoService,
   User,
   ReviewRequest,
   Reviewer,

--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -1,5 +1,6 @@
 import express from "express"
 import mockAxios from "jest-mock-axios"
+import simpleGit from "simple-git"
 import request from "supertest"
 
 import {
@@ -24,7 +25,6 @@ import { getAuthorizationMiddleware } from "@root/middleware"
 import { statsMiddleware } from "@root/middleware/stats"
 import { SitesRouter as _SitesRouter } from "@root/routes/v2/authenticated/sites"
 import { isomerRepoAxiosInstance } from "@root/services/api/AxiosInstance"
-import { GitHubService } from "@root/services/db/GitHubService"
 import { BaseDirectoryService } from "@root/services/directoryServices/BaseDirectoryService"
 import { ResourceRoomDirectoryService } from "@root/services/directoryServices/ResourceRoomDirectoryService"
 import { CollectionPageService } from "@root/services/fileServices/MdPageServices/CollectionPageService"
@@ -51,6 +51,8 @@ import DynamoDBService from "@root/services/infra/DynamoDBService"
 import InfraService from "@root/services/infra/InfraService"
 import StepFunctionsService from "@root/services/infra/StepFunctionsService"
 import ReviewRequestService from "@root/services/review/ReviewRequestService"
+import GitFileSystemService from "@services/db/GitFileSystemService"
+import RepoService from "@services/db/RepoService"
 import { getIdentityAuthService, getUsersService } from "@services/identity"
 import CollaboratorsService from "@services/identity/CollaboratorsService"
 import { sequelize } from "@tests/database"
@@ -62,9 +64,11 @@ const mockUpdatedAt = "now"
 const mockPermissions = { push: true }
 const mockPrivate = true
 
-const gitHubService = new GitHubService({
-  axiosInstance: isomerRepoAxiosInstance,
-})
+const gitFileSystemService = new GitFileSystemService(simpleGit())
+const gitHubService = new RepoService(
+  isomerRepoAxiosInstance,
+  gitFileSystemService
+)
 const configYmlService = new ConfigYmlService({ gitHubService })
 const usersService = getUsersService(sequelize)
 const isomerAdminsService = new IsomerAdminsService({ repository: IsomerAdmin })

--- a/src/server.js
+++ b/src/server.js
@@ -6,6 +6,7 @@ import { SgidClient } from "@opengovsg/sgid-client"
 import SequelizeStoreFactory from "connect-session-sequelize"
 import session from "express-session"
 import nocache from "nocache"
+import simpleGit from "simple-git"
 
 import { config } from "@config/config"
 
@@ -72,6 +73,8 @@ import getAuthenticatedSubrouter from "./routes/v2/authenticated"
 import { ReviewsRouter } from "./routes/v2/authenticated/review"
 import getAuthenticatedSitesSubrouter from "./routes/v2/authenticatedSites"
 import { SgidAuthRouter } from "./routes/v2/sgidAuth"
+import GitFileSystemService from "./services/db/GitFileSystemService"
+import RepoService from "./services/db/RepoService"
 import { PageService } from "./services/fileServices/MdPageServices/PageService"
 import { ConfigService } from "./services/fileServices/YmlFileServices/ConfigService"
 import CollaboratorsService from "./services/identity/CollaboratorsService"
@@ -144,13 +147,14 @@ const { FormsgRouter } = require("@routes/formsgSiteCreation")
 const { FormsgSiteLaunchRouter } = require("@routes/formsgSiteLaunch")
 const { AuthRouter } = require("@routes/v2/auth")
 
-const { GitHubService } = require("@services/db/GitHubService")
 const { AuthService } = require("@services/utilServices/AuthService")
 
 const authService = new AuthService({ usersService })
-const gitHubService = new GitHubService({
-  axiosInstance: isomerRepoAxiosInstance,
-})
+const gitFileSystemService = new GitFileSystemService(new simpleGit())
+const gitHubService = new RepoService(
+  isomerRepoAxiosInstance,
+  gitFileSystemService
+)
 const configYmlService = new ConfigYmlService({ gitHubService })
 const footerYmlService = new FooterYmlService({ gitHubService })
 const collectionYmlService = new CollectionYmlService({ gitHubService })

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -115,7 +115,9 @@ export default class GitFileSystemService {
   // Ensure that the repository is in the BRANCH_REF branch
   ensureCorrectBranch(repoName: string): ResultAsync<true, GitFileSystemError> {
     return ResultAsync.fromPromise(
-      this.git.revparse(["--abbrev-ref", "HEAD"]),
+      this.git
+        .cwd(`${EFS_VOL_PATH}/${repoName}`)
+        .revparse(["--abbrev-ref", "HEAD"]),
       (error) => {
         if (error instanceof GitError) {
           return new GitFileSystemError(error.message)

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -243,11 +243,13 @@ export default class GitFileSystemService {
             // such ref was fetched.
             // Full error message 2: error: cannot lock ref
             // 'refs/remotes/origin/staging': is at <new sha> but expected <old sha>
+            // Full error message 3: Cannot fast-forward your working tree.
             // These are known errors that can be safely ignored
             if (
               error instanceof GitError &&
               (error.message.includes("but no such ref was fetched.") ||
-                error.message.includes("error: cannot lock ref"))
+                error.message.includes("error: cannot lock ref") ||
+                error.message.includes("Cannot fast-forward your working tree"))
             ) {
               return false
             }

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -245,12 +245,18 @@ export default class GitFileSystemService {
             // Full error message 2: error: cannot lock ref
             // 'refs/remotes/origin/staging': is at <new sha> but expected <old sha>
             // Full error message 3: Cannot fast-forward your working tree.
+            // Full error message 4: Need to specify how to reconcile divergent branches.
             // These are known errors that can be safely ignored
             if (
               error instanceof GitError &&
               (error.message.includes("but no such ref was fetched.") ||
                 error.message.includes("error: cannot lock ref") ||
-                error.message.includes("Cannot fast-forward your working tree"))
+                error.message.includes(
+                  "Cannot fast-forward your working tree"
+                ) ||
+                error.message.includes(
+                  "Need to specify how to reconcile divergent branches"
+                ))
             ) {
               return false
             }

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -139,10 +139,10 @@ export default class GitFileSystemService {
             logger.error(`Error when checking out ${BRANCH_REF}: ${error}`)
             return new GitFileSystemError("An unknown error occurred")
           }
-        ).andThen(() => okAsync<true, never>(true))
+        ).andThen(() => okAsync<true>(true))
       }
 
-      return okAsync<true, never>(true)
+      return okAsync<true>(true)
     })
   }
 

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -240,10 +240,10 @@ export default class GitFileSystemService {
           }
         ),
         this.getGitBlobHash(repoName, filePath),
-      ]).map((contentsAndHash) => {
-        const [contents, sha] = contentsAndHash
+      ]).map((contentAndHash) => {
+        const [content, sha] = contentAndHash
         const result: GitFile = {
-          contents,
+          content,
           sha,
         }
         return result

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -238,14 +238,16 @@ export default class GitFileSystemService {
         ResultAsync.fromPromise(
           this.git.cwd(`${EFS_VOL_PATH}/${repoName}`).pull(),
           (error) => {
-            // Full error message:
-            // Your configuration specifies to merge with the ref
-            // 'refs/heads/staging' from the remote, but no such ref
-            // was fetched.
-            // This is a known error that can be safely ignored
+            // Full error message 1: Your configuration specifies to merge
+            // with the ref 'refs/heads/staging' from the remote, but no
+            // such ref was fetched.
+            // Full error message 2: error: cannot lock ref
+            // 'refs/remotes/origin/staging': is at <new sha> but expected <old sha>
+            // These are known errors that can be safely ignored
             if (
               error instanceof GitError &&
-              error.message.includes("but no such ref was fetched.")
+              (error.message.includes("but no such ref was fetched.") ||
+                error.message.includes("error: cannot lock ref"))
             ) {
               return false
             }

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -11,7 +11,7 @@ import GitFileSystemService from "./GitFileSystemService"
 import { GitHubService } from "./GitHubService"
 import * as ReviewApi from "./review"
 
-const WHITELISTED_GIT_SERVICE_REPOS = config.get("app.whitelistRepos")
+const WHITELISTED_GIT_SERVICE_REPOS = config.get("featureFlags.whitelistRepos")
 
 export default class RepoService extends GitHubService {
   private readonly gitFileSystemService: GitFileSystemService

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -11,7 +11,9 @@ import GitFileSystemService from "./GitFileSystemService"
 import { GitHubService } from "./GitHubService"
 import * as ReviewApi from "./review"
 
-const WHITELISTED_GIT_SERVICE_REPOS = config.get("featureFlags.whitelistRepos")
+const WHITELISTED_GIT_SERVICE_REPOS = config.get(
+  "featureFlags.ggsWhitelistedRepos"
+)
 
 export default class RepoService extends GitHubService {
   private readonly gitFileSystemService: GitFileSystemService

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -1,0 +1,245 @@
+import { AxiosCacheInstance } from "axios-cache-interceptor"
+
+import config from "@config/config"
+
+import logger from "@logger/logger"
+
+import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
+import { GitDirectoryItem, GitFile } from "@root/types/gitfilesystem"
+
+import GitFileSystemService from "./GitFileSystemService"
+import { GitHubService } from "./GitHubService"
+import * as ReviewApi from "./review"
+
+const WHITELISTED_GIT_SERVICE_REPOS = config.get("app.whitelistRepos")
+
+export default class RepoService extends GitHubService {
+  private readonly gitFileSystemService: GitFileSystemService
+
+  constructor(
+    axiosInstance: AxiosCacheInstance,
+    gitFileSystemService: GitFileSystemService
+  ) {
+    super({ axiosInstance })
+    this.gitFileSystemService = gitFileSystemService
+  }
+
+  isRepoWhitelisted(repoName: string): boolean {
+    return WHITELISTED_GIT_SERVICE_REPOS.split(",").includes(repoName)
+  }
+
+  getCommitDiff(siteName: string, base?: string, head?: string) {
+    return ReviewApi.getCommitDiff(siteName, base, head)
+  }
+
+  createPullRequest(
+    siteName: string,
+    title: string,
+    description?: string,
+    base?: string,
+    head?: string
+  ) {
+    return ReviewApi.createPullRequest(siteName, title, description, base, head)
+  }
+
+  getPullRequest(siteName: string, pullRequestNumber: number) {
+    return ReviewApi.getPullRequest(siteName, pullRequestNumber)
+  }
+
+  getBlob(repo: string, path: string, ref: string) {
+    return ReviewApi.getBlob(repo, path, ref)
+  }
+
+  updatePullRequest(
+    siteName: string,
+    pullRequestNumber: number,
+    title: string,
+    description?: string
+  ) {
+    return ReviewApi.updatePullRequest(
+      siteName,
+      pullRequestNumber,
+      title,
+      description
+    )
+  }
+
+  closeReviewRequest(siteName: string, pullRequestNumber: number) {
+    return ReviewApi.closeReviewRequest(siteName, pullRequestNumber)
+  }
+
+  mergePullRequest(siteName: string, pullRequestNumber: number) {
+    return ReviewApi.mergePullRequest(siteName, pullRequestNumber)
+  }
+
+  approvePullRequest(siteName: string, pullRequestNumber: number) {
+    return ReviewApi.approvePullRequest(siteName, pullRequestNumber)
+  }
+
+  async getComments(siteName: string, pullRequestNumber: number) {
+    return ReviewApi.getComments(siteName, pullRequestNumber)
+  }
+
+  async createComment(
+    siteName: string,
+    pullRequestNumber: number,
+    user: string,
+    message: string
+  ) {
+    return ReviewApi.createComment(siteName, pullRequestNumber, user, message)
+  }
+
+  getFilePath({ siteName, fileName, directoryName }: any): any {
+    return super.getFilePath({
+      siteName,
+      fileName,
+      directoryName,
+    })
+  }
+
+  getBlobPath({ siteName, fileSha }: any): any {
+    return super.getBlobPath({ siteName, fileSha })
+  }
+
+  getFolderPath({ siteName, directoryName }: any) {
+    return super.getFolderPath({ siteName, directoryName })
+  }
+
+  async create(
+    sessionData: any,
+    { content, fileName, directoryName, isMedia = false }: any
+  ): Promise<any> {
+    return await super.create(sessionData, {
+      content,
+      fileName,
+      directoryName,
+      isMedia,
+    })
+  }
+
+  async read(
+    sessionData: UserWithSiteSessionData,
+    { fileName, directoryName }: { fileName: string; directoryName?: string }
+  ): Promise<GitFile> {
+    if (this.isRepoWhitelisted(sessionData.siteName)) {
+      logger.info("Reading file from local Git file system")
+      const filePath = directoryName ? `${directoryName}/${fileName}` : fileName
+      const result = await this.gitFileSystemService.read(
+        sessionData.siteName,
+        filePath
+      )
+
+      if (result.isErr()) {
+        throw result.error
+      }
+
+      return result.value
+    }
+
+    return await super.read(sessionData, {
+      fileName,
+      directoryName,
+    })
+  }
+
+  // TODO: This is no longer used, remove it
+  async readMedia(sessionData: any, { fileSha }: any): Promise<any> {
+    return await super.readMedia(sessionData, { fileSha })
+  }
+
+  async readDirectory(
+    sessionData: UserWithSiteSessionData,
+    { directoryName }: { directoryName: string }
+  ): Promise<GitDirectoryItem[]> {
+    if (this.isRepoWhitelisted(sessionData.siteName)) {
+      logger.info("Reading directory from local Git file system")
+      const result = await this.gitFileSystemService.listDirectoryContents(
+        sessionData.siteName,
+        directoryName
+      )
+
+      if (result.isErr()) {
+        throw result.error
+      }
+
+      return result.value
+    }
+
+    return await super.readDirectory(sessionData, {
+      directoryName,
+    })
+  }
+
+  async update(
+    sessionData: any,
+    { fileContent, sha, fileName, directoryName }: any
+  ): Promise<any> {
+    return await super.update(sessionData, {
+      fileContent,
+      sha,
+      fileName,
+      directoryName,
+    })
+  }
+
+  async delete(
+    sessionData: any,
+    { sha, fileName, directoryName }: any
+  ): Promise<any> {
+    return await super.delete(sessionData, {
+      sha,
+      fileName,
+      directoryName,
+    })
+  }
+
+  async getRepoInfo(sessionData: any): Promise<any> {
+    return await super.getRepoInfo(sessionData)
+  }
+
+  async getRepoState(sessionData: any): Promise<any> {
+    return await super.getRepoState(sessionData)
+  }
+
+  async getLatestCommitOfBranch(sessionData: any, branch: any): Promise<any> {
+    return await super.getLatestCommitOfBranch(sessionData, branch)
+  }
+
+  async getTree(
+    sessionData: any,
+    githubSessionData: any,
+    { isRecursive }: any
+  ): Promise<any> {
+    return await super.getTree(sessionData, githubSessionData, {
+      isRecursive,
+    })
+  }
+
+  async updateTree(
+    sessionData: any,
+    githubSessionData: any,
+    { gitTree, message }: any
+  ): Promise<any> {
+    return await super.updateTree(sessionData, githubSessionData, {
+      gitTree,
+      message,
+    })
+  }
+
+  async updateRepoState(sessionData: any, { commitSha }: any): Promise<any> {
+    return await super.updateRepoState(sessionData, { commitSha })
+  }
+
+  async checkHasAccess(sessionData: any): Promise<any> {
+    return await super.checkHasAccess(sessionData)
+  }
+
+  async changeRepoPrivacy(
+    sessionData: any,
+    shouldMakePrivate: any
+  ): Promise<any> {
+    return await super.changeRepoPrivacy(sessionData, {
+      shouldMakePrivate,
+    })
+  }
+}

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -380,7 +380,7 @@ describe("GitFileSystemService", () => {
       })
 
       const expected: GitFile = {
-        contents: "fake content",
+        content: "fake content",
         sha: "fake-hash",
       }
       const actual = await GitFileSystemService.read(

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -21,6 +21,8 @@ const GitFileSystemService = new _GitFileSystemService(
   (MockSimpleGit as unknown) as SimpleGit
 )
 
+const BRANCH_REF = config.get("github.branchRef")
+
 describe("GitFileSystemService", () => {
   beforeAll(() => {
     mockFs({
@@ -201,9 +203,10 @@ describe("GitFileSystemService", () => {
   describe("getGitBlobHash", () => {
     it("should return the correct hash for a tracked file", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          revparse: jest.fn().mockResolvedValueOnce("fake-hash"),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("fake-hash"),
       })
 
       const result = await GitFileSystemService.getGitBlobHash(
@@ -216,9 +219,10 @@ describe("GitFileSystemService", () => {
 
     it("should return an error for an untracked file", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          revparse: jest.fn().mockRejectedValueOnce(new GitError()),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
       })
 
       const result = await GitFileSystemService.getGitBlobHash(
@@ -313,9 +317,10 @@ describe("GitFileSystemService", () => {
           ),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          pull: jest.fn().mockResolvedValueOnce(undefined),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        pull: jest.fn().mockResolvedValueOnce(undefined),
       })
 
       const result = await GitFileSystemService.pull("fake-repo")
@@ -335,9 +340,10 @@ describe("GitFileSystemService", () => {
           ),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          pull: jest.fn().mockRejectedValueOnce(new GitError()),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        pull: jest.fn().mockRejectedValueOnce(new GitError()),
       })
 
       const result = await GitFileSystemService.pull("fake-repo")
@@ -369,14 +375,16 @@ describe("GitFileSystemService", () => {
           ),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          pull: jest.fn().mockResolvedValueOnce(undefined),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          revparse: jest.fn().mockResolvedValueOnce("fake-hash"),
-        }),
+        pull: jest.fn().mockResolvedValueOnce(undefined),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("fake-hash"),
       })
 
       const expected: GitFile = {
@@ -403,14 +411,13 @@ describe("GitFileSystemService", () => {
           ),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          pull: jest.fn().mockResolvedValueOnce(undefined),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          revparse: jest.fn().mockRejectedValueOnce(new GitError()),
-        }),
+        pull: jest.fn().mockResolvedValueOnce(undefined),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
       })
 
       const result = await GitFileSystemService.read(
@@ -433,14 +440,13 @@ describe("GitFileSystemService", () => {
           ),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          pull: jest.fn().mockResolvedValueOnce(undefined),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          revparse: jest.fn().mockRejectedValueOnce(new GitError()),
-        }),
+        pull: jest.fn().mockResolvedValueOnce(undefined),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
       })
 
       const result = await GitFileSystemService.read(
@@ -463,9 +469,10 @@ describe("GitFileSystemService", () => {
           ),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          pull: jest.fn().mockRejectedValueOnce(new GitError()),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        pull: jest.fn().mockRejectedValueOnce(new GitError()),
       })
 
       const result = await GitFileSystemService.read(
@@ -480,19 +487,22 @@ describe("GitFileSystemService", () => {
   describe("listDirectoryContents", () => {
     it("should return the contents of a directory successfully", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          revparse: jest.fn().mockResolvedValueOnce("fake-dir-hash"),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          revparse: jest.fn().mockResolvedValueOnce("fake-empty-dir-hash"),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("fake-dir-hash"),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("fake-empty-dir-hash"),
       })
 
       const expectedFakeDir: GitDirectoryItem = {
@@ -531,19 +541,22 @@ describe("GitFileSystemService", () => {
 
     it("should return only results of files that are tracked by Git", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          revparse: jest.fn().mockResolvedValueOnce("fake-dir-hash"),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          revparse: jest.fn().mockRejectedValueOnce(new GitError()),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("fake-dir-hash"),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
       })
 
       const expectedFakeDir: GitDirectoryItem = {
@@ -573,19 +586,22 @@ describe("GitFileSystemService", () => {
 
     it("should return an empty result if the directory contain files that are all untracked", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          revparse: jest.fn().mockRejectedValueOnce(new GitError()),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          revparse: jest.fn().mockRejectedValueOnce(new GitError()),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkout: jest.fn().mockReturnValueOnce({
-          revparse: jest.fn().mockRejectedValueOnce(new GitError()),
-        }),
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
       })
 
       const actual = await GitFileSystemService.listDirectoryContents(

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -6,6 +6,7 @@ import config from "@config/config"
 import { ISOMER_GITHUB_ORG_NAME } from "@constants/constants"
 
 import GitFileSystemError from "@root/errors/GitFileSystemError"
+import { NotFoundError } from "@root/errors/NotFoundError"
 import { GitDirectoryItem, GitFile } from "@root/types/gitfilesystem"
 import _GitFileSystemService from "@services/db/GitFileSystemService"
 
@@ -456,7 +457,7 @@ describe("GitFileSystemService", () => {
       expect(actual._unsafeUnwrap()).toEqual(expected)
     })
 
-    it("should return a GitFileSystemError if the file does not exist", async () => {
+    it("should return a NotFoundError if the file does not exist", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
         checkIsRepo: jest.fn().mockResolvedValueOnce(true),
       })
@@ -482,7 +483,7 @@ describe("GitFileSystemService", () => {
         "fake-dir/non-existent-file"
       )
 
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
     })
 
     it("should return a error if an error occurred when getting the Git blob hash", async () => {
@@ -767,7 +768,7 @@ describe("GitFileSystemService", () => {
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
     })
 
-    it("should return a GitFileSystemError if the path does not exist", async () => {
+    it("should return a NotFoundError if the path does not exist", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
         checkIsRepo: jest.fn().mockResolvedValueOnce(true),
       })
@@ -789,7 +790,7 @@ describe("GitFileSystemService", () => {
         "non-existent-dir"
       )
 
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
     })
   })
 })

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -598,6 +598,22 @@ describe("GitFileSystemService", () => {
 
     it("should return only results of files that are tracked by Git", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
+        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        remote: jest
+          .fn()
+          .mockResolvedValueOnce(
+            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
+          ),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        pull: jest.fn().mockResolvedValueOnce(undefined),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
@@ -643,6 +659,22 @@ describe("GitFileSystemService", () => {
 
     it("should return an empty result if the directory contain files that are all untracked", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
+        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        remote: jest
+          .fn()
+          .mockResolvedValueOnce(
+            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
+          ),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        pull: jest.fn().mockResolvedValueOnce(undefined),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
@@ -670,6 +702,22 @@ describe("GitFileSystemService", () => {
     })
 
     it("should return an empty result if the directory is empty", async () => {
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        remote: jest
+          .fn()
+          .mockResolvedValueOnce(
+            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
+          ),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        pull: jest.fn().mockResolvedValueOnce(undefined),
+      })
       const actual = await GitFileSystemService.listDirectoryContents(
         "fake-repo",
         "fake-empty-dir"
@@ -679,6 +727,22 @@ describe("GitFileSystemService", () => {
     })
 
     it("should return a GitFileSystemError if the path is not a directory", async () => {
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        remote: jest
+          .fn()
+          .mockResolvedValueOnce(
+            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
+          ),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        pull: jest.fn().mockResolvedValueOnce(undefined),
+      })
       const result = await GitFileSystemService.listDirectoryContents(
         "fake-repo",
         "fake-dir/fake-file"
@@ -688,6 +752,22 @@ describe("GitFileSystemService", () => {
     })
 
     it("should return a GitFileSystemError if the path does not exist", async () => {
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        remote: jest
+          .fn()
+          .mockResolvedValueOnce(
+            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
+          ),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        pull: jest.fn().mockResolvedValueOnce(undefined),
+      })
       const result = await GitFileSystemService.listDirectoryContents(
         "fake-repo",
         "non-existent-dir"

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -261,9 +261,6 @@ describe("GitFileSystemService", () => {
   describe("getGitBlobHash", () => {
     it("should return the correct hash for a tracked file", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockResolvedValueOnce("fake-hash"),
       })
 
@@ -276,9 +273,6 @@ describe("GitFileSystemService", () => {
     })
 
     it("should return an error for an untracked file", async () => {
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
       MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockRejectedValueOnce(new GitError()),
       })
@@ -423,25 +417,6 @@ describe("GitFileSystemService", () => {
   describe("read", () => {
     it("should read the contents of a file successfully", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        remote: jest
-          .fn()
-          .mockResolvedValueOnce(
-            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
-          ),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        pull: jest.fn().mockResolvedValueOnce(undefined),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockResolvedValueOnce("fake-hash"),
       })
 
@@ -459,22 +434,6 @@ describe("GitFileSystemService", () => {
 
     it("should return a NotFoundError if the file does not exist", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        remote: jest
-          .fn()
-          .mockResolvedValueOnce(
-            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
-          ),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        pull: jest.fn().mockResolvedValueOnce(undefined),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockRejectedValueOnce(new GitError()),
       })
 
@@ -488,49 +447,7 @@ describe("GitFileSystemService", () => {
 
     it("should return a error if an error occurred when getting the Git blob hash", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        remote: jest
-          .fn()
-          .mockResolvedValueOnce(
-            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
-          ),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        pull: jest.fn().mockResolvedValueOnce(undefined),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockRejectedValueOnce(new GitError()),
-      })
-
-      const result = await GitFileSystemService.read(
-        "fake-repo",
-        "fake-dir/fake-file"
-      )
-
-      expect(result.isErr()).toBeTrue()
-    })
-
-    it("should return an error if an error occurred when pulling the repo", async () => {
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        remote: jest
-          .fn()
-          .mockResolvedValueOnce(
-            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
-          ),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        pull: jest.fn().mockRejectedValueOnce(new GitError()),
       })
 
       const result = await GitFileSystemService.read(
@@ -544,31 +461,6 @@ describe("GitFileSystemService", () => {
 
   describe("listDirectoryContents", () => {
     it("should return the contents of a directory successfully", async () => {
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        remote: jest
-          .fn()
-          .mockResolvedValueOnce(
-            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
-          ),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        pull: jest.fn().mockResolvedValueOnce(undefined),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
       MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
       })
@@ -615,31 +507,6 @@ describe("GitFileSystemService", () => {
 
     it("should return only results of files that are tracked by Git", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        remote: jest
-          .fn()
-          .mockResolvedValueOnce(
-            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
-          ),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        pull: jest.fn().mockResolvedValueOnce(undefined),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
@@ -676,31 +543,6 @@ describe("GitFileSystemService", () => {
 
     it("should return an empty result if the directory contain files that are all untracked", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
-        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        remote: jest
-          .fn()
-          .mockResolvedValueOnce(
-            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
-          ),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        pull: jest.fn().mockResolvedValueOnce(undefined),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockRejectedValueOnce(new GitError()),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
@@ -719,22 +561,6 @@ describe("GitFileSystemService", () => {
     })
 
     it("should return an empty result if the directory is empty", async () => {
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        remote: jest
-          .fn()
-          .mockResolvedValueOnce(
-            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
-          ),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        pull: jest.fn().mockResolvedValueOnce(undefined),
-      })
       const actual = await GitFileSystemService.listDirectoryContents(
         "fake-repo",
         "fake-empty-dir"
@@ -744,22 +570,6 @@ describe("GitFileSystemService", () => {
     })
 
     it("should return a GitFileSystemError if the path is not a directory", async () => {
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        remote: jest
-          .fn()
-          .mockResolvedValueOnce(
-            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
-          ),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        pull: jest.fn().mockResolvedValueOnce(undefined),
-      })
       const result = await GitFileSystemService.listDirectoryContents(
         "fake-repo",
         "fake-dir/fake-file"
@@ -769,22 +579,6 @@ describe("GitFileSystemService", () => {
     })
 
     it("should return a NotFoundError if the path does not exist", async () => {
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        remote: jest
-          .fn()
-          .mockResolvedValueOnce(
-            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
-          ),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        pull: jest.fn().mockResolvedValueOnce(undefined),
-      })
       const result = await GitFileSystemService.listDirectoryContents(
         "fake-repo",
         "non-existent-dir"

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -544,6 +544,22 @@ describe("GitFileSystemService", () => {
   describe("listDirectoryContents", () => {
     it("should return the contents of a directory successfully", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
+        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        remote: jest
+          .fn()
+          .mockResolvedValueOnce(
+            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
+          ),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        pull: jest.fn().mockResolvedValueOnce(undefined),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -1,0 +1,176 @@
+import { AxiosCacheInstance } from "axios-cache-interceptor"
+import mock from "mock-fs"
+import { okAsync } from "neverthrow"
+
+import {
+  mockAccessToken,
+  mockEmail,
+  mockGithubId,
+  mockIsomerUserId,
+  mockSiteName,
+  mockUserWithSiteSessionData,
+} from "@fixtures/sessionData"
+import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
+import { GitDirectoryItem, GitFile } from "@root/types/gitfilesystem"
+import GitFileSystemService from "@services/db/GitFileSystemService"
+import _RepoService from "@services/db/RepoService"
+
+import { GitHubService } from "../GitHubService"
+
+const MockAxiosInstance = {
+  put: jest.fn(),
+  get: jest.fn(),
+  delete: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+}
+
+const MockGitFileSystemService = {
+  read: jest.fn(),
+  listDirectoryContents: jest.fn(),
+}
+
+const RepoService = new _RepoService(
+  (MockAxiosInstance as unknown) as AxiosCacheInstance,
+  (MockGitFileSystemService as unknown) as GitFileSystemService
+)
+
+describe("RepoService", () => {
+  // Prevent inter-test pollution of mocks
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("isRepoWhitelisted", () => {
+    it("should indicate whitelisted repos as whitelisted correctly", () => {
+      const actual1 = RepoService.isRepoWhitelisted("fake-repo")
+      expect(actual1).toBe(true)
+
+      const actual2 = RepoService.isRepoWhitelisted(mockSiteName)
+      expect(actual2).toBe(true)
+    })
+
+    it("should indicate non-whitelisted repos as non-whitelisted correctly", () => {
+      const actual = RepoService.isRepoWhitelisted("not-whitelisted")
+      expect(actual).toBe(false)
+    })
+  })
+
+  describe("read", () => {
+    it("should read from the local Git file system if the repo is whitelisted", async () => {
+      const expected: GitFile = {
+        content: "test content",
+        sha: "test-sha",
+      }
+      MockGitFileSystemService.read.mockResolvedValueOnce(okAsync(expected))
+
+      const actual = await RepoService.read(mockUserWithSiteSessionData, {
+        fileName: "test.md",
+        directoryName: "",
+      })
+
+      expect(actual).toEqual(expected)
+    })
+
+    it("should read from GitHub directly if the repo is not whitelisted", async () => {
+      const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
+        githubId: mockGithubId,
+        accessToken: mockAccessToken,
+        isomerUserId: mockIsomerUserId,
+        email: mockEmail,
+        siteName: "not-whitelisted",
+      })
+      const expected: GitFile = {
+        content: "test content",
+        sha: "test-sha",
+      }
+      const gitHubServiceRead = jest.spyOn(GitHubService.prototype, "read")
+      gitHubServiceRead.mockResolvedValueOnce(expected)
+
+      const actual = await RepoService.read(sessionData, {
+        fileName: "test.md",
+        directoryName: "",
+      })
+
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe("readDirectory", () => {
+    it("should read from the local Git file system if the repo is whitelisted", async () => {
+      const expected: GitDirectoryItem[] = [
+        {
+          name: "fake-file.md",
+          type: "file",
+          sha: "test-sha1",
+          path: "test/fake-file.md",
+        },
+        {
+          name: "another-fake-file.md",
+          type: "file",
+          sha: "test-sha2",
+          path: "another-fake-file.md",
+        },
+        {
+          name: "fake-dir",
+          type: "dir",
+          sha: "test-sha3",
+          path: "fake-dir",
+        },
+      ]
+      MockGitFileSystemService.listDirectoryContents.mockResolvedValueOnce(
+        okAsync(expected)
+      )
+
+      const actual = await RepoService.readDirectory(
+        mockUserWithSiteSessionData,
+        {
+          directoryName: "test",
+        }
+      )
+
+      expect(actual).toEqual(expected)
+    })
+
+    it("should read from GitHub directly if the repo is not whitelisted", async () => {
+      const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
+        githubId: mockGithubId,
+        accessToken: mockAccessToken,
+        isomerUserId: mockIsomerUserId,
+        email: mockEmail,
+        siteName: "not-whitelisted",
+      })
+      const expected: GitDirectoryItem[] = [
+        {
+          name: "fake-file.md",
+          type: "file",
+          sha: "test-sha1",
+          path: "test/fake-file.md",
+        },
+        {
+          name: "another-fake-file.md",
+          type: "file",
+          sha: "test-sha2",
+          path: "another-fake-file.md",
+        },
+        {
+          name: "fake-dir",
+          type: "dir",
+          sha: "test-sha3",
+          path: "fake-dir",
+        },
+      ]
+      const gitHubServiceReadDirectory = jest.spyOn(
+        GitHubService.prototype,
+        "readDirectory"
+      )
+      gitHubServiceReadDirectory.mockResolvedValueOnce(expected)
+
+      const actual = await RepoService.readDirectory(sessionData, {
+        directoryName: "test",
+      })
+
+      expect(actual).toEqual(expected)
+    })
+  })
+})

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -58,8 +58,8 @@ import { StagingPermalink } from "@root/types/pages"
 import { RequestChangeInfo } from "@root/types/review"
 import { PathInfo } from "@root/types/util"
 import { extractPathInfo, getFileExt } from "@root/utils/files"
-import * as ReviewApi from "@services/db/review"
 
+import RepoService from "../db/RepoService"
 import { PageService } from "../fileServices/MdPageServices/PageService"
 import PlaceholderService from "../fileServices/utils/PlaceholderService"
 import { ConfigService } from "../fileServices/YmlFileServices/ConfigService"
@@ -88,7 +88,7 @@ const injectDefaultEditMeta = ({
  * Separately, this also allows us to add typings into this service.
  */
 export default class ReviewRequestService {
-  private readonly apiService: typeof ReviewApi
+  private readonly apiService: RepoService
 
   private readonly repository: ModelStatic<ReviewRequest>
 
@@ -107,7 +107,7 @@ export default class ReviewRequestService {
   private readonly sequelize: Sequelize
 
   constructor(
-    apiService: typeof ReviewApi,
+    apiService: RepoService,
     users: ModelStatic<User>,
     repository: ModelStatic<ReviewRequest>,
     reviewers: ModelStatic<Reviewer>,

--- a/src/services/review/__tests__/ReviewRequestService.spec.ts
+++ b/src/services/review/__tests__/ReviewRequestService.spec.ts
@@ -55,7 +55,7 @@ import { PageService } from "@root/services/fileServices/MdPageServices/PageServ
 import { ConfigService } from "@root/services/fileServices/YmlFileServices/ConfigService"
 import { GithubCommentData } from "@root/types/dto/review"
 import { Commit } from "@root/types/github"
-import * as ReviewApi from "@services/db/review"
+import RepoService from "@services/db/RepoService"
 import _ReviewRequestService from "@services/review/ReviewRequestService"
 
 const MockPageService: {
@@ -120,7 +120,7 @@ const MockSequelize = {
 }
 
 const ReviewRequestService = new _ReviewRequestService(
-  (MockReviewApi as unknown) as typeof ReviewApi,
+  (MockReviewApi as unknown) as RepoService,
   (MockUsersRepository as unknown) as ModelStatic<User>,
   (MockReviewRequestRepository as unknown) as ModelStatic<ReviewRequest>,
   (MockReviewersRepository as unknown) as ModelStatic<Reviewer>,

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -12,9 +12,11 @@ import { Umzug, SequelizeStorage } from "umzug"
 
 import { sequelize } from "@tests/database"
 
-const setupDb = async () => {
-  console.log("setting up database for testing")
+const setupEnvVars = () => {
+  process.env.WHITELISTED_GIT_SERVICE_REPOS = "fake-repo,mockSiteName"
+}
 
+const setupDb = async () => {
   const migrator = new Umzug({
     migrations: {
       glob: "src/database/migrations/*.js",
@@ -43,4 +45,12 @@ const setupDb = async () => {
   return migrator
 }
 
-export default setupDb
+const setup = async () => {
+  console.log("setting up environment variables")
+  setupEnvVars()
+
+  console.log("setting up database for testing")
+  return await setupDb()
+}
+
+export default setup

--- a/src/types/gitfilesystem.ts
+++ b/src/types/gitfilesystem.ts
@@ -1,5 +1,5 @@
 export type GitFile = {
-  contents: string
+  content: string
   sha: string
 }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes IS-351 and IS-405.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- This PR adds a new RepoService that aims to be a drop-in replacement of the legacy GitHubService
    - This RepoService **extends** (instead of implements) the GitHubService so that we can progressively TypeScript-ify GitHubService (and eventually replace it). This allows existing methods to continue being called, keeps RepoService backward compatible and methods can be re-implemented later (such as `read` and `readDirectory` in this PR).
    - Eventually, this RepoService will be independent from GitHubService, and other classes can potentially use both concurrently. RepoService will only have methods that are specific to an Isomer site repository (mainly just CRUD operations), whereas GitHubService will only have methods that require interfacing with GitHub (such as privatising repos).
- Both `git checkout` and `git pull` involve writing to disk, which causes issues in terms of concurrency due to file locks. Hence, they have been modified to only checkout when necessary, and the known concurrency issue of `git pull` is safely recovered from.

This PR is the second of a 2-part PR. The eventual architecture should look something like this:

![IS-320](https://github.com/isomerpages/isomercms-backend/assets/27919917/ede562c3-1450-4983-8d92-6c7d425e1abe)

## Tests

<!-- What tests should be run to confirm functionality? -->

1. Unit tests
2. End-to-end testing to ensure no regression

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `WHITELISTED_GIT_SERVICE_REPOS` : A comma-separated list of repositories that will use the GitFileSystemService instead of calling GitHub directly.

[IS-320]: https://isomeropengov.atlassian.net/browse/IS-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ