### PR TITLE
fix(authservice): update import

### DIFF
--- a/src/services/utilServices/AuthService.js
+++ b/src/services/utilServices/AuthService.js
@@ -17,7 +17,7 @@ const {
   E2E_TEST_EMAIL,
 } = require("@root/constants")
 const { BadRequestError } = require("@root/errors/BadRequestError")
-const logger = require("@root/logger/logger")
+const logger = require("@root/logger/logger").default
 const { isError } = require("@root/types")
 
 const CLIENT_ID = config.get("github.clientId")


### PR DESCRIPTION
## Problem
previously, no `.default` added on import leading to errors (due to `export default` interaction wtih `require`)


## Solution
add `.default` to `require` import