### PR TITLE
IS-401: Write extend repo service to support delete files folders

### DIFF
--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -690,7 +690,13 @@ export default class GitFileSystemService {
 
     return this.getLatestCommitOfBranch(repoName, BRANCH_REF)
       .andThen((latestCommit) => {
-        // It is guaranteed that the latest commit contains the SHA hash
+        if (!latestCommit.sha) {
+          return errAsync(
+            new GitFileSystemError(
+              `Unable to find latest commit of repo: ${repoName} on branch "${BRANCH_REF}"`
+            )
+          )
+        }
         oldStateSha = latestCommit.sha as string
         return okAsync(true)
       })

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -305,7 +305,7 @@ export default class RepoService extends GitHubService {
         throw result.error
       }
 
-      // this.gitFileSystemService.push(sessionData.siteName)
+      this.gitFileSystemService.push(sessionData.siteName)
       return { newSha: result.value }
     }
 

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -8,8 +8,6 @@ import { GithubSessionDataProps } from "@root/classes"
 import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import { GitHubCommitData } from "@root/types/commitData"
 import type {
-  DeleteDirInput,
-  DeleteFileInput,
   GitCommitResult,
   GitDirectoryItem,
   GitFile,

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -303,7 +303,7 @@ export default class RepoService extends GitHubService {
         throw result.error
       }
 
-      this.gitFileSystemService.push(sessionData.siteName)
+      // this.gitFileSystemService.push(sessionData.siteName)
       return { newSha: result.value }
     }
 
@@ -315,10 +315,28 @@ export default class RepoService extends GitHubService {
     })
   }
 
