### PR TITLE
IS-404: Write extend repo service to get latest commit of branch

### DIFF
--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -43,7 +43,6 @@ import { ConfigService } from "@root/services/fileServices/YmlFileServices/Confi
 import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/FooterYmlService"
 import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
-import { GitHubService } from "@services/db/GitHubService"
 import RepoService from "@services/db/RepoService"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
 import { getUsersService, notificationsService } from "@services/identity"
@@ -130,7 +129,7 @@ const MockSitesCacheService = {
 const MockPreviewService = {}
 const sitesService = new SitesService({
   siteRepository: Site,
-  gitHubService: (mockGithubService as unknown) as GitHubService,
+  gitHubService: (mockGithubService as unknown) as RepoService,
   configYmlService: (jest.fn() as unknown) as ConfigYmlService,
   usersService,
   isomerAdminsService: (jest.fn() as unknown) as IsomerAdminsService,

--- a/src/integration/Notifications.spec.ts
+++ b/src/integration/Notifications.spec.ts
@@ -1,4 +1,5 @@
 import express from "express"
+import simpleGit from "simple-git"
 import request from "supertest"
 
 import {
@@ -31,8 +32,6 @@ import {
 } from "@root/fixtures/sessionData"
 import { getAuthorizationMiddleware } from "@root/middleware"
 import { NotificationsRouter as _NotificationsRouter } from "@root/routes/v2/authenticated/notifications"
-import { genericGitHubAxiosInstance } from "@root/services/api/AxiosInstance"
-import { GitHubService } from "@root/services/db/GitHubService"
 import { BaseDirectoryService } from "@root/services/directoryServices/BaseDirectoryService"
 import { ResourceRoomDirectoryService } from "@root/services/directoryServices/ResourceRoomDirectoryService"
 import { CollectionPageService } from "@root/services/fileServices/MdPageServices/CollectionPageService"
@@ -51,6 +50,8 @@ import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import SitesService from "@root/services/identity/SitesService"
 import ReviewRequestService from "@root/services/review/ReviewRequestService"
+import { isomerRepoAxiosInstance } from "@services/api/AxiosInstance"
+import GitFileSystemService from "@services/db/GitFileSystemService"
 import RepoService from "@services/db/RepoService"
 import {
   getIdentityAuthService,
@@ -64,9 +65,11 @@ const MOCK_SITE = "mockSite"
 const MOCK_SITE_ID = "1"
 const MOCK_SITE_MEMBER_ID = "1"
 
-const gitHubService = new GitHubService({
-  axiosInstance: genericGitHubAxiosInstance,
-})
+const gitFileSystemService = new GitFileSystemService(simpleGit())
+const gitHubService = new RepoService(
+  isomerRepoAxiosInstance,
+  gitFileSystemService
+)
 const identityAuthService = getIdentityAuthService(gitHubService)
 const usersService = getUsersService(sequelize)
 const configYmlService = new ConfigYmlService({ gitHubService })

--- a/src/integration/Privatisation.spec.ts
+++ b/src/integration/Privatisation.spec.ts
@@ -1,6 +1,7 @@
 import express from "express"
 import mockAxios from "jest-mock-axios"
 import { ok, okAsync } from "neverthrow"
+import simpleGit from "simple-git"
 import request from "supertest"
 
 import { SitesRouter as _SitesRouter } from "@routes/v2/authenticated/sites"
@@ -61,7 +62,8 @@ import DeploymentsService from "@root/services/identity/DeploymentsService"
 import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import AuthorizationMiddlewareService from "@root/services/middlewareServices/AuthorizationMiddlewareService"
-import { GitHubService } from "@services/db/GitHubService"
+import { isomerRepoAxiosInstance } from "@services/api/AxiosInstance"
+import GitFileSystemService from "@services/db/GitFileSystemService"
 import RepoService from "@services/db/RepoService"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
 import { getIdentityAuthService, getUsersService } from "@services/identity"
@@ -94,8 +96,11 @@ jest.mock("../services/identity/DeploymentClient", () =>
       .mockImplementation(() => ok(mockDeleteInput)),
   }))
 )
-
-const gitHubService = new GitHubService({ axiosInstance: mockAxios.create() })
+const gitFileSystemService = new GitFileSystemService(simpleGit())
+const gitHubService = new RepoService(
+  isomerRepoAxiosInstance,
+  gitFileSystemService
+)
 const configYmlService = new ConfigYmlService({ gitHubService })
 const usersService = getUsersService(sequelize)
 const isomerAdminsService = new IsomerAdminsService({ repository: IsomerAdmin })

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -1,5 +1,6 @@
 import express from "express"
 import mockAxios from "jest-mock-axios"
+import simpleGit from "simple-git"
 import request from "supertest"
 
 import { ReviewsRouter as _ReviewsRouter } from "@routes/v2/authenticated/review"
@@ -88,7 +89,8 @@ import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/Fo
 import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import { ReviewRequestDto } from "@root/types/dto/review"
-import { GitHubService } from "@services/db/GitHubService"
+import { isomerRepoAxiosInstance } from "@services/api/AxiosInstance"
+import GitFileSystemService from "@services/db/GitFileSystemService"
 import RepoService from "@services/db/RepoService"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
 import { getUsersService, notificationsService } from "@services/identity"
@@ -98,7 +100,11 @@ import SitesService from "@services/identity/SitesService"
 import ReviewRequestService from "@services/review/ReviewRequestService"
 import { sequelize } from "@tests/database"
 
-const gitHubService = new GitHubService({ axiosInstance: mockAxios.create() })
+const gitFileSystemService = new GitFileSystemService(simpleGit())
+const gitHubService = new RepoService(
+  isomerRepoAxiosInstance,
+  gitFileSystemService
+)
 const configYmlService = new ConfigYmlService({ gitHubService })
 const usersService = getUsersService(sequelize)
 const isomerAdminsService = new IsomerAdminsService({ repository: IsomerAdmin })

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -501,7 +501,7 @@ export default class GitFileSystemService {
     branchName: string
   ): ResultAsync<GitLocalDiskCommitData, GitFileSystemError> {
     return ResultAsync.fromPromise(
-      this.git.cwd(`${EFS_VOL_PATH}/${repoName}`).checkout(branchName).log(),
+      this.git.cwd(`${EFS_VOL_PATH}/${repoName}`).log([branchName]),
       (error) => {
         if (error instanceof GitError) {
           return new GitFileSystemError(error.message)
@@ -511,6 +511,7 @@ export default class GitFileSystemService {
       }
     ).andThen((logSummary) => {
       const possibleCommit = logSummary.latest
+      console.log(`POSSIBLE COMMIT`, possibleCommit)
       if (this.isGitLocalDiskRawCommitData(possibleCommit)) {
         return okAsync({
           author: {

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -480,14 +480,14 @@ export default class GitFileSystemService {
   // TODO: Delete a file
   async delete() {}
 
-  isDefaultLogFields(commit: unknown): commit is DefaultLogFields {
+  isDefaultLogFields(logFields: unknown): logFields is DefaultLogFields {
     return (
-      !!commit &&
-      (commit as DefaultLogFields).author_name !== undefined &&
-      (commit as DefaultLogFields).author_email !== undefined &&
-      (commit as DefaultLogFields).date !== undefined &&
-      (commit as DefaultLogFields).message !== undefined &&
-      (commit as DefaultLogFields).hash !== undefined
+      !!logFields &&
+      (logFields as DefaultLogFields).author_name !== undefined &&
+      (logFields as DefaultLogFields).author_email !== undefined &&
+      (logFields as DefaultLogFields).date !== undefined &&
+      (logFields as DefaultLogFields).message !== undefined &&
+      (logFields as DefaultLogFields).hash !== undefined
     )
   }
 

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -9,7 +9,7 @@ import {
   Result,
   ResultAsync,
 } from "neverthrow"
-import { GitError, SimpleGit } from "simple-git"
+import { GitError, SimpleGit, DefaultLogFields } from "simple-git"
 
 import { config } from "@config/config"
 
@@ -21,10 +21,7 @@ import { ISOMER_GITHUB_ORG_NAME } from "@constants/constants"
 
 import { SessionDataProps } from "@root/classes"
 import { NotFoundError } from "@root/errors/NotFoundError"
-import {
-  GitHubCommitData,
-  GitLocalDiskRawCommitData,
-} from "@root/types/commitData"
+import { GitHubCommitData } from "@root/types/commitData"
 import type { GitDirectoryItem, GitFile } from "@root/types/gitfilesystem"
 import { IsomerCommitMessage } from "@root/types/github"
 
@@ -483,16 +480,14 @@ export default class GitFileSystemService {
   // TODO: Delete a file
   async delete() {}
 
-  isGitLocalDiskRawCommitData(
-    commit: unknown
-  ): commit is GitLocalDiskRawCommitData {
+  isDefaultLogFields(commit: unknown): commit is DefaultLogFields {
     return (
       !!commit &&
-      (commit as GitLocalDiskRawCommitData).author_name !== undefined &&
-      (commit as GitLocalDiskRawCommitData).author_email !== undefined &&
-      (commit as GitLocalDiskRawCommitData).date !== undefined &&
-      (commit as GitLocalDiskRawCommitData).message !== undefined &&
-      (commit as GitLocalDiskRawCommitData).hash !== undefined
+      (commit as DefaultLogFields).author_name !== undefined &&
+      (commit as DefaultLogFields).author_email !== undefined &&
+      (commit as DefaultLogFields).date !== undefined &&
+      (commit as DefaultLogFields).message !== undefined &&
+      (commit as DefaultLogFields).hash !== undefined
     )
   }
 
@@ -511,8 +506,7 @@ export default class GitFileSystemService {
       }
     ).andThen((logSummary) => {
       const possibleCommit = logSummary.latest
-      console.log(`POSSIBLE COMMIT`, possibleCommit)
-      if (this.isGitLocalDiskRawCommitData(possibleCommit)) {
+      if (this.isDefaultLogFields(possibleCommit)) {
         return okAsync({
           author: {
             name: possibleCommit.author_name,

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -481,14 +481,15 @@ export default class GitFileSystemService {
   async delete() {}
 
   isDefaultLogFields(logFields: unknown): logFields is DefaultLogFields {
+    const c = logFields as DefaultLogFields
     return (
       !!logFields &&
       typeof logFields === "object" &&
-      (logFields as DefaultLogFields).author_name !== undefined &&
-      (logFields as DefaultLogFields).author_email !== undefined &&
-      (logFields as DefaultLogFields).date !== undefined &&
-      (logFields as DefaultLogFields).message !== undefined &&
-      (logFields as DefaultLogFields).hash !== undefined
+      typeof c.author_name === "string" &&
+      typeof c.author_email === "string" &&
+      typeof c.date === "string" &&
+      typeof c.message === "string" &&
+      typeof c.hash === "string"
     )
   }
 

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -483,6 +483,7 @@ export default class GitFileSystemService {
   isDefaultLogFields(logFields: unknown): logFields is DefaultLogFields {
     return (
       !!logFields &&
+      typeof logFields === "object" &&
       (logFields as DefaultLogFields).author_name !== undefined &&
       (logFields as DefaultLogFields).author_email !== undefined &&
       (logFields as DefaultLogFields).date !== undefined &&

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -22,7 +22,7 @@ import { ISOMER_GITHUB_ORG_NAME } from "@constants/constants"
 import { SessionDataProps } from "@root/classes"
 import { NotFoundError } from "@root/errors/NotFoundError"
 import {
-  GitLocalDiskCommitData,
+  GitHubCommitData,
   GitLocalDiskRawCommitData,
 } from "@root/types/commitData"
 import type { GitDirectoryItem, GitFile } from "@root/types/gitfilesystem"
@@ -499,7 +499,7 @@ export default class GitFileSystemService {
   getLatestCommitOfBranch(
     repoName: string,
     branchName: string
-  ): ResultAsync<GitLocalDiskCommitData, GitFileSystemError> {
+  ): ResultAsync<GitHubCommitData, GitFileSystemError> {
     return ResultAsync.fromPromise(
       this.git.cwd(`${EFS_VOL_PATH}/${repoName}`).log([branchName]),
       (error) => {

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -206,7 +206,7 @@ export default class RepoService extends GitHubService {
 
   async getLatestCommitOfBranch(
     sessionData: UserWithSiteSessionData,
-    branchName: any
+    branchName: string
   ): Promise<GitHubCommitData> {
     const { siteName } = sessionData
     if (this.isRepoWhitelisted(siteName)) {

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -5,6 +5,7 @@ import config from "@config/config"
 import logger from "@logger/logger"
 
 import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
+import { GitHubCommitData } from "@root/types/commitData"
 import { GitDirectoryItem, GitFile } from "@root/types/gitfilesystem"
 
 import GitFileSystemService from "./GitFileSystemService"
@@ -204,9 +205,9 @@ export default class RepoService extends GitHubService {
   }
 
   async getLatestCommitOfBranch(
-    sessionData: any,
+    sessionData: UserWithSiteSessionData,
     branchName: any
-  ): Promise<any> {
+  ): Promise<GitHubCommitData> {
     const { siteName } = sessionData
     if (this.isRepoWhitelisted(siteName)) {
       logger.info(

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -203,8 +203,25 @@ export default class RepoService extends GitHubService {
     return await super.getRepoState(sessionData)
   }
 
-  async getLatestCommitOfBranch(sessionData: any, branch: any): Promise<any> {
-    return await super.getLatestCommitOfBranch(sessionData, branch)
+  async getLatestCommitOfBranch(
+    sessionData: any,
+    branchName: any
+  ): Promise<any> {
+    const { siteName } = sessionData
+    if (this.isRepoWhitelisted(siteName)) {
+      logger.info(
+        `Getting latest commit of branch ${branchName} for site ${siteName} from local Git file system`
+      )
+      const result = await this.gitFileSystemService.getLatestCommitOfBranch(
+        siteName,
+        branchName
+      )
+      if (result.isErr()) {
+        throw result.error
+      }
+      return result.value
+    }
+    return await super.getLatestCommitOfBranch(sessionData, branchName)
   }
 
   async getTree(

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -11,6 +11,10 @@ import {
   mockUserWithSiteSessionData,
 } from "@fixtures/sessionData"
 import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
+import {
+  GitHubCommitData,
+  GitLocalDiskCommitData,
+} from "@root/types/commitData"
 import { GitDirectoryItem, GitFile } from "@root/types/gitfilesystem"
 import GitFileSystemService from "@services/db/GitFileSystemService"
 import _RepoService from "@services/db/RepoService"
@@ -28,6 +32,7 @@ const MockAxiosInstance = {
 const MockGitFileSystemService = {
   read: jest.fn(),
   listDirectoryContents: jest.fn(),
+  getLatestCommitOfBranch: jest.fn(),
 }
 
 const RepoService = new _RepoService(
@@ -170,6 +175,57 @@ describe("RepoService", () => {
         directoryName: "test",
       })
 
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe("getLatestCommitOfBranch", () => {
+    it("should read the latest commit data from the local Git file system if the repo is whitelisted", async () => {
+      const expected: GitLocalDiskCommitData = {
+        author: {
+          name: "test author",
+          email: "test@email.com",
+          date: "2023-07-20T11:25:05+08:00",
+        },
+        sha: "test-sha",
+        message: "test message",
+      }
+      MockGitFileSystemService.getLatestCommitOfBranch.mockResolvedValueOnce(
+        okAsync(expected)
+      )
+
+      const actual = await RepoService.getLatestCommitOfBranch(
+        mockUserWithSiteSessionData,
+        "master"
+      )
+      expect(actual).toEqual(expected)
+    })
+
+    it("should read latest commit data from GitHub if the repo is not whitelisted", async () => {
+      const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
+        githubId: mockGithubId,
+        accessToken: mockAccessToken,
+        isomerUserId: mockIsomerUserId,
+        email: mockEmail,
+        siteName: "not-whitelisted",
+      })
+      const expected: GitHubCommitData = {
+        author: {
+          name: "test author",
+          email: "test@email.com",
+          date: "2023-07-20T11:25:05+08:00",
+        },
+        message: "test message",
+      }
+      const gitHubServiceReadDirectory = jest.spyOn(
+        GitHubService.prototype,
+        "getLatestCommitOfBranch"
+      )
+      gitHubServiceReadDirectory.mockResolvedValueOnce(expected)
+      const actual = await RepoService.getLatestCommitOfBranch(
+        sessionData,
+        "master"
+      )
       expect(actual).toEqual(expected)
     })
   })

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -11,10 +11,7 @@ import {
   mockUserWithSiteSessionData,
 } from "@fixtures/sessionData"
 import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
-import {
-  GitHubCommitData,
-  GitLocalDiskCommitData,
-} from "@root/types/commitData"
+import { GitHubCommitData } from "@root/types/commitData"
 import { GitDirectoryItem, GitFile } from "@root/types/gitfilesystem"
 import GitFileSystemService from "@services/db/GitFileSystemService"
 import _RepoService from "@services/db/RepoService"
@@ -181,7 +178,7 @@ describe("RepoService", () => {
 
   describe("getLatestCommitOfBranch", () => {
     it("should read the latest commit data from the local Git file system if the repo is whitelisted", async () => {
-      const expected: GitLocalDiskCommitData = {
+      const expected: GitHubCommitData = {
         author: {
           name: "test author",
           email: "test@email.com",

--- a/src/services/identity/SitesService.ts
+++ b/src/services/identity/SitesService.ts
@@ -24,7 +24,7 @@ import type { RepositoryData, SiteUrls } from "@root/types/repoInfo"
 import { SiteInfo } from "@root/types/siteInfo"
 import { Brand } from "@root/types/util"
 import { safeJsonParse } from "@root/utils/json"
-import { GitHubService } from "@services/db/GitHubService"
+import RepoService from "@services/db/RepoService"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
 import IsomerAdminsService from "@services/identity/IsomerAdminsService"
 import UsersService from "@services/identity/UsersService"
@@ -32,7 +32,7 @@ import ReviewRequestService from "@services/review/ReviewRequestService"
 
 interface SitesServiceProps {
   siteRepository: ModelStatic<Site>
-  gitHubService: GitHubService
+  gitHubService: RepoService
   configYmlService: ConfigYmlService
   usersService: UsersService
   isomerAdminsService: IsomerAdminsService

--- a/src/services/identity/__tests__/SitesService.spec.ts
+++ b/src/services/identity/__tests__/SitesService.spec.ts
@@ -47,7 +47,7 @@ import { GitHubCommitData } from "@root/types/commitData"
 import { ConfigYmlData } from "@root/types/configYml"
 import type { RepositoryData, SiteUrls } from "@root/types/repoInfo"
 import { SiteInfo } from "@root/types/siteInfo"
-import { GitHubService } from "@services/db/GitHubService"
+import RepoService from "@services/db/RepoService"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
 import IsomerAdminsService from "@services/identity/IsomerAdminsService"
 import { SitesCacheService } from "@services/identity/SitesCacheService"
@@ -88,7 +88,7 @@ const MockSitesCacheService = {
 const MockPreviewService = {}
 const SitesService = new _SitesService({
   siteRepository: (MockRepository as unknown) as ModelStatic<Site>,
-  gitHubService: (MockGithubService as unknown) as GitHubService,
+  gitHubService: (MockGithubService as unknown) as RepoService,
   configYmlService: (MockConfigYmlService as unknown) as ConfigYmlService,
   usersService: (MockUsersService as unknown) as UsersService,
   isomerAdminsService: (MockIsomerAdminsService as unknown) as IsomerAdminsService,

--- a/src/types/commitData.ts
+++ b/src/types/commitData.ts
@@ -7,12 +7,3 @@ export type GitHubCommitData = {
   message: string
   sha?: string
 }
-
-// returned by Simple Git
-export type GitLocalDiskRawCommitData = {
-  hash: string
-  date: string
-  message: string
-  author_name: string
-  author_email: string
-}

--- a/src/types/commitData.ts
+++ b/src/types/commitData.ts
@@ -5,11 +5,8 @@ export type GitHubCommitData = {
     date: string
   }
   message: string
+  sha?: string
 }
-
-export type GitLocalDiskCommitData = {
-  sha: string
-} & GitHubCommitData
 
 // returned by Simple Git
 export type GitLocalDiskRawCommitData = {

--- a/src/types/commitData.ts
+++ b/src/types/commitData.ts
@@ -6,3 +6,16 @@ export type GitHubCommitData = {
   }
   message: string
 }
+
+export type GitLocalDiskCommitData = {
+  sha: string
+} & GitHubCommitData
+
+// returned by Simple Git
+export type GitLocalDiskRawCommitData = {
+  hash: string
+  date: string
+  message: string
+  author_name: string
+  author_email: string
+}


### PR DESCRIPTION
## Problem

Create a function that provides the latest commit information for a given branch. The return type should match the existing function with the same name in GitHubService. However, the latest commit of branch should be retrieved from the local file system for a whitelisted repository, but continue the existing behaviour of retrieving from GitHub API for a non-whitelisted repository.

Note: In addition to the existing properties, the commit SHA should also be returned, to allow for rolling back of changes.

Closes IS-404

## Solution

RepoService contains the logic to call the appropriate function depending on whether the repository is whitelisted or not, whereas GitFileSystemService contains the logic to retrieve the latest commit information from the local file system.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Tests

Ensure the following test suites pass:
- src/integration/NotificationOnEditHandler.spec.ts
- src/integration/Notifications.spec.ts
- src/integration/Privatisation.spec.ts
- src/integration/Reviews.spec.ts
- src/services/db/__tests__/RepoService.spec.ts
- src/services/identity/__tests__/SitesService.spec.ts

CMS Flow:
- Visit site dashboard will trigger API call to /info endpoint
- For a whitelisted repo, this should fetch the info from local disk
- For non-whitelisted repo, this should fetch the info from GitHub