### PR TITLE
feat: add platform predeploy hooks

### DIFF
--- a/.platform/hooks/predeploy/01_mount_efs.sh
+++ b/.platform/hooks/predeploy/01_mount_efs.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Install AWS CLI if it's not installed yet
+which aws >/dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Installing AWS CLI..."
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    unzip awscliv2.zip
+    sudo ./aws/install
+    rm awscliv2.zip
+    rm -rf aws
+    echo "AWS CLI installed successfully."
+fi
+
+ENV_TYPE=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_PREFIX)
+
+AWS_REGION="ap-southeast-1"
+FILE_SYSTEM_ID_PARAM_NAME="${ENV_TYPE}_EFS_ID"
+MOUNT_DIRECTORY_PARAM_NAME="${ENV_TYPE}_EFS_MOUNT_DIR"
+
+FILE_SYSTEM_ID=$(aws ssm get-parameter --name $FILE_SYSTEM_ID_PARAM_NAME --region $AWS_REGION --query 'Parameter.Value' --output text)
+MOUNT_DIRECTORY=$(aws ssm get-parameter --name $MOUNT_DIRECTORY_PARAM_NAME --region $AWS_REGION --query 'Parameter.Value' --output text)
+
+yum install -y amazon-efs-utils
+
+EFS_MOUNT_DIR=$MOUNT_DIRECTORY
+EFS_FILE_SYSTEM_ID=$FILE_SYSTEM_ID
+
+echo "Mounting EFS filesystem ${EFS_FILE_SYSTEM_ID} to directory ${EFS_MOUNT_DIR} ..."
+
+echo 'Stopping NFS ID Mapper...'
+service rpcidmapd status &> /dev/null
+if [ $? -ne 0 ] ; then
+    echo 'rpc.idmapd is already stopped!'
+else
+    service rpcidmapd stop
+    if [ $? -ne 0 ] ; then
+        echo 'ERROR: Failed to stop NFS ID Mapper!'
+        exit 1
+    fi
+fi
+
+echo 'Checking if EFS mount directory exists...'
+if [ ! -d ${EFS_MOUNT_DIR} ]; then
+    echo "Creating directory ${EFS_MOUNT_DIR} ..."
+    mkdir -p ${EFS_MOUNT_DIR}
+    if [ $? -ne 0 ]; then
+        echo 'ERROR: Directory creation failed!'
+        exit 1
+    fi
+else
+    echo "Directory ${EFS_MOUNT_DIR} already exists!"
+fi
+
+mountpoint -q ${EFS_MOUNT_DIR}
+if [ $? -ne 0 ]; then
+    echo "mount -t efs -o tls ${EFS_FILE_SYSTEM_ID}:/ ${EFS_MOUNT_DIR}"
+    mount -t efs -o tls ${EFS_FILE_SYSTEM_ID}:/ ${EFS_MOUNT_DIR}
+    if [ $? -ne 0 ] ; then
+        echo 'ERROR: Mount command failed!'
+        exit 1
+    fi
+    chmod 777 ${EFS_MOUNT_DIR}
+    runuser -l  ec2-user -c "touch ${EFS_MOUNT_DIR}/it_works"
+    if [[ $? -ne 0 ]]; then
+        echo 'ERROR: Permission Error!'
+        exit 1
+    else
+        runuser -l  ec2-user -c "rm -f ${EFS_MOUNT_DIR}/it_works"
+    fi
+else
+    echo "Directory ${EFS_MOUNT_DIR} is already a valid mountpoint!"
+fi
+
+echo 'EFS mount complete.'

--- a/.platform/hooks/predeploy/01_mount_efs.sh
+++ b/.platform/hooks/predeploy/01_mount_efs.sh
@@ -1,5 +1,29 @@
 #!/bin/bash
 
+# Note the following has been adapted from https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/services-efs.html
+
+###################################################################################################
+#### Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file mounts an Amazon EFS file system to a specified directory.
+#### Both the directory and the EFS file system ID to be mounted is retrieved from AWS SSM.
+####
+#### If your environment and file system are in a custom VPC, you must configure the VPC to allow
+#### DNS resolution and DNS host names. See this topic in the VPC User Guide for more information:
+####    http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html
+###################################################################################################
+
 # Install AWS CLI if it's not installed yet
 which aws >/dev/null 2>&1
 if [ $? -ne 0 ]; then

--- a/.platform/hooks/predeploy/02_fetch_ssh_keys.sh
+++ b/.platform/hooks/predeploy/02_fetch_ssh_keys.sh
@@ -11,8 +11,8 @@ aws configure set default.region ap-southeast-1
 
 echo "Fetching keys"
 # Note we write to webapp user directory which runs our app
