### PR TITLE
Fix/mutex lock

### DIFF
--- a/src/errors/LockedError.ts
+++ b/src/errors/LockedError.ts
@@ -1,0 +1,11 @@
+import { BaseIsomerError } from "./BaseError"
+
+export default class LockedError extends BaseIsomerError {
+  constructor(message: string) {
+    super({
+      status: 423,
+      code: "LockedError",
+      message,
+    })
+  }
+}

--- a/src/middleware/routeHandler.js
+++ b/src/middleware/routeHandler.js
@@ -8,15 +8,43 @@ const { default: GithubSessionData } = require("@classes/GithubSessionData")
 const { lock, unlock } = require("@utils/mutex-utils")
 const { getCommitAndTreeSha, revertCommit } = require("@utils/utils.js")
 
-const GitFileSystemError = require("@root/errors/GitFileSystemError")
+const GitFileSystemError = require("@root/errors/GitFileSystemError").default
+const LockedError = require("@root/errors/LockedError").default
 const {
   default: GitFileSystemService,
 } = require("@services/db/GitFileSystemService")
+
+const logger = require("@logger/logger").default
 
 const WHITELISTED_GIT_SERVICE_REPOS = config.get(
   "featureFlags.ggsWhitelistedRepos"
 )
 const BRANCH_REF = config.get("github.branchRef")
+
+const gitFileSystemService = new GitFileSystemService(new SimpleGit())
+
+const isRepoWhitelisted = (siteName) =>
+  WHITELISTED_GIT_SERVICE_REPOS.split(",").includes(siteName)
+
+const handleGitFileLock = async (repoName, next) => {
+  if (!isRepoWhitelisted(repoName)) return true
+  const result = await gitFileSystemService.hasGitFileLock(repoName)
+  if (result.isErr()) {
+    next(result.err)
+    return false
+  }
+  const isGitLocked = result.value
+  if (isGitLocked) {
+    logger.error(`Failed to lock repo ${repoName}: git file system in use.`)
+    next(
+      new LockedError(
+        `Someone else is currently modifying repo ${repoName}. Please try again later.`
+      )
+    )
+    return false
+  }
+  return true
+}
 
 // Used when there are no write API calls to the repo on GitHub
 const attachReadRouteHandlerWrapper = (routeHandler) => async (
@@ -36,6 +64,9 @@ const attachWriteRouteHandlerWrapper = (routeHandler) => async (
   next
 ) => {
   const { siteName } = req.params
+
+  const isGitAvailable = await handleGitFileLock(siteName, next)
+  if (!isGitAvailable) return
   try {
     await lock(siteName)
   } catch (err) {
@@ -54,8 +85,6 @@ const attachWriteRouteHandlerWrapper = (routeHandler) => async (
   }
 }
 
-const gitFileSystemService = new GitFileSystemService(new SimpleGit())
-
 const attachRollbackRouteHandlerWrapper = (routeHandler) => async (
   req,
   res,
@@ -65,10 +94,10 @@ const attachRollbackRouteHandlerWrapper = (routeHandler) => async (
   const { siteName } = req.params
 
   const { accessToken } = userSessionData
-  const isRepoWhitelisted = WHITELISTED_GIT_SERVICE_REPOS.split(",").includes(
-    siteName
-  )
+  const shouldUseGitFileSystem = isRepoWhitelisted(siteName)
 
+  const isGitAvailable = await handleGitFileLock(siteName, next)
+  if (!isGitAvailable) return
   try {
     await lock(siteName)
   } catch (err) {
@@ -77,7 +106,7 @@ const attachRollbackRouteHandlerWrapper = (routeHandler) => async (
   }
 
   let originalCommitSha
-  if (isRepoWhitelisted) {
+  if (shouldUseGitFileSystem) {
     const result = await gitFileSystemService.getLatestCommitOfBranch(
       siteName,
       BRANCH_REF
@@ -120,7 +149,7 @@ const attachRollbackRouteHandlerWrapper = (routeHandler) => async (
   }
   await routeHandler(req, res, next).catch(async (err) => {
     try {
-      if (isRepoWhitelisted) {
+      if (shouldUseGitFileSystem) {
         await backOff(() => {
           const rollbackRes = gitFileSystemService
             .rollback(siteName, originalCommitSha)

--- a/src/middleware/routeHandler.js
+++ b/src/middleware/routeHandler.js
@@ -42,7 +42,7 @@ const attachWriteRouteHandlerWrapper = (routeHandler) => async (
     next(err)
   }
 
-  routeHandler(req, res, next).catch(async (err) => {
+  await routeHandler(req, res, next).catch(async (err) => {
     await unlock(siteName)
     next(err)
   })
@@ -114,7 +114,7 @@ const attachRollbackRouteHandlerWrapper = (routeHandler) => async (
       next(err)
     }
   }
-  routeHandler(req, res, next).catch(async (err) => {
+  await routeHandler(req, res, next).catch(async (err) => {
     try {
       if (isRepoWhitelisted) {
         await backOff(() => {

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -50,6 +50,21 @@ export default class GitFileSystemService {
     this.git = git
   }
 
+  hasGitFileLock(repoName: string): ResultAsync<boolean, GitFileSystemError> {
+    const gitFileLockPath = ".git/index.lock"
+    return this.getFilePathStats(repoName, gitFileLockPath)
+      .andThen(() => ok(true))
+      .orElse((error) => {
+        if (error instanceof NotFoundError) {
+          return ok(false)
+        }
+        logger.error(
+          `Error when checking for git file lock for ${repoName}: ${error}`
+        )
+        return err(error)
+      })
+  }
+
   isDefaultLogFields(logFields: unknown): logFields is DefaultLogFields {
     const c = logFields as DefaultLogFields
     return (

--- a/src/utils/mutex-utils.js
+++ b/src/utils/mutex-utils.js
@@ -5,7 +5,7 @@ const { config } = require("@config/config")
 
 const logger = require("@logger/logger").default
 
-const { ConflictError } = require("@errors/ConflictError")
+const LockedError = require("@root/errors/LockedError")
 
 // Env vars
 const NODE_ENV = config.get("env")
@@ -52,7 +52,7 @@ const lock = async (siteName) => {
     logger.error(
       `Failed to lock repo ${siteName}: ${JSON.stringify(serializeError(err))}`
     )
-    throw new ConflictError(
+    throw new LockedError(
       `Someone else is currently modifying repo ${siteName}. Please try again later.`
     )
   }

--- a/src/utils/mutex-utils.js
+++ b/src/utils/mutex-utils.js
@@ -5,7 +5,7 @@ const { config } = require("@config/config")
 
 const logger = require("@logger/logger").default
 
-const LockedError = require("@root/errors/LockedError")
+const LockedError = require("@root/errors/LockedError").default
 
 // Env vars
 const NODE_ENV = config.get("env")


### PR DESCRIPTION
## Problem
This PR fixes issues with our existing mutex lock. It has been tested on both local dev and staging.

Currently, our route handler behaviour seems to suffer from 2 issues that make our mutex locks not work as intended:

- The wrapped route is not awaited, resulting in the existing behaviour where the mutex locks and unlocks while the method is still executing
- Express' `next` does not cut off the remainder of the method, and must be cut off explicitly - in our existing implementation, even if the mutex lock is hit, the actual route still continues to execute

This PR modifies the behaviour of both our write and rollback wrappers to handle this scenario.

In addition, the returned error has been modified from `409` to `423` (Locked) - this is to better reflect the reason for rejecting the request, and also results in a regular error toast on the frontend instead of the special conflict modal that would normally show up for modification of outdated files.

Resolves IS-478
