### PR TITLE
Feat/siteLaunch/integrationForFinalScreens

### DIFF
--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -356,21 +356,21 @@ export default class InfraService {
       return errAsync(generatedDnsRecords.error)
     }
 
-    let jobStatus: SiteLaunchStatus
+    let siteLaunchStatus: SiteLaunchStatus
     switch (site.value.jobStatus) {
       case JobStatus.Ready:
-        jobStatus = SiteLaunchStatusObject.Launched
+        siteLaunchStatus = SiteLaunchStatusObject.Launched
         break
       case JobStatus.Failed:
-        jobStatus = SiteLaunchStatusObject.Failure
+        siteLaunchStatus = SiteLaunchStatusObject.Failure
         break
       default:
-        jobStatus = SiteLaunchStatusObject.Launching
+        siteLaunchStatus = SiteLaunchStatusObject.Launching
         break
     }
 
     return okAsync<SiteLaunchDto>({
-      siteLaunchStatus: jobStatus,
+      siteLaunchStatus,
       dnsRecords: generatedDnsRecords.value.dnsRecords,
       siteUrl: generatedDnsRecords.value.siteUrl,
     })

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -347,7 +347,7 @@ export default class InfraService {
     }
     if (site.value.siteStatus !== SiteStatus.Launched) {
       return okAsync<SiteLaunchDto>({
-        siteStatus: SiteLaunchStatusObject.NotLaunched,
+        siteLaunchStatus: SiteLaunchStatusObject.NotLaunched,
       })
     }
 
@@ -370,7 +370,7 @@ export default class InfraService {
     }
 
     return okAsync<SiteLaunchDto>({
-      siteStatus: jobStatus,
+      siteLaunchStatus: jobStatus,
       dnsRecords: generatedDnsRecords.value.dnsRecords,
       siteUrl: generatedDnsRecords.value.siteUrl,
     })

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -357,12 +357,16 @@ export default class InfraService {
     }
 
     let jobStatus: SiteLaunchStatus
-    if (site.value.jobStatus === JobStatus.Ready) {
-      jobStatus = SiteLaunchStatusObject.Launched
-    } else if (site.value.jobStatus === JobStatus.Failed) {
-      jobStatus = SiteLaunchStatusObject.Failure
-    } else {
-      jobStatus = SiteLaunchStatusObject.Launching
+    switch (site.value.jobStatus) {
+      case JobStatus.Ready:
+        jobStatus = SiteLaunchStatusObject.Launched
+        break
+      case JobStatus.Failed:
+        jobStatus = SiteLaunchStatusObject.Failure
+        break
+      default:
+        jobStatus = SiteLaunchStatusObject.Launching
+        break
     }
 
     return okAsync<SiteLaunchDto>({

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -31,6 +31,7 @@ import { AmplifyError } from "@root/types/amplify"
 import {
   DnsResultsForSite,
   SiteLaunchDto,
+  SiteLaunchStatus,
   SiteLaunchStatusObject,
 } from "@root/types/siteInfo"
 import { SiteLaunchMessage } from "@root/types/siteLaunch"
@@ -355,12 +356,17 @@ export default class InfraService {
       return errAsync(generatedDnsRecords.error)
     }
 
+    let jobStatus: SiteLaunchStatus
+    if (site.value.jobStatus === JobStatus.Ready) {
+      jobStatus = SiteLaunchStatusObject.Launched
+    } else if (site.value.jobStatus === JobStatus.Failed) {
+      jobStatus = SiteLaunchStatusObject.Failure
+    } else {
+      jobStatus = SiteLaunchStatusObject.Launching
+    }
+
     return okAsync<SiteLaunchDto>({
-      siteStatus:
-        // status is only successful iff job is ready
-        site.value.jobStatus === JobStatus.Ready
-          ? SiteLaunchStatusObject.Launched
-          : SiteLaunchStatusObject.Launching,
+      siteStatus: jobStatus,
       dnsRecords: generatedDnsRecords.value.dnsRecords,
       siteUrl: generatedDnsRecords.value.siteUrl,
     })

--- a/src/types/siteInfo.ts
+++ b/src/types/siteInfo.ts
@@ -26,7 +26,7 @@ export const SiteLaunchStatusObject = {
   Launched: "LAUNCHED",
   NotLaunched: "NOT_LAUNCHED",
   Launching: "LAUNCHING",
-  Failure: "FAILURE",
+  Failure: "FAILED",
 } as const
 
 export type SiteLaunchStatus = typeof SiteLaunchStatusObject[keyof typeof SiteLaunchStatusObject]

--- a/src/types/siteInfo.ts
+++ b/src/types/siteInfo.ts
@@ -26,6 +26,7 @@ export const SiteLaunchStatusObject = {
   Launched: "LAUNCHED",
   NotLaunched: "NOT_LAUNCHED",
   Launching: "LAUNCHING",
+  Failure: "FAILURE",
 } as const
 
 export type SiteLaunchStatus = typeof SiteLaunchStatusObject[keyof typeof SiteLaunchStatusObject]

--- a/src/types/siteInfo.ts
+++ b/src/types/siteInfo.ts
@@ -32,7 +32,7 @@ export const SiteLaunchStatusObject = {
 export type SiteLaunchStatus = typeof SiteLaunchStatusObject[keyof typeof SiteLaunchStatusObject]
 
 export interface SiteLaunchDto {
-  siteStatus: SiteLaunchStatus
+  siteLaunchStatus: SiteLaunchStatus
   dnsRecords?: DNSRecord[]
   siteUrl?: string
 }


### PR DESCRIPTION
## Problem

Currently the BE routes does not support the final screens for site launch. can be reviewed together with [fe pr](https://github.com/isomerpages/isomercms-frontend/pull/1410) 

## Solution

This PR modifies a failure state to actually be returned to the fe.