-aws ssm get-parameter --name $SSH_PUBLIC_KEY_PARAM_NAME --with-decryption --query "Parameter.Value" --output text > /home/webapp/.ssh/github.pub
-aws ssm get-parameter --name $SSH_PRIVATE_KEY_PARAM_NAME --with-decryption --query "Parameter.Value" --output text > /home/webapp/.ssh/github
+aws ssm get-parameter --name $SSH_PUBLIC_KEY_PARAM_NAME --with-decryption --query "Parameter.Value" --output text > /home/webapp/.ssh/github.pub || { echo "Failed to fetch SSH public key"; exit 1; }
+aws ssm get-parameter --name $SSH_PRIVATE_KEY_PARAM_NAME --with-decryption --query "Parameter.Value" --output text > /home/webapp/.ssh/github || { echo "Failed to fetch SSH private key"; exit 1; }
 
 # Set the permissions for the keys
 echo "Setting permissions"

--- a/.platform/hooks/predeploy/02_fetch_ssh_keys.sh
+++ b/.platform/hooks/predeploy/02_fetch_ssh_keys.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Get the env type from EB
+ENV_TYPE=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_PREFIX)
+
+SSH_PUBLIC_KEY_PARAM_NAME="${ENV_TYPE}_SSH_PUBLIC_KEY"
+SSH_PRIVATE_KEY_PARAM_NAME="${ENV_TYPE}_SSH_PRIVATE_KEY"
+
+echo "Set AWS region"
+aws configure set default.region ap-southeast-1
+
+echo "Fetching keys"
+# Note we write to webapp user directory which runs our app
+aws ssm get-parameter --name $SSH_PUBLIC_KEY_PARAM_NAME --with-decryption --query "Parameter.Value" --output text > /home/webapp/.ssh/github.pub
+aws ssm get-parameter --name $SSH_PRIVATE_KEY_PARAM_NAME --with-decryption --query "Parameter.Value" --output text > /home/webapp/.ssh/github
+
+# Set the permissions for the keys
+echo "Setting permissions"
+chmod 600 /home/webapp/.ssh/github.pub
+chmod 600 /home/webapp/.ssh/github
+
+echo "Fetching keys complete"

--- a/.platform/hooks/predeploy/03_add_keys_to_ssh_config.sh
+++ b/.platform/hooks/predeploy/03_add_keys_to_ssh_config.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# add github as host and ssh key to ssh config
+cat << EOF > /home/webapp/.ssh/config
+Host github.com
+  IdentityFile /home/webapp/.ssh/github
+  User git
+EOF

--- a/.platform/hooks/predeploy/04_add_github_to_known_hosts.sh
+++ b/.platform/hooks/predeploy/04_add_github_to_known_hosts.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Get the server's public key
+ssh-keyscan -t rsa github.com > github_rsa.pub
+
+# Generate the key's fingerprint
+SERVER_FINGERPRINT=$(ssh-keygen -lf github_rsa.pub | awk '{print $2}')
+echo "SERVER_FINGERPRINT: $SERVER_FINGERPRINT" > /tmp/setup-github-known-hosts.txt
+
+# The official GitHub RSA fingerprint
+# https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
+OFFICIAL_FINGERPRINT="SHA256:uNiVztksCsDhcc0u9e8BujQXVUpKZIDTMczCvj3tD2s"
+
+# Check if the server's fingerprint matches the official fingerprint
+# Note: This check is important to prevent any MITM attacks
+if [ "$SERVER_FINGERPRINT" = "$OFFICIAL_FINGERPRINT" ]; then
+    # If the fingerprints match, add the public key to the known_hosts file
+    cat github_rsa.pub > /home/webapp/.ssh/known_hosts
+    echo "GitHub's public key added to known_hosts." >> /tmp/setup-github-known-hosts.txt
+else
+    # If the fingerprints don't match, output a warning and exit with an error
+    echo "WARNING: The server's SSH key fingerprint doesn't match the official GitHub fingerprint." >> /tmp/setup-github-known-hosts.txt
+    exit 1
+fi
+
+# Remove the temporary public key file
+rm github_rsa.pub
+
+# all the above would have been performed as root
+# so we need to allow webapp user to access so that it can add to the known_hosts etc.
+chown -R webapp:webapp /home/webapp/.ssh

--- a/.platform/hooks/predeploy/04_add_github_to_known_hosts.sh
+++ b/.platform/hooks/predeploy/04_add_github_to_known_hosts.sh
@@ -29,4 +29,5 @@ rm github_rsa.pub
 
 # all the above would have been performed as root
 # so we need to allow webapp user to access so that it can add to the known_hosts etc.
