### PR TITLE
feat: Log 5xx errors for sms client

### DIFF
--- a/src/services/identity/SmsClient.ts
+++ b/src/services/identity/SmsClient.ts
@@ -37,6 +37,7 @@ class SmsClient {
       await this.axiosClient.post(endpoint, sms)
     } catch (err) {
       if (isAxiosError(err) && err.code === "500") {
+        // NOTE: Do not change the copy of this string below as it is used for alarms
         logger.error(`Postman is returning 500 error for sending sms: ${err}`)
       }
       logger.error(`Failed to send SMS to ${recipient}: ${err}`)

--- a/src/services/identity/SmsClient.ts
+++ b/src/services/identity/SmsClient.ts
@@ -5,6 +5,7 @@ import { config } from "@config/config"
 import logger from "@logger/logger"
 
 import { AxiosClient } from "@root/types"
+import { isAxiosError } from "@root/utils/axios-utils"
 
 const POSTMAN_SMS_CRED_NAME = config.get("postman.smsCredName")
 
@@ -35,6 +36,9 @@ class SmsClient {
     try {
       await this.axiosClient.post(endpoint, sms)
     } catch (err) {
+      if (isAxiosError(err) && err.code === "500") {
+        logger.error(`Postman is returning 500 error for sending sms: ${err}`)
+      }
       logger.error(`Failed to send SMS to ${recipient}: ${err}`)
       throw new Error("Failed to send SMS.")
     }


### PR DESCRIPTION
## Problem

Currently we are oblivious when Twilo goes down. 

## Solution

This logs a specific string which we can later use to to trigger alarm. We **_only_** log for 5xx errors since we dont want to trigger alarms for say invalid numbers. 

However, since this is infra level stuff, this is a bit hard to test + cannot guarentee that there wont be any false positives. To monitor post deploy if this solution is ok. 


**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible


## Deploy Notes

Post release we would need to create a custom metric for our backend.std.out errors to match for `Postman is returning 500 error for sending sms` + create a corresponding alarm for that metric. 

