### PR TITLE
chore: remove test for concurrent viewed call

### DIFF
--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -719,23 +719,6 @@ describe("Review Requests Integration Tests", () => {
       // Assert
       expect(actual.statusCode).toEqual(404)
     })
-
-    it("should not throw an error if two sub-sequent calls are being made", async () => {
-      const app = generateRouterForUserWithSite(
-        subrouter,
-        MOCK_USER_SESSION_DATA_TWO,
-        MOCK_REPO_NAME_ONE
-      )
-
-      // Act
-      const promises = await Promise.all([
-        request(app).post(`/${MOCK_REPO_NAME_ONE}/viewed`),
-        request(app).post(`/${MOCK_REPO_NAME_ONE}/viewed`),
-      ])
-      // Assert
-      expect(promises[0].statusCode).toEqual(200)
-      expect(promises[1].statusCode).toEqual(200)
-    })
   })
 
   describe("/:requestId GET", () => {


### PR DESCRIPTION
Reverts https://github.com/isomerpages/isomercms-backend/pull/909 - now that our mutex lock works, the test throws a 423 error instead, and we're unable to replicate the conditions which we were testing on production anymore (prod instead returns 423 for 2 update calls in quick succession)