+# this is a recursive command to update all files under .ssh/ folder to webapp user's ownership
 chown -R webapp:webapp /home/webapp/.ssh

--- a/.platform/hooks/predeploy/04_add_github_to_known_hosts.sh
+++ b/.platform/hooks/predeploy/04_add_github_to_known_hosts.sh
@@ -20,6 +20,7 @@ if [ "$SERVER_FINGERPRINT" = "$OFFICIAL_FINGERPRINT" ]; then
 else
     # If the fingerprints don't match, output a warning and exit with an error
     echo "WARNING: The server's SSH key fingerprint doesn't match the official GitHub fingerprint." >> /tmp/setup-github-known-hosts.txt
+    rm github_rsa.pub
     exit 1
 fi
 

--- a/.platform/hooks/predeploy/05_set_git_profile.sh
+++ b/.platform/hooks/predeploy/05_set_git_profile.sh
@@ -24,6 +24,11 @@ echo "[user]" > /home/webapp/.gitconfig
 echo "  name = $GIT_USER_NAME" >> /home/webapp/.gitconfig
 echo "  email = $GIT_USER_EMAIL" >> /home/webapp/.gitconfig
 
-echo "Git global config has been set with the following values:"
-echo "User name: $GIT_USER_NAME" > /tmp/setup-git-profile.txt
+# Change ownership of .gitconfig to webapp user
+chown webapp:webapp /home/webapp/.gitconfig
+
+echo "Git global config has been set with the following values:" > /tmp/setup-git-profile.txt
+echo "User name: $GIT_USER_NAME" >> /tmp/setup-git-profile.txt
 echo "User email: $GIT_USER_EMAIL" >> /tmp/setup-git-profile.txt
+
+echo "Setup complete." >> /tmp/setup-git-profile.txt

--- a/.platform/hooks/predeploy/05_set_git_profile.sh
+++ b/.platform/hooks/predeploy/05_set_git_profile.sh
@@ -13,6 +13,12 @@ aws configure set default.region ap-southeast-1
 GIT_USER_NAME=$(aws ssm get-parameter --name $GIT_USER_NAME_PARAM_NAME --with-decryption --query "Parameter.Value" --output text)
 GIT_USER_EMAIL=$(aws ssm get-parameter --name $GIT_USER_EMAIL_PARAM_NAME --with-decryption --query "Parameter.Value" --output text)
 
+# Check if required variables are not empty
+if [[ -z $GIT_USER_NAME || -z $GIT_USER_EMAIL ]]; then
+    echo "Error: Failed to fetch Git user information from AWS SSM." > /tmp/setup-git-profile.txt
+    exit 1
+fi
+
 # Write the configuration to .gitconfig
 echo "[user]" >> /home/webapp/.gitconfig
 echo "  name = $GIT_USER_NAME" >> /home/webapp/.gitconfig

--- a/.platform/hooks/predeploy/05_set_git_profile.sh
+++ b/.platform/hooks/predeploy/05_set_git_profile.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Get the env type from EB
+ENV_TYPE=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_PREFIX)
+
+GIT_USER_NAME_PARAM_NAME="${ENV_TYPE}_GIT_USER_NAME"
+GIT_USER_EMAIL_PARAM_NAME="${ENV_TYPE}_GIT_USER_EMAIL"
+
+# Set AWS region
+aws configure set default.region ap-southeast-1
+
+# Fetch git user's name and email from SSM
+GIT_USER_NAME=$(aws ssm get-parameter --name $GIT_USER_NAME_PARAM_NAME --with-decryption --query "Parameter.Value" --output text)
+GIT_USER_EMAIL=$(aws ssm get-parameter --name $GIT_USER_EMAIL_PARAM_NAME --with-decryption --query "Parameter.Value" --output text)
+
+# Write the configuration to .gitconfig
+echo "[user]" >> ~/.gitconfig
+echo "  name = $GIT_USER_NAME" >> ~/.gitconfig
+echo "  email = $GIT_USER_EMAIL" >> ~/.gitconfig
+
+echo "Git global config has been set with the following values:"
+echo "User name: $GIT_USER_NAME" > /tmp/setup-git-profile.txt
+echo "User email: $GIT_USER_EMAIL" >> /tmp/setup-git-profile.txt

