### PR TITLE
Fix/git file lock

### DIFF
--- a/src/middleware/routeHandler.js
+++ b/src/middleware/routeHandler.js
@@ -8,8 +8,10 @@ const { default: GithubSessionData } = require("@classes/GithubSessionData")
 const { lock, unlock } = require("@utils/mutex-utils")
 const { getCommitAndTreeSha, revertCommit } = require("@utils/utils.js")
 
-const { ConflictError } = require("@root/errors/ConflictError")
-const GitFileSystemError = require("@root/errors/GitFileSystemError")
+const GitFileSystemError = require("@root/errors/GitFileSystemError").default
+
+const LockedError = require("@root/errors/LockedError").default
+
 const {
   default: GitFileSystemService,
 } = require("@services/db/GitFileSystemService")
@@ -37,7 +39,7 @@ const handleGitFileLock = async (repoName, next) => {
   if (isGitLocked) {
     logger.error(`Failed to lock repo ${repoName}: git file system in use`)
     next(
-      new ConflictError(
+      new LockedError(
         `Someone else is currently modifying repo ${repoName}. Please try again later.`
       )
     )

--- a/src/middleware/routeHandler.js
+++ b/src/middleware/routeHandler.js
@@ -9,9 +9,7 @@ const { lock, unlock } = require("@utils/mutex-utils")
 const { getCommitAndTreeSha, revertCommit } = require("@utils/utils.js")
 
 const GitFileSystemError = require("@root/errors/GitFileSystemError").default
-
 const LockedError = require("@root/errors/LockedError").default
-
 const {
   default: GitFileSystemService,
 } = require("@services/db/GitFileSystemService")
@@ -37,7 +35,7 @@ const handleGitFileLock = async (repoName, next) => {
   }
   const isGitLocked = result.value
   if (isGitLocked) {
-    logger.error(`Failed to lock repo ${repoName}: git file system in use`)
+    logger.error(`Failed to lock repo ${repoName}: git file system in use.`)
     next(
       new LockedError(
         `Someone else is currently modifying repo ${repoName}. Please try again later.`

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -50,6 +50,21 @@ export default class GitFileSystemService {
     this.git = git
   }
 
+  hasGitFileLock(repoName: string): ResultAsync<boolean, GitFileSystemError> {
+    const gitFileLockPath = ".git/index.lock"
+    return this.getFilePathStats(repoName, gitFileLockPath)
+      .andThen((stats) => ok(stats.isFile()))
+      .orElse((error) => {
+        if (error instanceof NotFoundError) {
+          return ok(false)
+        }
+        logger.error(
+          `Error when checking for git file lock for ${repoName}: ${error}`
+        )
+        return err(error)
+      })
+  }
+
   isDefaultLogFields(logFields: unknown): logFields is DefaultLogFields {
     const c = logFields as DefaultLogFields
     return (

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -53,7 +53,7 @@ export default class GitFileSystemService {
   hasGitFileLock(repoName: string): ResultAsync<boolean, GitFileSystemError> {
     const gitFileLockPath = ".git/index.lock"
     return this.getFilePathStats(repoName, gitFileLockPath)
-      .andThen((stats) => ok(stats.isFile()))
+      .andThen(() => ok(true))
       .orElse((error) => {
         if (error instanceof NotFoundError) {
           return ok(false)


### PR DESCRIPTION
## Problem

This PR resolves issues we currently have with concurrent edits on the same file. As not all git operations are awaited before returning (git push is done async), it becomes possible for a git repo to still be locked when a new user attempts to make a change. However, our existing route handlers only look at the status of our mutex lock, which does not take this into consideration. This PR adds an additional method `hasGitFileLock` to `GitFileSystemService`, and extends our existing write and rollback handlers to check for the existence of the git file lock before proceeding.

This PR has been tested on staging.

To test on local dev:

- [ ] On a whitelisted repo, from the root of the repo, create a `.git/index.lock` file
- [ ] Attempt to perform any operation that modifies the git state of that repo on the cms
- [ ] You should receive a 423 on the frontend, reflected as an error toast `Your page could not be updated. Someone else is currently modifying repo a-test-v4. Please try again later.`

Resolves IS-434.