+  // deletes a file
   async delete(
-    sessionData: any,
+    sessionData: UserWithSiteSessionData,
     { sha, fileName, directoryName }: any
   ): Promise<any> {
+    if (this.isRepoWhitelisted(sessionData.siteName)) {
+      logger.info("Deleting file in local Git file system")
+      const filePath = directoryName ? `${directoryName}/${fileName}` : fileName
+      const result = await this.gitFileSystemService.delete(
+        sessionData.siteName,
+        filePath,
+        sha,
+        sessionData.isomerUserId
+      )
+
+      if (result.isErr()) {
+        throw result.error
+      }
+
+      this.gitFileSystemService.push(sessionData.siteName)
+      return { newSha: result.value }
+    }
     return await super.delete(sessionData, {
       sha,
       fileName,

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -330,6 +330,9 @@ export default class RepoService extends GitHubService {
     }
   ): Promise<void> {
     if (this.isRepoWhitelisted(sessionData.siteName)) {
+      logger.info(
+        `Deleting directory in local Git file system for repo: ${sessionData.siteName}, directory name: ${directoryName}`
+      )
       const result = await this.gitFileSystemService.delete(
         sessionData.siteName,
         directoryName,

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -328,7 +328,7 @@ export default class RepoService extends GitHubService {
       message: string
       githubSessionData: GithubSessionDataProps
     }
-  ): Promise<any> {
+  ): Promise<void> {
     // helper function for delete directory
     const updateTreeAndRepoState = async () => {
       const gitTree = await this.getTree(sessionData, githubSessionData, {
@@ -350,7 +350,7 @@ export default class RepoService extends GitHubService {
         message,
       })
 
-      await this.updateRepoState(sessionData, {
+      return await this.updateRepoState(sessionData, {
         commitSha: newCommitSha,
       })
     }
@@ -373,10 +373,10 @@ export default class RepoService extends GitHubService {
       // TODO: The below functions are pending (getTree, updateTree and updateRepoState)
       await updateTreeAndRepoState()
 
-      return { newSha: result.value }
+      return
     }
 
-    await updateTreeAndRepoState()
+    return await updateTreeAndRepoState()
   }
 
   // deletes a file
@@ -391,7 +391,7 @@ export default class RepoService extends GitHubService {
       fileName: string
       directoryName: string
     }
-  ): Promise<any> {
+  ): Promise<void> {
     if (this.isRepoWhitelisted(sessionData.siteName)) {
       logger.info(
         `Deleting file in local Git file system for repo: ${sessionData.siteName}, directory name: ${directoryName}, file name: ${fileName}`
@@ -412,8 +412,7 @@ export default class RepoService extends GitHubService {
       }
 
       this.gitFileSystemService.push(sessionData.siteName)
-
-      return { newSha: result.value }
+      return
     }
 
     // GitHub flow

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -1092,6 +1092,29 @@ describe("GitFileSystemService", () => {
   })
 
   describe("delete", () => {
+    it("should return a error if latest commit sha is not found", async () => {
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        log: jest.fn().mockResolvedValueOnce({
+          latest: {
+            author_name: "fake-author",
+            author_email: "fake-email",
+            date: "fake-date",
+            message: "fake-message",
+            hash: undefined,
+          },
+        }),
+      })
+
+      const actual = await GitFileSystemService.delete(
+        "fake-repo",
+        "fake-dir/fake-file",
+        "fake-old-hash",
+        "fake-user-id",
+        false
+      )
+      expect(actual._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
+    })
+
     describe("deleteFile", () => {
       it("should delete a file successfully", async () => {
         // getLatestCommitOfBranch

--- a/src/services/directoryServices/BaseDirectoryService.js
+++ b/src/services/directoryServices/BaseDirectoryService.js
@@ -77,35 +77,13 @@ class BaseDirectoryService {
   }
 
   async delete(sessionData, githubSessionData, { directoryName, message }) {
-    const gitTree = await this.gitHubService.getTree(
-      sessionData,
+    await this.gitHubService.delete(sessionData, {
+      sha: "",
+      fileName: "",
+      directoryName,
+      isDir: true,
+      message,
       githubSessionData,
-      {
-        isRecursive: true,
-      }
-    )
-
-    // Retrieve removed items and set their sha to null
-    const newGitTree = gitTree
-      .filter(
-        (item) =>
-          item.path.startsWith(`${directoryName}/`) && item.type !== "tree"
-      )
-      .map((item) => ({
-        ...item,
-        sha: null,
-      }))
-
-    const newCommitSha = await this.gitHubService.updateTree(
-      sessionData,
-      githubSessionData,
-      {
-        gitTree: newGitTree,
-        message,
-      }
-    )
-    await this.gitHubService.updateRepoState(sessionData, {
-      commitSha: newCommitSha,
     })
   }
 

--- a/src/services/directoryServices/BaseDirectoryService.js
+++ b/src/services/directoryServices/BaseDirectoryService.js
@@ -77,11 +77,8 @@ class BaseDirectoryService {
   }
 
   async delete(sessionData, githubSessionData, { directoryName, message }) {
-    await this.gitHubService.delete(sessionData, {
-      sha: "",
-      fileName: "",
+    await this.gitHubService.deleteDirectory(sessionData, {
       directoryName,
-      isDir: true,
       message,
       githubSessionData,
     })

--- a/src/services/directoryServices/__tests__/BaseDirectoryService.spec.js
+++ b/src/services/directoryServices/__tests__/BaseDirectoryService.spec.js
@@ -62,6 +62,7 @@ describe("Base Directory Service", () => {
     getTree: jest.fn(),
     updateTree: jest.fn(),
     updateRepoState: jest.fn(),
+    deleteDirectory: jest.fn(),
   }
 
   const {
@@ -229,25 +230,12 @@ describe("Base Directory Service", () => {
           message,
         })
       ).resolves.not.toThrow()
-      expect(mockGithubService.getTree).toHaveBeenCalledWith(
+      expect(mockGithubService.deleteDirectory).toHaveBeenCalledWith(
         sessionData,
-        mockGithubSessionData,
         {
-          isRecursive: true,
-        }
-      )
-      expect(mockGithubService.updateTree).toHaveBeenCalledWith(
-        sessionData,
-        mockGithubSessionData,
-        {
-          gitTree: mockedDeletedTree,
+          directoryName,
           message,
-        }
-      )
-      expect(mockGithubService.updateRepoState).toHaveBeenCalledWith(
-        sessionData,
-        {
-          commitSha: sha,
+          githubSessionData: mockGithubSessionData,
         }
       )
     })

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -92,3 +92,12 @@ export interface RawComment {
   body: string
   created_at: string
 }
+
+export type RawGitTreeEntry = {
+  path: string
+  mode: string
+  type: "tree" | "file"
+  sha: string
+  url: string
+  size?: number // only exists if it is a file
+}


### PR DESCRIPTION
## Problem

Create a new function in RepoService and GitFileSystemService to support deleting files and folders

Closes IS-401

## Solution

RepoService contains the logic to determine the service to utilise depending on whether the repository is whitelisted or not, whereas GitFileSystemService should contain the logic to delete files and folders.

There are 2 new functions in RepoService - `delete` and `deleteDirectory`, but both of them utilise a single `delete` function from GitFileSystemService.

This new function should create commits that are similar to the ones created by GitHubService currently. All other Git-related quirks should also be maintained (i.e. deleting the .keep file inside a folder in order to delete it).

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Tests

To ensure all tests pass with `npm run test`

## Notes

There are 2 CI tests for BaseDirectoryService is failing for "move" operations though this PR is only focused on delete operations. Currently, still investigating into the root cause. However, these tests will be overriden by @dcshzj 's PR for move files/folders, hence this would be a low priority fix.