### PR TITLE
Fix axios method type to return string

### DIFF
--- a/src/services/infra/StatsService.ts
+++ b/src/services/infra/StatsService.ts
@@ -96,7 +96,7 @@ export class StatsService {
     })
   }
 
-  incrementGithubApiCall = (method: Method, site: string) => {
+  incrementGithubApiCall = (method: string, site: string) => {
     this.statsD.increment("users.github.api", {
       site,
       // NOTE: Allowed to pass in lowercase,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The axios types have changed after upgrading in #850.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The `Method` type has changed to `string` in StatsService due to an upgrade of the `axios` package which has changed the return type

## Tests

<!-- What tests should be run to confirm functionality? -->

1. Unit tests
2. Build the repo to check that the type error no longer appears

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

_None_