### PR TITLE
fix: require base64

### DIFF
--- a/src/classes/Collection.js
+++ b/src/classes/Collection.js
@@ -3,6 +3,8 @@ const {
   sanitizedYamlStringify,
 } = require("@utils/yaml-utils")
 
+const { Base64 } = require("js-base64")
+
 require("bluebird")
 require("lodash")
 const {

--- a/src/classes/Config.js
+++ b/src/classes/Config.js
@@ -1,5 +1,6 @@
 import { config } from "@config/config"
 
+const { Base64 } = require("js-base64")
 const _ = require("lodash")
 
 const {

--- a/src/classes/Resource.js
+++ b/src/classes/Resource.js
@@ -1,4 +1,5 @@
 const Bluebird = require("bluebird")
+const { Base64 } = require("js-base64")
 const _ = require("lodash")
 
 // Import classes

--- a/src/classes/ResourceRoom.js
+++ b/src/classes/ResourceRoom.js
@@ -21,6 +21,8 @@ const {
 const RESOURCE_ROOM_INDEX_PATH = "index.html"
 const NAV_FILE_NAME = "navigation.yml"
 
+const { Base64 } = require("js-base64")
+
 class ResourceRoom {
   constructor(accessToken, siteName) {
     this.accessToken = accessToken

--- a/src/routes/v1/authenticatedSites/collectionPages.js
+++ b/src/routes/v1/authenticatedSites/collectionPages.js
@@ -4,6 +4,7 @@ import { statsMiddleware } from "@root/middleware/stats"
 
 const Bluebird = require("bluebird")
 const express = require("express")
+const { Base64 } = require("js-base64")
 const _ = require("lodash")
 
 // Import errors

--- a/src/routes/v1/authenticatedSites/collections.js
+++ b/src/routes/v1/authenticatedSites/collections.js
@@ -3,6 +3,7 @@ import { Versions } from "@constants"
 import { statsMiddleware } from "@root/middleware/stats"
 
 const express = require("express")
+const { Base64 } = require("js-base64")
 
 // Import middleware
 const {

--- a/src/routes/v1/authenticatedSites/folders.js
+++ b/src/routes/v1/authenticatedSites/folders.js
@@ -4,6 +4,7 @@ import { statsMiddleware } from "@root/middleware/stats"
 
 const Bluebird = require("bluebird")
 const express = require("express")
+const { Base64 } = require("js-base64")
 
 const {
   attachReadRouteHandlerWrapper,

--- a/src/routes/v1/authenticatedSites/homepage.js
+++ b/src/routes/v1/authenticatedSites/homepage.js
@@ -3,6 +3,7 @@ import { Versions } from "@constants"
 import { statsMiddleware } from "@root/middleware/stats"
 
 const express = require("express")
+const { Base64 } = require("js-base64")
 
 const router = express.Router({ mergeParams: true })
 

--- a/src/routes/v1/authenticatedSites/navigation.js
+++ b/src/routes/v1/authenticatedSites/navigation.js
@@ -3,6 +3,7 @@ import { Versions } from "@constants"
 import { statsMiddleware } from "@root/middleware/stats"
 
 const express = require("express")
+const { Base64 } = require("js-base64")
 
 const {
   sanitizedYamlParse,

--- a/src/routes/v1/authenticatedSites/netlifyToml.js
+++ b/src/routes/v1/authenticatedSites/netlifyToml.js
@@ -3,6 +3,7 @@ import { Versions } from "@constants"
 import { statsMiddleware } from "@root/middleware/stats"
 
 const express = require("express")
+const { Base64 } = require("js-base64")
 const toml = require("toml")
 
 // Import middleware

--- a/src/routes/v1/authenticatedSites/pages.js
+++ b/src/routes/v1/authenticatedSites/pages.js
@@ -1,6 +1,7 @@
 import { Versions } from "@constants"
 
 const express = require("express")
+const { Base64 } = require("js-base64")
 
 // Import middleware
 const {

--- a/src/routes/v1/authenticatedSites/resourcePages.js
+++ b/src/routes/v1/authenticatedSites/resourcePages.js
@@ -3,6 +3,7 @@ import { Versions } from "@constants"
 import { statsMiddleware } from "@root/middleware/stats"
 
 const express = require("express")
+const { Base64 } = require("js-base64")
 
 const router = express.Router({ mergeParams: true })
 


### PR DESCRIPTION
This PR fixes an issue introduced by the upgrade of `base64-js`, which previously worked without an explicit import. The affected endpoints are all v1 endpoints, but several api calls on the frontend still use v1 endpoints. We should modify the endpoints being used on the frontend to use v2 endpoints instead, but I've opted for this solution first, since at least 2 of the remaining endpoints do not work with a direct swap (edit nav uses a v1 endpoint that has no equivalent functionality in v2, and edit page uses an outdated v1 endpoint that the v2 endpoint changes the dto of).