### PR TITLE
Feat/ggs rollback handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "isomorphic-dompurify": "^0.24.0",
         "isomorphic-git": "^1.18.2",
         "joi": "^17.4.0",
-        "js-base64": "^2.6.4",
+        "js-base64": "^3.7.5",
         "jsdom": "^16.7.0",
         "jsonwebtoken": "^9.0.0",
         "lodash": "^4.17.21",
@@ -11769,9 +11769,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz",
+      "integrity": "sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "isomorphic-dompurify": "^0.24.0",
     "isomorphic-git": "^1.18.2",
     "joi": "^17.4.0",
-    "js-base64": "^2.6.4",
+    "js-base64": "^3.7.5",
     "jsdom": "^16.7.0",
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",

--- a/src/middleware/routeHandler.js
+++ b/src/middleware/routeHandler.js
@@ -1,9 +1,22 @@
 const { backOff } = require("exponential-backoff")
+const SimpleGit = require("simple-git")
+
+const { config } = require("@config/config")
 
 const { default: GithubSessionData } = require("@classes/GithubSessionData")
 
 const { lock, unlock } = require("@utils/mutex-utils")
 const { getCommitAndTreeSha, revertCommit } = require("@utils/utils.js")
+
+const GitFileSystemError = require("@root/errors/GitFileSystemError")
+const {
+  default: GitFileSystemService,
+} = require("@services/db/GitFileSystemService")
+
+const WHITELISTED_GIT_SERVICE_REPOS = config.get(
+  "featureFlags.ggsWhitelistedRepos"
+)
+const BRANCH_REF = config.get("github.branchRef")
 
 // Used when there are no write API calls to the repo on GitHub
 const attachReadRouteHandlerWrapper = (routeHandler) => async (
@@ -31,6 +44,8 @@ const attachWriteRouteHandlerWrapper = (routeHandler) => async (
   await unlock(siteName)
 }
 
+const gitFileSystemService = new GitFileSystemService(new SimpleGit())
+
 const attachRollbackRouteHandlerWrapper = (routeHandler) => async (
   req,
   res,
@@ -40,32 +55,72 @@ const attachRollbackRouteHandlerWrapper = (routeHandler) => async (
   const { siteName } = req.params
 
   const { accessToken } = userSessionData
+  const isRepoWhitelisted = WHITELISTED_GIT_SERVICE_REPOS.split(",").includes(
+    siteName
+  )
 
   await lock(siteName)
 
   let originalCommitSha
-  try {
-    const { currentCommitSha, treeSha } = await getCommitAndTreeSha(
+  if (isRepoWhitelisted) {
+    const result = await gitFileSystemService.getLatestCommitOfBranch(
       siteName,
-      accessToken
+      BRANCH_REF
     )
+    if (result.isErr()) {
+      await unlock(siteName)
+      next(result.err)
+    } else {
+      originalCommitSha = result.value.sha
+      if (!originalCommitSha) {
+        await unlock(siteName)
+        next(result.err)
+      }
+      // Unused for git file system, but to maintain existing structure
+      res.locals.githubSessionData = new GithubSessionData({
+        currentCommitSha: "",
+        treeSha: "",
+      })
+    }
+  } else {
+    try {
+      const { currentCommitSha, treeSha } = await getCommitAndTreeSha(
+        siteName,
+        accessToken
+      )
 
-    const githubSessionData = new GithubSessionData({
-      currentCommitSha,
-      treeSha,
-    })
-    res.locals.githubSessionData = githubSessionData
+      const githubSessionData = new GithubSessionData({
+        currentCommitSha,
+        treeSha,
+      })
+      res.locals.githubSessionData = githubSessionData
 
-    originalCommitSha = currentCommitSha
-  } catch (err) {
-    await unlock(siteName)
-    next(err)
+      originalCommitSha = currentCommitSha
+    } catch (err) {
+      await unlock(siteName)
+      next(err)
+    }
   }
   routeHandler(req, res, next).catch(async (err) => {
     try {
-      await backOff(() =>
-        revertCommit(originalCommitSha, siteName, accessToken)
-      )
+      if (isRepoWhitelisted) {
+        await backOff(() => {
+          const rollbackRes = gitFileSystemService
+            .rollback(siteName, originalCommitSha)
+            .unwrapOr(false)
+          if (!rollbackRes) throw new GitFileSystemError("Rollback failure")
+        })
+        await backOff(() => {
+          const pushRes = gitFileSystemService
+            .push(siteName, true)
+            .unwrapOr(false)
+          if (!pushRes) throw new GitFileSystemError("Push failure")
+        })
+      } else {
+        await backOff(() => {
+          revertCommit(originalCommitSha, siteName, accessToken)
+        })
+      }
     } catch (retryErr) {
       await unlock(siteName)
       next(retryErr)

--- a/src/services/configServices/NetlifyTomlService.js
+++ b/src/services/configServices/NetlifyTomlService.js
@@ -1,3 +1,4 @@
+const { Base64 } = require("js-base64")
 const toml = require("toml")
 
 const { config } = require("@config/config")

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -1,6 +1,14 @@
 import fs from "fs"
 
-import { combine, err, errAsync, ok, okAsync, ResultAsync } from "neverthrow"
+import {
+  combine,
+  err,
+  errAsync,
+  ok,
+  okAsync,
+  Result,
+  ResultAsync,
+} from "neverthrow"
 import { CleanOptions, GitError, SimpleGit, DefaultLogFields } from "simple-git"
 
 import { config } from "@config/config"

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -1,14 +1,6 @@
 import fs from "fs"
 
-import {
-  combine,
-  err,
-  errAsync,
-  ok,
-  okAsync,
-  Result,
-  ResultAsync,
-} from "neverthrow"
+import { combine, err, errAsync, ok, okAsync, ResultAsync } from "neverthrow"
 import { CleanOptions, GitError, SimpleGit, DefaultLogFields } from "simple-git"
 
 import { config } from "@config/config"
@@ -344,7 +336,10 @@ export default class GitFileSystemService {
   }
 
   // Push the latest changes to upstream Git hosting provider
-  push(repoName: string): ResultAsync<string, GitFileSystemError> {
+  push(
+    repoName: string,
+    isForce?: boolean
+  ): ResultAsync<string, GitFileSystemError> {
     return this.isValidGitRepo(repoName).andThen((isValid) => {
       if (!isValid) {
         return errAsync(
@@ -354,7 +349,9 @@ export default class GitFileSystemService {
 
       return this.ensureCorrectBranch(repoName).andThen(() =>
         ResultAsync.fromPromise(
-          this.git.cwd(`${EFS_VOL_PATH}/${repoName}`).push(),
+          isForce
+            ? this.git.cwd(`${EFS_VOL_PATH}/${repoName}`).push(["--force"])
+            : this.git.cwd(`${EFS_VOL_PATH}/${repoName}`).push(),
           (error) => {
             logger.error(`Error when pushing ${repoName}: ${error}`)
 

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -346,7 +346,7 @@ export default class GitFileSystemService {
   // Push the latest changes to upstream Git hosting provider
   push(
     repoName: string,
-    isForce?: boolean
+    isForce = false
   ): ResultAsync<string, GitFileSystemError> {
     return this.isValidGitRepo(repoName).andThen((isValid) => {
       if (!isValid) {

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -4,6 +4,7 @@ import config from "@config/config"
 
 import logger from "@logger/logger"
 
+import { GithubSessionDataProps } from "@root/classes"
 import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import { GitHubCommitData } from "@root/types/commitData"
 import type {
@@ -13,6 +14,7 @@ import type {
 } from "@root/types/gitfilesystem"
 import { MediaDirOutput, MediaFileOutput, MediaType } from "@root/types/media"
 import { getMediaFileInfo } from "@root/utils/media-utils"
+import { RawGitTreeEntry } from "@root/types/github"
 
 import GitFileSystemService from "./GitFileSystemService"
 import { GitHubService } from "./GitHubService"
@@ -315,10 +317,101 @@ export default class RepoService extends GitHubService {
     })
   }
 
+  async deleteDirectory(
+    sessionData: UserWithSiteSessionData,
+    {
+      directoryName,
+      message,
+      githubSessionData,
+    }: {
+      directoryName: string
+      message: string
+      githubSessionData: GithubSessionDataProps
+    }
+  ): Promise<void> {
+    if (this.isRepoWhitelisted(sessionData.siteName)) {
+      logger.info(
+        `Deleting directory in local Git file system for repo: ${sessionData.siteName}, directory name: ${directoryName}`
+      )
+      const result = await this.gitFileSystemService.delete(
+        sessionData.siteName,
+        directoryName,
+        "",
+        sessionData.isomerUserId,
+        true
+      )
+
+      if (result.isErr()) {
+        throw result.error
+      }
+
+      this.gitFileSystemService.push(sessionData.siteName)
+      return
+    }
+
+    // GitHub flow
+    const gitTree = await this.getTree(sessionData, githubSessionData, {
+      isRecursive: true,
+    })
+
+    // Retrieve removed items and set their sha to null
+    const newGitTree = gitTree
+      .filter(
+        (item) =>
+          item.path.startsWith(`${directoryName}/`) && item.type !== "tree"
+      )
+      .map((item) => ({
+        ...item,
+        sha: null,
+      }))
+
+    const newCommitSha = this.updateTree(sessionData, githubSessionData, {
+      gitTree: newGitTree,
+      message,
+    })
+
+    return await this.updateRepoState(sessionData, {
+      commitSha: newCommitSha,
+    })
+  }
+
+  // deletes a file
   async delete(
-    sessionData: any,
-    { sha, fileName, directoryName }: any
-  ): Promise<any> {
+    sessionData: UserWithSiteSessionData,
+    {
+      sha,
+      fileName,
+      directoryName,
+    }: {
+      sha: string
+      fileName: string
+      directoryName: string
+    }
+  ): Promise<void> {
+    if (this.isRepoWhitelisted(sessionData.siteName)) {
+      logger.info(
+        `Deleting file in local Git file system for repo: ${sessionData.siteName}, directory name: ${directoryName}, file name: ${fileName}`
+      )
+
+      const filePath = directoryName ? `${directoryName}/${fileName}` : fileName
+
+      const result = await this.gitFileSystemService.delete(
+        sessionData.siteName,
+        filePath,
+        sha,
+        sessionData.isomerUserId,
+        false
+      )
+
+      if (result.isErr()) {
+        throw result.error
+      }
+
+      this.gitFileSystemService.push(sessionData.siteName)
+      return
+    }
+
+    // GitHub flow
     return await super.delete(sessionData, {
       sha,
       fileName,
@@ -359,7 +452,7 @@ export default class RepoService extends GitHubService {
     sessionData: any,
     githubSessionData: any,
     { isRecursive }: any
-  ): Promise<any> {
+  ): Promise<RawGitTreeEntry[]> {
     return await super.getTree(sessionData, githubSessionData, {
       isRecursive,
     })

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -1,4 +1,7 @@
+import { Stats } from "fs"
+
 import mockFs from "mock-fs"
+import { okAsync } from "neverthrow"
 import { GitError, SimpleGit } from "simple-git"
 
 import config from "@config/config"
@@ -1085,6 +1088,318 @@ describe("GitFileSystemService", () => {
         "master"
       )
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
+    })
+  })
+
+  describe("delete", () => {
+    it("should return a error if latest commit sha is not found", async () => {
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        log: jest.fn().mockResolvedValueOnce({
+          latest: {
+            author_name: "fake-author",
+            author_email: "fake-email",
+            date: "fake-date",
+            message: "fake-message",
+            hash: undefined,
+          },
+        }),
+      })
+
+      const actual = await GitFileSystemService.delete(
+        "fake-repo",
+        "fake-dir/fake-file",
+        "fake-old-hash",
+        "fake-user-id",
+        false
+      )
+      expect(actual._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
+    })
+
+    describe("deleteFile", () => {
+      it("should delete a file successfully", async () => {
+        // getLatestCommitOfBranch
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          log: jest.fn().mockResolvedValueOnce({
+            latest: {
+              author_name: "fake-author",
+              author_email: "fake-email",
+              date: "fake-date",
+              message: "fake-message",
+              hash: "test-commit-sha",
+            },
+          }),
+        })
+
+        // getGitBlobHash
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          revparse: jest.fn().mockResolvedValueOnce("fake-old-hash"),
+        })
+
+        // commit
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          checkIsRepo: jest.fn().mockResolvedValueOnce(true),
+        })
+
+        // commit
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          remote: jest
+            .fn()
+            .mockResolvedValueOnce(
+              `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
+            ),
+        })
+
+        // commit
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+        })
+
+        // commit
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          add: jest.fn().mockReturnValueOnce({
+            commit: jest
+              .fn()
+              .mockResolvedValueOnce({ commit: "fake-new-hash" }),
+          }),
+        })
+
+        const actual = await GitFileSystemService.delete(
+          "fake-repo",
+          "fake-dir/fake-file",
+          "fake-old-hash",
+          "fake-user-id",
+          false
+        )
+
+        expect(actual._unsafeUnwrap()).toEqual("fake-new-hash")
+      })
+
+      it("should return a error if the file is not valid", async () => {
+        // getLatestCommitOfBranch
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          log: jest.fn().mockResolvedValueOnce({
+            latest: {
+              author_name: "fake-author",
+              author_email: "fake-email",
+              date: "fake-date",
+              message: "fake-message",
+              hash: "test-commit-sha",
+            },
+          }),
+        })
+        const mockStats = new Stats()
+        const spyGetFilePathStats = jest
+          .spyOn(GitFileSystemService, "getFilePathStats")
+          .mockResolvedValueOnce(
+            okAsync({
+              ...mockStats,
+              isFile: () => false,
+              isDirectory: () => true,
+            })
+          )
+
+        const actual = await GitFileSystemService.delete(
+          "fake-repo",
+          "fake-dir",
+          "fake-old-hash",
+          "fake-user-id",
+          false
+        )
+        expect(spyGetFilePathStats).toBeCalledTimes(1)
+        expect(actual._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
+      })
+
+      it("should return a error if the file hash does not match", async () => {
+        // getLatestCommitOfBranch
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          log: jest.fn().mockResolvedValueOnce({
+            latest: {
+              author_name: "fake-author",
+              author_email: "fake-email",
+              date: "fake-date",
+              message: "fake-message",
+              hash: "wrong-sha",
+            },
+          }),
+        })
+
+        const mockStats = new Stats()
+        jest
+          .spyOn(GitFileSystemService, "getFilePathStats")
+          .mockResolvedValueOnce(
+            okAsync({
+              ...mockStats,
+              isFile: () => true,
+              isDirectory: () => false,
+            })
+          )
+
+        const spyGetGitBlobHash = jest
+          .spyOn(GitFileSystemService, "getGitBlobHash")
+          .mockReturnValueOnce(okAsync("correct-sha"))
+
+        const actual = await GitFileSystemService.delete(
+          "fake-repo",
+          "fake-dir",
+          "fake-old-hash",
+          "fake-user-id",
+          false
+        )
+        expect(spyGetGitBlobHash).toBeCalledTimes(1)
+        expect(actual._unsafeUnwrapErr()).toBeInstanceOf(ConflictError)
+      })
+    })
+
+    describe("deleteDirectory", () => {
+      it("should delete a directory successfully", async () => {
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          log: jest.fn().mockResolvedValueOnce({
+            latest: {
+              author_name: "fake-author",
+              author_email: "fake-email",
+              date: "fake-date",
+              message: "fake-message",
+              hash: "test-commit-sha",
+            },
+          }),
+        })
+
+        // commit
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          checkIsRepo: jest.fn().mockResolvedValueOnce(true),
+        })
+
+        // commit
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          remote: jest
+            .fn()
+            .mockResolvedValueOnce(
+              `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
+            ),
+        })
+
+        // commit
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+        })
+
+        // commit
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          add: jest.fn().mockReturnValueOnce({
+            commit: jest
+              .fn()
+              .mockResolvedValueOnce({ commit: "fake-new-hash" }),
+          }),
+        })
+
+        const actual = await GitFileSystemService.delete(
+          "fake-repo",
+          "fake-dir",
+          "",
+          "fake-user-id",
+          true
+        )
+        console.log(`ACTUAL`, actual)
+
+        expect(actual._unsafeUnwrap()).toEqual("fake-new-hash")
+      })
+
+      it("should return a error if the directory is not valid", async () => {
+        // getLatestCommitOfBranch
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          log: jest.fn().mockResolvedValueOnce({
+            latest: {
+              author_name: "fake-author",
+              author_email: "fake-email",
+              date: "fake-date",
+              message: "fake-message",
+              hash: "test-commit-sha",
+            },
+          }),
+        })
+        const mockStats = new Stats()
+        const spyGetFilePathStats = jest
+          .spyOn(GitFileSystemService, "getFilePathStats")
+          .mockResolvedValueOnce(
+            okAsync({
+              ...mockStats,
+              isFile: () => true,
+              isDirectory: () => false,
+            })
+          )
+
+        const actual = await GitFileSystemService.delete(
+          "fake-repo",
+          "fake-dir",
+          "",
+          "fake-user-id",
+          true
+        )
+        expect(spyGetFilePathStats).toBeCalledTimes(1)
+        expect(actual._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
+      })
+
+      it("should rollback changes if an error occurred when committing", async () => {
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          log: jest.fn().mockResolvedValueOnce({
+            latest: {
+              author_name: "fake-author",
+              author_email: "fake-email",
+              date: "fake-date",
+              message: "fake-message",
+              hash: "test-commit-sha",
+            },
+          }),
+        })
+        const mockStats = new Stats()
+        jest
+          .spyOn(GitFileSystemService, "getFilePathStats")
+          .mockResolvedValueOnce(
+            okAsync({
+              ...mockStats,
+              isFile: () => false,
+              isDirectory: () => true,
+            })
+          )
+
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          checkIsRepo: jest.fn().mockResolvedValueOnce(true),
+        })
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          remote: jest
+            .fn()
+            .mockResolvedValueOnce(
+              `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
+            ),
+        })
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          revparse: jest.fn().mockResolvedValueOnce(BRANCH_REF),
+        })
+
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          add: jest.fn().mockReturnValueOnce({
+            commit: jest.fn().mockRejectedValueOnce(new GitError()),
+          }),
+        })
+        MockSimpleGit.cwd.mockReturnValueOnce({
+          reset: jest.fn().mockReturnValueOnce({
+            clean: jest.fn().mockResolvedValueOnce(undefined),
+          }),
+        })
+
+        const spyRollback = jest.spyOn(GitFileSystemService, "rollback")
+
+        const actual = await GitFileSystemService.delete(
+          "fake-repo",
+          "fake-dir",
+          "fake new content",
+          "fake-user-id",
+          true
+        )
+
+        expect(actual._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
+        expect(spyRollback).toHaveBeenCalledWith("fake-repo", "test-commit-sha")
+      })
     })
   })
 })

--- a/src/services/directoryServices/BaseDirectoryService.js
+++ b/src/services/directoryServices/BaseDirectoryService.js
@@ -77,35 +77,10 @@ class BaseDirectoryService {
   }
 
   async delete(sessionData, githubSessionData, { directoryName, message }) {
-    const gitTree = await this.gitHubService.getTree(
-      sessionData,
+    await this.gitHubService.deleteDirectory(sessionData, {
+      directoryName,
+      message,
       githubSessionData,
-      {
-        isRecursive: true,
-      }
-    )
-
-    // Retrieve removed items and set their sha to null
-    const newGitTree = gitTree
-      .filter(
-        (item) =>
-          item.path.startsWith(`${directoryName}/`) && item.type !== "tree"
-      )
-      .map((item) => ({
-        ...item,
-        sha: null,
-      }))
-
-    const newCommitSha = await this.gitHubService.updateTree(
-      sessionData,
-      githubSessionData,
-      {
-        gitTree: newGitTree,
-        message,
-      }
-    )
-    await this.gitHubService.updateRepoState(sessionData, {
-      commitSha: newCommitSha,
     })
   }
 

--- a/src/services/directoryServices/__tests__/BaseDirectoryService.spec.js
+++ b/src/services/directoryServices/__tests__/BaseDirectoryService.spec.js
@@ -62,6 +62,7 @@ describe("Base Directory Service", () => {
     getTree: jest.fn(),
     updateTree: jest.fn(),
     updateRepoState: jest.fn(),
+    deleteDirectory: jest.fn(),
   }
 
   const {
@@ -229,25 +230,12 @@ describe("Base Directory Service", () => {
           message,
         })
       ).resolves.not.toThrow()
-      expect(mockGithubService.getTree).toHaveBeenCalledWith(
+      expect(mockGithubService.deleteDirectory).toHaveBeenCalledWith(
         sessionData,
-        mockGithubSessionData,
         {
-          isRecursive: true,
-        }
-      )
-      expect(mockGithubService.updateTree).toHaveBeenCalledWith(
-        sessionData,
-        mockGithubSessionData,
-        {
-          gitTree: mockedDeletedTree,
+          directoryName,
           message,
-        }
-      )
-      expect(mockGithubService.updateRepoState).toHaveBeenCalledWith(
-        sessionData,
-        {
-          commitSha: sha,
+          githubSessionData: mockGithubSessionData,
         }
       )
     })

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -92,3 +92,12 @@ export interface RawComment {
   body: string
   created_at: string
 }
+
+export type RawGitTreeEntry = {
+  path: string
+  mode: string
+  type: "tree" | "file"
+  sha: string
+  url: string
+  size?: number // only exists if it is a file
+}


### PR DESCRIPTION
## Problem

This PR introduces rollback functionality for whitelisted ggs repos. Currently, this is being done by the `attachRollbackRouteHandler` wrapper by taking Github as the source of truth before and reverting to the latest commit at the beginning of the failed transaction - this PR extends that method for whitelisted repos to instead take the latest commit of the EFS, and revert the local copy of the repo stored on EFS before force pushing that to github.

It also introduces an optional `force` param to the `push` method in `GitFileSystemService`, in order to support reverting the remote repo to the rolled back state on the EFS.

## Tests

For local testing only

- [ ] Ensure the whitelisted target git repo on your local file system is identical to remote
- [ ] Make the create method return an error (e.g. `return errAsync(new GitFileSystemError("test create error"))`)
- [ ] Attempt to create a collection page (Operation involves an `update` step, which should succeed, then a `create` step, which should fail)
- [ ] Check the local git file system - should be up to date with remote
- [ ] Check the github repo - no new commits should have appeared