### PR TITLE
fix(GGs): hotfixes from bugs identified during testing

### DIFF
--- a/src/middleware/routeHandler.js
+++ b/src/middleware/routeHandler.js
@@ -36,12 +36,21 @@ const attachWriteRouteHandlerWrapper = (routeHandler) => async (
   next
 ) => {
   const { siteName } = req.params
-  await lock(siteName)
+  try {
+    await lock(siteName)
+  } catch (err) {
+    next(err)
+  }
+
   routeHandler(req, res, next).catch(async (err) => {
     await unlock(siteName)
     next(err)
   })
-  await unlock(siteName)
+  try {
+    await unlock(siteName)
+  } catch (err) {
+    next(err)
+  }
 }
 
 const gitFileSystemService = new GitFileSystemService(new SimpleGit())
@@ -59,7 +68,11 @@ const attachRollbackRouteHandlerWrapper = (routeHandler) => async (
     siteName
   )
 
-  await lock(siteName)
+  try {
+    await lock(siteName)
+  } catch (err) {
+    next(err)
+  }
 
   let originalCommitSha
   if (isRepoWhitelisted) {
@@ -129,7 +142,11 @@ const attachRollbackRouteHandlerWrapper = (routeHandler) => async (
     next(err)
   })
 
-  await unlock(siteName)
+  try {
+    await unlock(siteName)
+  } catch (err) {
+    next(err)
+  }
 }
 
 module.exports = {

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -53,8 +53,8 @@ export default class GitFileSystemService {
   isDefaultLogFields(logFields: unknown): logFields is DefaultLogFields {
     const c = logFields as DefaultLogFields
     return (
-      !!c &&
-      typeof c === "object" &&
+      !!logFields &&
+      typeof logFields === "object" &&
       typeof c.author_name === "string" &&
       typeof c.author_email === "string" &&
       typeof c.date === "string" &&
@@ -562,7 +562,7 @@ export default class GitFileSystemService {
               )
               return new GitFileSystemError("An unknown error occurred")
             }
-          ).map((_) => true)
+          ).map(() => true)
         }
         return err(error)
       })

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -53,8 +53,8 @@ export default class GitFileSystemService {
   isDefaultLogFields(logFields: unknown): logFields is DefaultLogFields {
     const c = logFields as DefaultLogFields
     return (
-      !!logFields &&
-      typeof logFields === "object" &&
+      !!c &&
+      typeof c === "object" &&
       typeof c.author_name === "string" &&
       typeof c.author_email === "string" &&
       typeof c.date === "string" &&

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -396,7 +396,7 @@ export default class RepoService extends GitHubService {
         sha: null,
       }))
 
-    const newCommitSha = this.updateTree(sessionData, githubSessionData, {
+    const newCommitSha = await this.updateTree(sessionData, githubSessionData, {
       gitTree: newGitTree,
       message,
     })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The GGs MVP solution is imperfect.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The `getLatestCommitOfBranch` function was only successful in getting the Git logs for branches that also exist locally. This has now been adjusted to retry with an `origin/` prefix if it failed the first time, so that it gets the latest hash of the origin remote.
    - Note: The reason why we do not just default to using `origin/` prefix is because there might be some local changes that have not been pushed to GitHub yet for the staging branch. The `origin/staging` remote would be stale during the period of time where the local commits have not yet been pushed to GitHub. Hence, first using the local branch ensures that we always return the latest commit information.
- The `git mv` function is too strict and causes concurrency issues with Git. This has now been adjusted to only do `git mv` when we are only renaming a single path.
    - Note: The `git mv` was originally introduced to handle case-sensitive renames. This works, but when moving multiple files, due to concurrency issues within Git, it would result in an error. Since moving multiple files do not have the issue of case-sensitive renames, we can just stick to using the local filesystem rename.
    - The commit function has also been adjusted to allow skipping the step of adding the old and new paths to Git. This step is skipped if `git mv` is used, as adding the old path would throw an error, since it has already been added by Git.
    - We do not support moving multiple pages/files at the same time. The `moveFiles` method is only used when we create a new folder and let the user move multiple pages/files to this new folder in a single step. So in that sense, there is a guarantee that the new folder is empty and will not bring about any conflicts due to casing. Thus, a filesystem move is sufficient.
- Pushing now retries once if it failed the first time.
    - This is not 100% ideal, but it catches the majority of issues with git push and allows the upstream GitHub repository to always get the latest commits. This is important so that Netlify/Amplify can begin building those repositories with the latest changes as soon as possible, rather than wait for another update operation to happen and cause certain commits to not be built.
- Updating the tree for non-whitelisted repos now `await` correctly for the new commit SHA before updating the repo state
    - This was causing the GitHub API to throw an error with status code 422, along with the message `Invalid request.\n\nFor 'properties/sha', {} is not a string.`. This also prevented the deletion of directories from working correctly.

## Tests

<!-- What tests should be run to confirm functionality? -->

1. Unit tests
2. e2e tests

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*