### PR TITLE
Feat/is 399 ggs create file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "isomorphic-dompurify": "^0.24.0",
         "isomorphic-git": "^1.18.2",
         "joi": "^17.4.0",
-        "js-base64": "^2.6.4",
+        "js-base64": "^3.7.5",
         "jsdom": "^16.7.0",
         "jsonwebtoken": "^9.0.0",
         "lodash": "^4.17.21",
@@ -11769,9 +11769,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz",
+      "integrity": "sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "isomorphic-dompurify": "^0.24.0",
     "isomorphic-git": "^1.18.2",
     "joi": "^17.4.0",
-    "js-base64": "^2.6.4",
+    "js-base64": "^3.7.5",
     "jsdom": "^16.7.0",
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",

--- a/src/services/configServices/NetlifyTomlService.js
+++ b/src/services/configServices/NetlifyTomlService.js
@@ -1,3 +1,4 @@
+const { Base64 } = require("js-base64")
 const toml = require("toml")
 
 const { config } = require("@config/config")

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -1,6 +1,5 @@
 import fs from "fs"
 
-import { Base64 } from "js-base64"
 import {
   combine,
   err,

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -27,7 +27,11 @@ import { SessionDataProps } from "@root/classes"
 import { MediaTypeError } from "@root/errors/MediaTypeError"
 import { MediaFileInput, MediaFileOutput } from "@root/types"
 import { GitHubCommitData } from "@root/types/commitData"
-import type { GitDirectoryItem, GitFile } from "@root/types/gitfilesystem"
+import type {
+  GitCommitResult,
+  GitDirectoryItem,
+  GitFile,
+} from "@root/types/gitfilesystem"
 import type { IsomerCommitMessage } from "@root/types/github"
 import { ALLOWED_FILE_EXTENSIONS } from "@root/utils/file-upload-utils"
 
@@ -438,7 +442,7 @@ export default class GitFileSystemService {
     directoryName: string,
     fileName: string
   ): ResultAsync<
-    { sha: string },
+    GitCommitResult,
     ConflictError | GitFileSystemError | NotFoundError
   > {
     const filePath = directoryName ? `${directoryName}/${fileName}` : fileName
@@ -511,7 +515,7 @@ export default class GitFileSystemService {
           `Create file: ${filePath}`
         )
       )
-      .map((commit) => ({ sha: commit }))
+      .map((commit) => ({ newSha: commit }))
       .orElse((error) => {
         if (error instanceof GitFileSystemNeedsRollbackError) {
           return this.rollback(repoName, oldStateSha).andThen(() =>

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -431,19 +431,13 @@ export default class GitFileSystemService {
   }
 
   // Creates a file and the associated directory if it doesn't exist
-  create({
-    repoName,
-    userId,
-    content,
-    directoryName,
-    fileName,
-  }: {
-    repoName: string
-    userId: string
-    content: string
-    directoryName: string
+  create(
+    repoName: string,
+    userId: string,
+    content: string,
+    directoryName: string,
     fileName: string
-  }): ResultAsync<
+  ): ResultAsync<
     { sha: string },
     ConflictError | GitFileSystemError | NotFoundError
   > {

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -460,13 +460,16 @@ export default class GitFileSystemService {
         return okAsync(true)
       })
       .andThen(() => this.getFilePathStats(repoName, directoryName))
-      .andThen(() => ok(""))
+      .andThen((stats) => {
+        if (stats.isDirectory()) return ok(true)
+        return err(new NotFoundError())
+      })
       .orElse((error) => {
         if (error instanceof NotFoundError) {
           // Create directory if it does not already exist
           try {
             fs.promises.mkdir(pathToEfsDir)
-            return ok("")
+            return ok(true)
           } catch (mkdirErr) {
             logger.error(
               `Error occurred while creating ${pathToEfsDir} directory: ${mkdirErr}`

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -487,11 +487,11 @@ export default class GitFileSystemService {
               `File ${filePath} already exists in repo ${repoName}`
             )
           )
-        return ok("")
+        return ok(true)
       })
       .orElse((error) => {
         if (error instanceof NotFoundError) {
-          return ok("")
+          return ok(true)
         }
         return err(error)
       })

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -499,9 +499,11 @@ export default class GitFileSystemService {
           (error) => {
             logger.error(`Error when creating ${filePath}: ${error}`)
             if (error instanceof Error) {
-              return new GitFileSystemError(error.message)
+              return new GitFileSystemNeedsRollbackError(error.message)
             }
-            return new GitFileSystemError("An unknown error occurred")
+            return new GitFileSystemNeedsRollbackError(
+              "An unknown error occurred"
+            )
           }
         )
       )

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -519,8 +519,7 @@ export default class GitFileSystemService {
       )
       .map((commit) => ({ sha: commit }))
       .orElse((error) => {
-        if (false) {
-          // TODO: replace with unique rollback error
+        if (error instanceof GitFileSystemNeedsRollbackError) {
           return this.rollback(repoName, oldStateSha).andThen(() =>
             errAsync(new GitFileSystemError(error.message))
           )

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -504,8 +504,6 @@ export default class GitFileSystemService {
             return new GitFileSystemError("An unknown error occurred")
           }
         )
-          .map((res) => res)
-          .mapErr((error) => error)
       )
       .andThen(() =>
         this.commit(

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -142,6 +142,7 @@ export default class RepoService extends GitHubService {
         throw result.error
       }
 
+      this.gitFileSystemService.push(sessionData.siteName)
       return result.value
     }
     return await super.create(sessionData, {

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -129,7 +129,9 @@ export default class RepoService extends GitHubService {
     }
   ): Promise<{ sha: string }> {
     if (this.isRepoWhitelisted(sessionData.siteName)) {
-      logger.info("Writing file to local Git file system")
+      logger.info(
+        `Writing file to local Git file system - Site name: ${sessionData.siteName}, directory name: ${directoryName}, file name: ${fileName}`
+      )
       const result = await this.gitFileSystemService.create(
         sessionData.siteName,
         sessionData.isomerUserId,

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -143,7 +143,7 @@ export default class RepoService extends GitHubService {
       }
 
       this.gitFileSystemService.push(sessionData.siteName)
-      return result.value
+      return { sha: result.value.newSha }
     }
     return await super.create(sessionData, {
       content,

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -130,13 +130,13 @@ export default class RepoService extends GitHubService {
   ): Promise<{ sha: string }> {
     if (this.isRepoWhitelisted(sessionData.siteName)) {
       logger.info("Writing file to local Git file system")
-      const result = await this.gitFileSystemService.create({
-        repoName: sessionData.siteName,
-        userId: sessionData.isomerUserId,
+      const result = await this.gitFileSystemService.create(
+        sessionData.siteName,
+        sessionData.isomerUserId,
         content,
         directoryName,
-        fileName,
-      })
+        fileName
+      )
 
       if (result.isErr()) {
         throw result.error

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -115,9 +115,35 @@ export default class RepoService extends GitHubService {
   }
 
   async create(
-    sessionData: any,
-    { content, fileName, directoryName, isMedia = false }: any
-  ): Promise<any> {
+    sessionData: UserWithSiteSessionData,
+    {
+      content,
+      fileName,
+      directoryName,
+      isMedia = false,
+    }: {
+      content: string
+      fileName: string
+      directoryName: string
+      isMedia?: boolean
+    }
+  ): Promise<{ sha: string }> {
+    if (this.isRepoWhitelisted(sessionData.siteName)) {
+      logger.info("Writing file to local Git file system")
+      const result = await this.gitFileSystemService.create({
+        repoName: sessionData.siteName,
+        userId: sessionData.isomerUserId,
+        content,
+        directoryName,
+        fileName,
+      })
+
+      if (result.isErr()) {
+        throw result.error
+      }
+
+      return result.value
+    }
     return await super.create(sessionData, {
       content,
       fileName,

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -850,7 +850,7 @@ describe("GitFileSystemService", () => {
       })
 
       const expected = {
-        sha: expectedSha,
+        newSha: expectedSha,
       }
       const actual = await GitFileSystemService.create(
         "fake-repo",
@@ -899,7 +899,7 @@ describe("GitFileSystemService", () => {
       })
 
       const expected = {
-        sha: expectedSha,
+        newSha: expectedSha,
       }
       const actual = await GitFileSystemService.create(
         "fake-repo",

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -852,13 +852,13 @@ describe("GitFileSystemService", () => {
       const expected = {
         sha: expectedSha,
       }
-      const actual = await GitFileSystemService.create({
-        repoName: "fake-repo",
-        userId: "fake-user-id",
-        content: "fake content",
-        directoryName: "fake-dir",
-        fileName: "create-file",
-      })
+      const actual = await GitFileSystemService.create(
+        "fake-repo",
+        "fake-user-id",
+        "fake content",
+        "fake-dir",
+        "create-file"
+      )
 
       expect(actual._unsafeUnwrap()).toEqual(expected)
     })
@@ -901,13 +901,13 @@ describe("GitFileSystemService", () => {
       const expected = {
         sha: expectedSha,
       }
-      const actual = await GitFileSystemService.create({
-        repoName: "fake-repo",
-        userId: "fake-user-id",
-        content: "fake content",
-        directoryName: "fake-create-dir",
-        fileName: "create-file",
-      })
+      const actual = await GitFileSystemService.create(
+        "fake-repo",
+        "fake-user-id",
+        "fake content",
+        "fake-create-dir",
+        "create-file"
+      )
 
       expect(actual._unsafeUnwrap()).toEqual(expected)
     })
@@ -924,13 +924,13 @@ describe("GitFileSystemService", () => {
           },
         }),
       })
-      const actual = await GitFileSystemService.create({
-        repoName: "fake-repo",
-        userId: "fake-user-id",
-        content: "fake content",
-        directoryName: "fake-dir",
-        fileName: "fake-file",
-      })
+      const actual = await GitFileSystemService.create(
+        "fake-repo",
+        "fake-user-id",
+        "fake content",
+        "fake-dir",
+        "fake-file"
+      )
 
       expect(actual.isErr()).toBeTrue()
     })
@@ -975,13 +975,13 @@ describe("GitFileSystemService", () => {
       })
       const spyRollback = jest.spyOn(GitFileSystemService, "rollback")
 
-      const actual = await GitFileSystemService.create({
-        repoName: "fake-repo",
-        userId: "fake-user-id",
-        content: "fake content",
-        directoryName: "fake-dir",
-        fileName: "create-file-rollback",
-      })
+      const actual = await GitFileSystemService.create(
+        "fake-repo",
+        "fake-user-id",
+        "fake content",
+        "fake-dir",
+        "create-file-rollback"
+      )
 
       expect(actual._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
       expect(spyRollback).toHaveBeenCalledWith("fake-repo", "test-commit-sha")

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -58,6 +58,140 @@ describe("GitFileSystemService", () => {
     mockFs.restore()
   })
 
+  describe("listDirectoryContents", () => {
+    it("should return the contents of a directory successfully", async () => {
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("fake-dir-hash"),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("fake-empty-dir-hash"),
+      })
+
+      const expectedFakeDir: GitDirectoryItem = {
+        name: "fake-dir",
+        type: "dir",
+        sha: "fake-dir-hash",
+        path: "fake-dir",
+        size: 0,
+      }
+      const expectedFakeEmptyDir: GitDirectoryItem = {
+        name: "fake-empty-dir",
+        type: "dir",
+        sha: "fake-empty-dir-hash",
+        path: "fake-empty-dir",
+        size: 0,
+      }
+      const expectedAnotherFakeFile: GitDirectoryItem = {
+        name: "another-fake-file",
+        type: "file",
+        sha: "another-fake-file-hash",
+        path: "another-fake-file",
+        size: "Another fake content".length,
+      }
+
+      const result = await GitFileSystemService.listDirectoryContents(
+        "fake-repo",
+        ""
+      )
+      const actual = result
+        ._unsafeUnwrap()
+        .sort((a, b) => a.name.localeCompare(b.name))
+
+      expect(actual).toMatchObject([
+        expectedAnotherFakeFile,
+        expectedFakeDir,
+        expectedFakeEmptyDir,
+      ])
+    })
+
+    it("should return only results of files that are tracked by Git", async () => {
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("fake-dir-hash"),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
+      })
+
+      const expectedFakeDir: GitDirectoryItem = {
+        name: "fake-dir",
+        type: "dir",
+        sha: "fake-dir-hash",
+        path: "fake-dir",
+        size: 0,
+      }
+      const expectedAnotherFakeFile: GitDirectoryItem = {
+        name: "another-fake-file",
+        type: "file",
+        sha: "another-fake-file-hash",
+        path: "another-fake-file",
+        size: "Another fake content".length,
+      }
+
+      const result = await GitFileSystemService.listDirectoryContents(
+        "fake-repo",
+        ""
+      )
+
+      const actual = result
+        ._unsafeUnwrap()
+        .sort((a, b) => a.name.localeCompare(b.name))
+
+      expect(actual).toMatchObject([expectedAnotherFakeFile, expectedFakeDir])
+    })
+
+    it("should return an empty result if the directory contain files that are all untracked", async () => {
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
+      })
+
+      const actual = await GitFileSystemService.listDirectoryContents(
+        "fake-repo",
+        ""
+      )
+
+      expect(actual._unsafeUnwrap()).toHaveLength(0)
+    })
+
+    it("should return an empty result if the directory is empty", async () => {
+      const actual = await GitFileSystemService.listDirectoryContents(
+        "fake-repo",
+        "fake-empty-dir"
+      )
+
+      expect(actual._unsafeUnwrap()).toHaveLength(0)
+    })
+
+    it("should return a GitFileSystemError if the path is not a directory", async () => {
+      const result = await GitFileSystemService.listDirectoryContents(
+        "fake-repo",
+        "fake-dir/fake-file"
+      )
+
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
+    })
+
+    it("should return a NotFoundError if the path does not exist", async () => {
+      const result = await GitFileSystemService.listDirectoryContents(
+        "fake-repo",
+        "non-existent-dir"
+      )
+
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+    })
+  })
+
   describe("isGitInitialized", () => {
     it("should mark a valid Git repo as initialized", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
@@ -683,7 +817,17 @@ describe("GitFileSystemService", () => {
       const expectedSha = "fake-hash"
 
       MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce("fake-hash"),
+        log: jest.fn().mockResolvedValueOnce({
+          latest: {
+            author_name: "fake-author",
+            author_email: "fake-email",
+            date: "fake-date",
+            message: "fake-message",
+            hash: "test-commit-sha",
+          },
+        }),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
         checkIsRepo: jest.fn().mockResolvedValueOnce(true),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
@@ -722,7 +866,17 @@ describe("GitFileSystemService", () => {
     it("should create a directory and a file if the directory doesn't already exist", async () => {
       const expectedSha = "fake-hash"
       MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
+        log: jest.fn().mockResolvedValueOnce({
+          latest: {
+            author_name: "fake-author",
+            author_email: "fake-email",
+            date: "fake-date",
+            message: "fake-message",
+            hash: "test-commit-sha",
+          },
+        }),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
         checkIsRepo: jest.fn().mockResolvedValueOnce(true),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
@@ -759,6 +913,17 @@ describe("GitFileSystemService", () => {
     })
 
     it("should return an error if the file already exists", async () => {
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        log: jest.fn().mockResolvedValueOnce({
+          latest: {
+            author_name: "fake-author",
+            author_email: "fake-email",
+            date: "fake-date",
+            message: "fake-message",
+            hash: "test-commit-sha",
+          },
+        }),
+      })
       const actual = await GitFileSystemService.create({
         repoName: "fake-repo",
         userId: "fake-user-id",
@@ -813,140 +978,6 @@ describe("GitFileSystemService", () => {
       )
 
       expect(result.isErr()).toBeTrue()
-    })
-  })
-
-  describe("listDirectoryContents", () => {
-    it("should return the contents of a directory successfully", async () => {
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce("fake-dir-hash"),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce("fake-empty-dir-hash"),
-      })
-
-      const expectedFakeDir: GitDirectoryItem = {
-        name: "fake-dir",
-        type: "dir",
-        sha: "fake-dir-hash",
-        path: "fake-dir",
-        size: 0,
-      }
-      const expectedFakeEmptyDir: GitDirectoryItem = {
-        name: "fake-empty-dir",
-        type: "dir",
-        sha: "fake-empty-dir-hash",
-        path: "fake-empty-dir",
-        size: 0,
-      }
-      const expectedAnotherFakeFile: GitDirectoryItem = {
-        name: "another-fake-file",
-        type: "file",
-        sha: "another-fake-file-hash",
-        path: "another-fake-file",
-        size: "Another fake content".length,
-      }
-
-      const result = await GitFileSystemService.listDirectoryContents(
-        "fake-repo",
-        ""
-      )
-      const actual = result
-        ._unsafeUnwrap()
-        .sort((a, b) => a.name.localeCompare(b.name))
-
-      expect(actual).toMatchObject([
-        expectedAnotherFakeFile,
-        expectedFakeDir,
-        expectedFakeEmptyDir,
-      ])
-    })
-
-    it("should return only results of files that are tracked by Git", async () => {
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce("fake-dir-hash"),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
-      })
-
-      const expectedFakeDir: GitDirectoryItem = {
-        name: "fake-dir",
-        type: "dir",
-        sha: "fake-dir-hash",
-        path: "fake-dir",
-        size: 0,
-      }
-      const expectedAnotherFakeFile: GitDirectoryItem = {
-        name: "another-fake-file",
-        type: "file",
-        sha: "another-fake-file-hash",
-        path: "another-fake-file",
-        size: "Another fake content".length,
-      }
-
-      const result = await GitFileSystemService.listDirectoryContents(
-        "fake-repo",
-        ""
-      )
-
-      const actual = result
-        ._unsafeUnwrap()
-        .sort((a, b) => a.name.localeCompare(b.name))
-
-      expect(actual).toMatchObject([expectedAnotherFakeFile, expectedFakeDir])
-    })
-
-    it("should return an empty result if the directory contain files that are all untracked", async () => {
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
-      })
-
-      const actual = await GitFileSystemService.listDirectoryContents(
-        "fake-repo",
-        ""
-      )
-
-      expect(actual._unsafeUnwrap()).toHaveLength(0)
-    })
-
-    it("should return an empty result if the directory is empty", async () => {
-      const actual = await GitFileSystemService.listDirectoryContents(
-        "fake-repo",
-        "fake-empty-dir"
-      )
-
-      expect(actual._unsafeUnwrap()).toHaveLength(0)
-    })
-
-    it("should return a GitFileSystemError if the path is not a directory", async () => {
-      const result = await GitFileSystemService.listDirectoryContents(
-        "fake-repo",
-        "fake-dir/fake-file"
-      )
-
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
-    })
-
-    it("should return a NotFoundError if the path does not exist", async () => {
-      const result = await GitFileSystemService.listDirectoryContents(
-        "fake-repo",
-        "non-existent-dir"
-      )
-
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
     })
   })
 

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -932,7 +932,7 @@ describe("GitFileSystemService", () => {
         "fake-file"
       )
 
-      expect(actual.isErr()).toBeTrue()
+      expect(actual._unsafeUnwrapErr()).toBeInstanceOf(ConflictError)
     })
 
     it("should rollback changes if an error occurred when committing", async () => {

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -30,6 +30,7 @@ const MockAxiosInstance = {
 const MockGitFileSystemService = {
   read: jest.fn(),
   readMediaFile: jest.fn(),
+  create: jest.fn(),
   listDirectoryContents: jest.fn(),
   push: jest.fn(),
   update: jest.fn(),
@@ -59,6 +60,50 @@ describe("RepoService", () => {
     it("should indicate non-whitelisted repos as non-whitelisted correctly", () => {
       const actual = RepoService.isRepoWhitelisted("not-whitelisted")
       expect(actual).toBe(false)
+    })
+  })
+
+  describe("create", () => {
+    it("should create using the local Git file system if the repo is whitelisted", async () => {
+      const expected = {
+        sha: "test-sha",
+      }
+      MockGitFileSystemService.create.mockResolvedValueOnce(okAsync(expected))
+
+      const actual = await RepoService.create(mockUserWithSiteSessionData, {
+        content: "content",
+        fileName: "test.md",
+        directoryName: "",
+        isMedia: false,
+      })
+
+      expect(actual).toEqual(expected)
+      expect(MockGitFileSystemService.create).toHaveBeenCalled()
+    })
+
+    it("should create files on GitHub directly if the repo is not whitelisted", async () => {
+      const sessionData = new UserWithSiteSessionData({
+        githubId: mockGithubId,
+        accessToken: mockAccessToken,
+        isomerUserId: mockIsomerUserId,
+        email: mockEmail,
+        siteName: "not-whitelisted",
+      })
+      const expected = {
+        sha: "test-sha",
+      }
+      const gitHubServiceCreate = jest.spyOn(GitHubService.prototype, "create")
+      gitHubServiceCreate.mockResolvedValueOnce(expected)
+
+      const actual = await RepoService.create(sessionData, {
+        content: "content",
+        fileName: "test.md",
+        directoryName: "",
+        isMedia: false,
+      })
+
+      expect(actual).toEqual(expected)
+      expect(gitHubServiceCreate).toHaveBeenCalled()
     })
   })
 

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -65,10 +65,16 @@ describe("RepoService", () => {
 
   describe("create", () => {
     it("should create using the local Git file system if the repo is whitelisted", async () => {
-      const expected = {
-        sha: "test-sha",
+      const returnedSha = "test-sha"
+      const createOutput = {
+        newSha: returnedSha,
       }
-      MockGitFileSystemService.create.mockResolvedValueOnce(okAsync(expected))
+      const expected = {
+        sha: returnedSha,
+      }
+      MockGitFileSystemService.create.mockResolvedValueOnce(
+        okAsync(createOutput)
+      )
 
       const actual = await RepoService.create(mockUserWithSiteSessionData, {
         content: "content",


### PR DESCRIPTION
## Problem

This PR introduces creates to our GGS solution. Resolves IS-399. This PR also modifies checks for the existence of paths to use `gitFilePathStats` instead of `fs.existsSync`.

**Features**:

- Refactored safeExistsSync calls in `clone` and `isValidGitRepo` to use `getFilePathStats` instead
- Create operation supported for GGS

Future work:

- Verify image creation - pending image retrieval PR
