### PR TITLE
fix(GGs): return sha of commit made instead of path to repository

### DIFF
--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -358,7 +358,7 @@ export default class GitFileSystemService {
             }
           )
         )
-        .map(() => `${EFS_VOL_PATH}/${repoName}`)
+        .map((commitResult) => commitResult.commit)
     })
   }
 

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -492,7 +492,10 @@ describe("GitFileSystemService", () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
       })
-      const mockCommitFn = jest.fn().mockResolvedValueOnce(undefined)
+      const mockCommitSha = "fake-commit-sha"
+      const mockCommitFn = jest
+        .fn()
+        .mockResolvedValueOnce({ commit: mockCommitSha })
       MockSimpleGit.cwd.mockReturnValueOnce({
         add: jest.fn().mockReturnValueOnce({
           commit: mockCommitFn,
@@ -513,7 +516,7 @@ describe("GitFileSystemService", () => {
         MOCK_GITHUB_COMMIT_MESSAGE_ALPHA_ONE
       )
 
-      expect(result.isOk()).toBeTrue()
+      expect(result._unsafeUnwrap()).toBe(mockCommitSha)
       expect(mockCommitFn).toHaveBeenCalledWith(expectedCommitMessage)
     })
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The `commit` function in GitFileSystemService mistakenly returned the path to the directory instead of the original intended SHA of the commit made.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The `commit` function was adjusted to return the SHA of the latest commit made, instead of returning the path to the repository

## Tests

<!-- What tests should be run to confirm functionality? -->

1. Unit tests

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*