### PR TITLE
feat(integration): reviews inte test

### DIFF
--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -719,6 +719,23 @@ describe("Review Requests Integration Tests", () => {
       // Assert
       expect(actual.statusCode).toEqual(404)
     })
+
+    it("should not throw an error if two seb-sequent calls are being made", async () => {
+      const app = generateRouterForUserWithSite(
+        subrouter,
+        MOCK_USER_SESSION_DATA_TWO,
+        MOCK_REPO_NAME_ONE
+      )
+
+      // Act
+      const promises = await Promise.all([
+        request(app).post(`/${MOCK_REPO_NAME_ONE}/viewed`),
+        request(app).post(`/${MOCK_REPO_NAME_ONE}/viewed`),
+      ])
+      // Assert
+      expect(promises[0].statusCode).toEqual(200)
+      expect(promises[1].statusCode).toEqual(200)
+    })
   })
 
   describe("/:requestId GET", () => {

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -720,7 +720,7 @@ describe("Review Requests Integration Tests", () => {
       expect(actual.statusCode).toEqual(404)
     })
 
-    it("should not throw an error if two seb-sequent calls are being made", async () => {
+    it("should not throw an error if two sub-sequent calls are being made", async () => {
       const app = generateRouterForUserWithSite(
         subrouter,
         MOCK_USER_SESSION_DATA_TWO,


### PR DESCRIPTION
## Problem

When the PR #867 was introduced, the test case was mocked so there was no proof of functionality (at the unit test level) + no test cases to actually prevent regression. 


## Solution

Add integration test for this.


## Before & After Screenshots

**BEFORE**:

NOTE: This is run on a codebase where the changes introduced in #867 was _**reverted**_. 
![Screenshot 2023-08-18 at 1 14 45 PM](https://github.com/isomerpages/isomercms-backend/assets/42832651/49ee2c68-2edd-4cc3-b5cb-c71c90c73633)


**AFTER**:

![Screenshot 2023-08-18 at 1 15 20 PM](https://github.com/isomerpages/isomercms-backend/assets/42832651/ef6fe1c1-0779-447a-a072-8c97f8d28ee1)


## Tests

integration tests