--- a/.platform/hooks/predeploy/05_set_git_profile.sh
+++ b/.platform/hooks/predeploy/05_set_git_profile.sh
@@ -14,9 +14,9 @@ GIT_USER_NAME=$(aws ssm get-parameter --name $GIT_USER_NAME_PARAM_NAME --with-de
 GIT_USER_EMAIL=$(aws ssm get-parameter --name $GIT_USER_EMAIL_PARAM_NAME --with-decryption --query "Parameter.Value" --output text)
 
 # Write the configuration to .gitconfig
-echo "[user]" >> ~/.gitconfig
-echo "  name = $GIT_USER_NAME" >> ~/.gitconfig
-echo "  email = $GIT_USER_EMAIL" >> ~/.gitconfig
+echo "[user]" >> /home/webapp/.gitconfig
+echo "  name = $GIT_USER_NAME" >> /home/webapp/.gitconfig
+echo "  email = $GIT_USER_EMAIL" >> /home/webapp/.gitconfig
 
 echo "Git global config has been set with the following values:"
 echo "User name: $GIT_USER_NAME" > /tmp/setup-git-profile.txt

--- a/.platform/hooks/predeploy/05_set_git_profile.sh
+++ b/.platform/hooks/predeploy/05_set_git_profile.sh
@@ -20,7 +20,7 @@ if [[ -z $GIT_USER_NAME || -z $GIT_USER_EMAIL ]]; then
 fi
 
 # Write the configuration to .gitconfig
-echo "[user]" >> /home/webapp/.gitconfig
+echo "[user]" > /home/webapp/.gitconfig
 echo "  name = $GIT_USER_NAME" >> /home/webapp/.gitconfig
 echo "  email = $GIT_USER_EMAIL" >> /home/webapp/.gitconfig
 


### PR DESCRIPTION
## **NOTE: DO NOT MERGE TILL WE ARE READY TO ROLLOUT GGS**

## Problem

This PR contains all the scripts we need to run on an infra-level to make CMS BE ready to integrate with our Git File System Service.

Closes IS-317, IS-319, IS-337, IS-375, IS-390

## Solution

This PR contains pre-deploy hooks which we instruct Elastic Beanstalk to perform before starting app deployment.

Note: There are 3 different types of hooks - `prebuild`, `predeploy` and `postdeploy`. We are using the predeploy hooks as we need to setup these config before our app starts serving requests.

There are 5 scripts corresponding to the following actions:

### Mount EFS

This fetches a file system ID & mount location from SSM and mounts the corresponding EFS volume. 

Note that we have decided to perform EFS creation manually outside the use of scripts/hooks as it is a 1-time operation

### Fetch SSH Keys

Next, we will be using SSH authentication for GitHub. So we create a SSH pub/private keypair. We store these as secure strings in SSM.

We fetch these SSH keys on predeploy and copy it to the `.ssh/` of `webapp` user.

The user we add to here is important. There are 3 types of users: `root`, `ec2-user` and `webapp`.

When our app runs, it runs as `webapp` user. When EB runs the predeploy or other hooks, it runs as `root`. Hence, it is important to ensure our files are able to be accessed by `webapp` user.

### Add to SSH Config

Next, we add to the SSH config to use the SSH keys for auth to Github.com as the host.

### Add Github to Known Hosts

Often when cloning for first time, we will encounter the prompt whether to trust the host. On an automated environment, we won’t be able to provide this manual input.

Hence, we add it to the `known_hosts` file ahead of time.

### Setup Git profile

To perform Git CLI commands, we need to setup the git user profile/config. We do this via the `.gitconfig` file for the `webapp` user's directory.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Tests

We will need to test a few things manually:
1. If EFS is mounted successfully
2. Whether 2 instances are able to see/edit the shared files in EFS
3. If SSH configs are set correctly within `.ssh/`
4. Whether we are able to git clone, git pull, git push from isomerpages

## Deploy Notes

**Note: This PR should only be merged when we are ready to rollout GGS**

**Dependencies**:
- We will need to create an EFS volume in the staging and prod VPCs beforehand
- We will need to set the EFS ID into the SSM parameters

**New SSM parameters**:
1. `EFS_ID` - exposed on SSM to mount to the correct EFS vol
    1. `STAGING_EFS_ID`
    2. `PROD_EFS_ID`
2.  `STAGING_GIT_USER_NAME`
    1. `STAGING_GIT_USER_EMAIL`
    2. `PROD_GIT_USER_NAME`
    3. `PROD_GIT_USER_EMAIL`
3. SSH keys - exposed on SSM to be fetched at deployment time
    1. `STAGING_SSH_PUBLIC_KEY`
    2. `STAGING_SSH_PRIVATE_KEY`
    3. `PROD_SSH_PUBLIC_KEY`
    5. `PROD_SSH_PRIVATE_KEY`
  
**New environment variables**:
- `EFS_VOL_PATH`: This should have been already added from @dcshzj 's PRs. This should point to `/efs/repos`.
