### PR TITLE
Fix/ggs create images

### DIFF
--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -444,7 +444,8 @@ export default class GitFileSystemService {
     userId: string,
     content: string,
     directoryName: string,
-    fileName: string
+    fileName: string,
+    encoding: "utf-8" | "base64" = "utf-8"
   ): ResultAsync<
     GitCommitResult,
     ConflictError | GitFileSystemError | NotFoundError
@@ -502,7 +503,7 @@ export default class GitFileSystemService {
       })
       .andThen(() =>
         ResultAsync.fromPromise(
-          fs.promises.writeFile(pathToEfsFile, encodedContent),
+          fs.promises.writeFile(pathToEfsFile, encodedContent, encoding),
           (error) => {
             logger.error(`Error when creating ${filePath}: ${error}`)
             if (error instanceof Error) {

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -12,9 +12,9 @@ import type {
   GitDirectoryItem,
   GitFile,
 } from "@root/types/gitfilesystem"
+import { RawGitTreeEntry } from "@root/types/github"
 import { MediaDirOutput, MediaFileOutput, MediaType } from "@root/types/media"
 import { getMediaFileInfo } from "@root/utils/media-utils"
-import { RawGitTreeEntry } from "@root/types/github"
 
 import GitFileSystemService from "./GitFileSystemService"
 import { GitHubService } from "./GitHubService"
@@ -139,7 +139,8 @@ export default class RepoService extends GitHubService {
         sessionData.isomerUserId,
         content,
         directoryName,
-        fileName
+        fileName,
+        isMedia ? "base64" : "utf-8"
       )
 
       if (result.isErr()) {

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -815,7 +815,7 @@ describe("GitFileSystemService", () => {
   })
 
   describe("create", () => {
-    it("should create a file successfully", async () => {
+    it("should create a non-media file successfully", async () => {
       const expectedSha = "fake-hash"
 
       MockSimpleGit.cwd.mockReturnValueOnce({
@@ -859,7 +859,59 @@ describe("GitFileSystemService", () => {
         "fake-user-id",
         "fake content",
         "fake-dir",
-        "create-file"
+        "create-file",
+        "utf-8"
+      )
+
+      expect(actual._unsafeUnwrap()).toEqual(expected)
+    })
+
+    it("should create a media file successfully", async () => {
+      const expectedSha = "fake-hash"
+
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        log: jest.fn().mockResolvedValueOnce({
+          latest: {
+            author_name: "fake-author",
+            author_email: "fake-email",
+            date: "fake-date",
+            message: "fake-message",
+            hash: "test-commit-sha",
+          },
+        }),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        checkIsRepo: jest.fn().mockResolvedValueOnce(true),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        remote: jest
+          .fn()
+          .mockResolvedValueOnce(
+            `git@github.com:${ISOMER_GITHUB_ORG_NAME}/fake-repo.git`
+          ),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("fake-hash"),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        checkout: jest.fn().mockResolvedValueOnce(undefined),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        add: jest.fn().mockReturnValueOnce({
+          commit: jest.fn().mockResolvedValueOnce({ commit: expectedSha }),
+        }),
+      })
+
+      const expected = {
+        newSha: expectedSha,
+      }
+      const actual = await GitFileSystemService.create(
+        "fake-repo",
+        "fake-user-id",
+        "fake content",
+        "fake-dir",
+        "create-media-file",
+        "base64"
       )
 
       expect(actual._unsafeUnwrap()).toEqual(expected)
@@ -908,7 +960,8 @@ describe("GitFileSystemService", () => {
         "fake-user-id",
         "fake content",
         "fake-create-dir",
-        "create-file"
+        "create-file",
+        "utf-8"
       )
 
       expect(actual._unsafeUnwrap()).toEqual(expected)
@@ -931,7 +984,8 @@ describe("GitFileSystemService", () => {
         "fake-user-id",
         "fake content",
         "fake-dir",
-        "fake-file"
+        "fake-file",
+        "utf-8"
       )
 
       expect(actual._unsafeUnwrapErr()).toBeInstanceOf(ConflictError)
@@ -982,7 +1036,8 @@ describe("GitFileSystemService", () => {
         "fake-user-id",
         "fake content",
         "fake-dir",
-        "create-file-rollback"
+        "create-file-rollback",
+        "utf-8"
       )
 
       expect(actual._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -65,8 +65,11 @@ describe("RepoService", () => {
   })
 
   describe("create", () => {
-    it("should create using the local Git file system if the repo is whitelisted", async () => {
+    it("should create using the local Git file system using utf-8 for non-media files if the repo is whitelisted", async () => {
       const returnedSha = "test-sha"
+      const mockContent = "content"
+      const mockFileName = "test.md"
+      const mockDirectoryName = ""
       const createOutput = {
         newSha: returnedSha,
       }
@@ -78,17 +81,61 @@ describe("RepoService", () => {
       )
 
       const actual = await RepoService.create(mockUserWithSiteSessionData, {
-        content: "content",
-        fileName: "test.md",
-        directoryName: "",
+        content: mockContent,
+        fileName: mockFileName,
+        directoryName: mockDirectoryName,
         isMedia: false,
       })
 
       expect(actual).toEqual(expected)
-      expect(MockGitFileSystemService.create).toHaveBeenCalled()
+      expect(MockGitFileSystemService.create).toHaveBeenCalledWith(
+        mockUserWithSiteSessionData.siteName,
+        mockUserWithSiteSessionData.isomerUserId,
+        mockContent,
+        mockDirectoryName,
+        mockFileName,
+        "utf-8"
+      )
+    })
+
+    it("should create using the local Git file system using base64 for media files if the repo is whitelisted", async () => {
+      const returnedSha = "test-sha"
+      const mockContent = "content"
+      const mockFileName = "test.md"
+      const mockDirectoryName = ""
+      const createOutput = {
+        newSha: returnedSha,
+      }
+      const expected = {
+        sha: returnedSha,
+      }
+      MockGitFileSystemService.create.mockResolvedValueOnce(
+        okAsync(createOutput)
+      )
+
+      const actual = await RepoService.create(mockUserWithSiteSessionData, {
+        content: mockContent,
+        fileName: mockFileName,
+        directoryName: mockDirectoryName,
+        isMedia: true,
+      })
+
+      expect(actual).toEqual(expected)
+      expect(MockGitFileSystemService.create).toHaveBeenCalledWith(
+        mockUserWithSiteSessionData.siteName,
+        mockUserWithSiteSessionData.isomerUserId,
+        mockContent,
+        mockDirectoryName,
+        mockFileName,
+        "base64"
+      )
     })
 
     it("should create files on GitHub directly if the repo is not whitelisted", async () => {
+      const mockContent = "content"
+      const mockFileName = "test.md"
+      const mockDirectoryName = ""
+      const isMedia = false
       const sessionData = new UserWithSiteSessionData({
         githubId: mockGithubId,
         accessToken: mockAccessToken,
@@ -106,11 +153,16 @@ describe("RepoService", () => {
         content: "content",
         fileName: "test.md",
         directoryName: "",
-        isMedia: false,
+        isMedia,
       })
 
       expect(actual).toEqual(expected)
-      expect(gitHubServiceCreate).toHaveBeenCalled()
+      expect(gitHubServiceCreate).toHaveBeenCalledWith(sessionData, {
+        content: mockContent,
+        fileName: mockFileName,
+        directoryName: mockDirectoryName,
+        isMedia,
+      })
     })
   })
 


### PR DESCRIPTION
## Problem

This PR introduces a fix for image creation functionality for ggs, which was previous not working due to incorrect encoding. The `create` method in `GitFileSystemService` has been extended to take an `encoding` as an argument, which allows the correct specification of `base64` to be used for media files.