### PR TITLE
IS-506: Migrate GGS Whitelist Feature Flag to GB

### DIFF
--- a/src/classes/UserWithSiteSessionData.ts
+++ b/src/classes/UserWithSiteSessionData.ts
@@ -1,7 +1,10 @@
+import { GrowthBook } from "@growthbook/growthbook"
+
 import UserSessionData, { SessionDataProps } from "./UserSessionData"
 
 export type UserWithSiteSessionDataProps = SessionDataProps & {
   siteName: string
+  growthbook?: GrowthBook
 }
 
 /**
@@ -11,9 +14,14 @@ export type UserWithSiteSessionDataProps = SessionDataProps & {
 class UserWithSiteSessionData extends UserSessionData {
   readonly siteName: string
 
+  readonly growthbook?: GrowthBook
+
   constructor(props: UserWithSiteSessionDataProps) {
     super(props)
     this.siteName = props.siteName
+    if (props.growthbook) {
+      this.growthbook = props.growthbook
+    }
   }
 
   getGithubParamsWithSite() {

--- a/src/classes/UserWithSiteSessionData.ts
+++ b/src/classes/UserWithSiteSessionData.ts
@@ -1,5 +1,7 @@
 import { GrowthBook } from "@growthbook/growthbook"
 
+import { FeatureFlags } from "@root/types/featureFlags"
+
 import UserSessionData, { SessionDataProps } from "./UserSessionData"
 
 export type UserWithSiteSessionDataProps = SessionDataProps & {
@@ -14,7 +16,7 @@ export type UserWithSiteSessionDataProps = SessionDataProps & {
 class UserWithSiteSessionData extends UserSessionData {
   readonly siteName: string
 
-  readonly growthbook?: GrowthBook
+  readonly growthbook?: GrowthBook<FeatureFlags>
 
   constructor(props: UserWithSiteSessionDataProps) {
     super(props)

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -414,12 +414,6 @@ const config = convict({
     },
   },
   featureFlags: {
-    ggsWhitelistedRepos: {
-      doc: "Comma-separated list of whitelisted repos for local Git service",
-      env: "WHITELISTED_GIT_SERVICE_REPOS",
-      format: String,
-      default: "",
-    },
     ggsTrackedSites: {
       doc: "Comma-separated list of tracked sites for GitHub API hits",
       env: "GGS_EXPERIMENTAL_TRACKING_SITES",

--- a/src/fixtures/sessionData.ts
+++ b/src/fixtures/sessionData.ts
@@ -1,6 +1,9 @@
+import { GrowthBook } from "@growthbook/growthbook"
+
 import GithubSessionData from "@root/classes/GithubSessionData"
 import UserSessionData from "@root/classes/UserSessionData"
 import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
+import { FeatureFlags } from "@root/types/featureFlags"
 
 import {
   MOCK_USER_EMAIL_ONE,
@@ -20,6 +23,7 @@ export const mockEmail = "mockEmail"
 export const mockTreeSha = "mockTreeSha"
 export const mockCurrentCommitSha = "mockCurrentCommitSha"
 export const mockSiteName = "mockSiteName"
+export const mockGrowthBook = new GrowthBook<FeatureFlags>()
 
 export const mockGithubState = {
   treeSha: mockTreeSha,
@@ -40,6 +44,17 @@ export const mockUserWithSiteSessionData = new UserWithSiteSessionData({
   email: mockEmail,
   siteName: mockSiteName,
 })
+
+export const mockUserWithSiteSessionDataAndGrowthBook = new UserWithSiteSessionData(
+  {
+    githubId: mockGithubId,
+    accessToken: mockAccessToken,
+    isomerUserId: mockIsomerUserId,
+    email: mockEmail,
+    siteName: mockSiteName,
+    growthbook: mockGrowthBook,
+  }
+)
 
 export const mockGithubSessionData = new GithubSessionData({
   treeSha: mockTreeSha,

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -51,14 +51,16 @@ export class AuthenticationMiddleware {
       res.locals.userSessionData = userSessionData
 
       // populate growthbook
-      const gbAttributes: GrowthBookAttributes = {
-        isomerUserId,
-        email,
+      if (req.growthbook) {
+        const gbAttributes: GrowthBookAttributes = {
+          isomerUserId,
+          email,
+        }
+        if (session.userInfo.githubId) {
+          gbAttributes.githubId = session.userInfo.githubId
+        }
+        req.growthbook.setAttributes(gbAttributes)
       }
-      if (session.userInfo.githubId) {
-        gbAttributes.githubId = session.userInfo.githubId
-      }
-      req.growthbook.setAttributes(gbAttributes)
 
       return next()
     } catch (err) {

--- a/src/middleware/featureFlag.ts
+++ b/src/middleware/featureFlag.ts
@@ -14,7 +14,7 @@ export const featureFlagMiddleware: RequestHandlerWithGrowthbook<
 
   // Clean up at the end of the request
   res.on("close", () => {
-    req.growthbook.destroy()
+    if (req.growthbook) req.growthbook.destroy()
   })
 
   // Wait for features to load (will be cached in-memory for future requests)

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -87,14 +87,16 @@ const attachSiteHandler: RequestHandler<
   const { userSessionData } = res.locals
 
   // populate growthbook
-  const { isomerUserId, email, githubId } = userSessionData
-  const gbAttributes: GrowthBookAttributes = {
-    isomerUserId,
-    email,
-    siteName,
+  if (req.growthbook) {
+    const { isomerUserId, email, githubId } = userSessionData
+    const gbAttributes: GrowthBookAttributes = {
+      isomerUserId,
+      email,
+      siteName,
+    }
+    if (githubId) gbAttributes.githubId = githubId
+    req.growthbook.setAttributes(gbAttributes)
   }
-  if (githubId) gbAttributes.githubId = githubId
-  req.growthbook.setAttributes(gbAttributes)
 
   const userWithSiteSessionData = new UserWithSiteSessionData({
     ...userSessionData.getGithubParams(),

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -85,11 +85,6 @@ const attachSiteHandler: RequestHandler<
     params: { siteName },
   } = req
   const { userSessionData } = res.locals
-  const userWithSiteSessionData = new UserWithSiteSessionData({
-    ...userSessionData.getGithubParams(),
-    siteName,
-  })
-  res.locals.userWithSiteSessionData = userWithSiteSessionData
 
   // populate growthbook
   const { isomerUserId, email, githubId } = userSessionData
@@ -100,6 +95,13 @@ const attachSiteHandler: RequestHandler<
   }
   if (githubId) gbAttributes.githubId = githubId
   req.growthbook.setAttributes(gbAttributes)
+
+  const userWithSiteSessionData = new UserWithSiteSessionData({
+    ...userSessionData.getGithubParams(),
+    siteName,
+    growthbook: req.growthbook, // inject into session
+  })
+  res.locals.userWithSiteSessionData = userWithSiteSessionData
 
   return next()
 }

--- a/src/middleware/routeHandler.js
+++ b/src/middleware/routeHandler.js
@@ -69,10 +69,9 @@ const attachWriteRouteHandlerWrapper = (routeHandler) => async (
     })
   }
 
-  let isGitAvailable = false
-  if (!isRepoWhitelisted(siteName, ggsWhitelistedRepos.repos)) {
-    isGitAvailable = true
-  } else {
+  let isGitAvailable = true
+  // only check git file lock if the repo is whitelisted
+  if (isRepoWhitelisted(siteName, ggsWhitelistedRepos.repos)) {
     isGitAvailable = await handleGitFileLock(siteName, next)
   }
 

--- a/src/middleware/routeHandler.js
+++ b/src/middleware/routeHandler.js
@@ -20,8 +20,15 @@ const BRANCH_REF = config.get("github.branchRef")
 
 const gitFileSystemService = new GitFileSystemService(new SimpleGit())
 
-const isRepoWhitelisted = (siteName, ggsWhitelistedRepos) =>
+const isRepoWhitelisted = (siteName, ggsWhitelistedRepos) => {
+  // TODO: adding log to simplify debugging, to be removed after stabilising
+  logger.info(
+    `Checking if ${siteName} is GGS whitelisted: ${ggsWhitelistedRepos.includes(
+      siteName
+    )}`
+  )
   ggsWhitelistedRepos.includes(siteName)
+}
 
 const handleGitFileLock = async (repoName, next) => {
   const result = await gitFileSystemService.hasGitFileLock(repoName)

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -21,9 +21,6 @@ import GitFileSystemService from "./GitFileSystemService"
 import { GitHubService } from "./GitHubService"
 import * as ReviewApi from "./review"
 
-const WHITELISTED_GIT_SERVICE_REPOS = config.get(
-  "featureFlags.ggsWhitelistedRepos"
-)
 const PLACEHOLDER_FILE_NAME = ".keep"
 export default class RepoService extends GitHubService {
   private readonly gitFileSystemService: GitFileSystemService
@@ -47,6 +44,14 @@ export default class RepoService extends GitHubService {
     } = sessionData.growthbook.getFeatureValue("ggs_whitelisted_repos", {
       repos: [],
     })
+
+    console.log(
+      `I RECEIVED: ${JSON.stringify(
+        ggsWhitelistedRepos
+      )} to compare with ${repoName}. Returning ${ggsWhitelistedRepos.repos.includes(
+        repoName
+      )}`
+    )
 
     return ggsWhitelistedRepos.repos.includes(repoName)
   }

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -45,10 +45,9 @@ export default class RepoService extends GitHubService {
       repos: [],
     })
 
-    console.log(
-      `I RECEIVED: ${JSON.stringify(
-        ggsWhitelistedRepos
-      )} to compare with ${repoName}. Returning ${ggsWhitelistedRepos.repos.includes(
+    // TODO: Adding for initial debugging if required. Remove once stabilised
+    logger.info(
+      `Evaluating if ${repoName} is whitelisted: ${ggsWhitelistedRepos.repos.includes(
         repoName
       )}`
     )

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -47,7 +47,7 @@ export default class RepoService extends GitHubService {
 
     // TODO: Adding for initial debugging if required. Remove once stabilised
     logger.info(
-      `Evaluating if ${repoName} is whitelisted: ${ggsWhitelistedRepos.repos.includes(
+      `Evaluating if ${repoName} is GGS whitelisted: ${ggsWhitelistedRepos.repos.includes(
         repoName
       )}`
     )

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -36,8 +36,19 @@ export default class RepoService extends GitHubService {
     this.gitFileSystemService = gitFileSystemService
   }
 
-  isRepoWhitelisted(repoName: string): boolean {
-    return WHITELISTED_GIT_SERVICE_REPOS.split(",").includes(repoName)
+  isRepoWhitelisted(
+    repoName: string,
+    sessionData: UserWithSiteSessionData
+  ): boolean {
+    if (!sessionData.growthbook) return false
+
+    const ggsWhitelistedRepos: {
+      repos: string[]
+    } = sessionData.growthbook.getFeatureValue("ggs_whitelisted_repos", {
+      repos: [],
+    })
+
+    return ggsWhitelistedRepos.repos.includes(repoName)
   }
 
   getCommitDiff(siteName: string, base?: string, head?: string) {
@@ -131,7 +142,7 @@ export default class RepoService extends GitHubService {
       isMedia?: boolean
     }
   ): Promise<{ sha: string }> {
-    if (this.isRepoWhitelisted(sessionData.siteName)) {
+    if (this.isRepoWhitelisted(sessionData.siteName, sessionData)) {
       logger.info(
         `Writing file to local Git file system - Site name: ${sessionData.siteName}, directory name: ${directoryName}, file name: ${fileName}`
       )
@@ -163,7 +174,7 @@ export default class RepoService extends GitHubService {
     sessionData: UserWithSiteSessionData,
     { fileName, directoryName }: { fileName: string; directoryName?: string }
   ): Promise<GitFile> {
-    if (this.isRepoWhitelisted(sessionData.siteName)) {
+    if (this.isRepoWhitelisted(sessionData.siteName, sessionData)) {
       logger.info("Reading file from local Git file system")
       const filePath = directoryName ? `${directoryName}/${fileName}` : fileName
       const result = await this.gitFileSystemService.read(
@@ -193,7 +204,7 @@ export default class RepoService extends GitHubService {
     const { siteName } = sessionData
 
     // fetch from local disk
-    if (this.isRepoWhitelisted(siteName)) {
+    if (this.isRepoWhitelisted(siteName, sessionData)) {
       logger.info(
         `Reading media file from disk. Site name: ${siteName}, directory name: ${directoryName}, file name: ${fileName},`
       )
@@ -238,7 +249,7 @@ export default class RepoService extends GitHubService {
     sessionData: UserWithSiteSessionData,
     { directoryName }: { directoryName: string }
   ): Promise<GitDirectoryItem[]> {
-    if (this.isRepoWhitelisted(sessionData.siteName)) {
+    if (this.isRepoWhitelisted(sessionData.siteName, sessionData)) {
       logger.info("Reading directory from local Git file system")
       const result = await this.gitFileSystemService.listDirectoryContents(
         sessionData.siteName,
@@ -270,7 +281,7 @@ export default class RepoService extends GitHubService {
       (file.type === "file" || file.type === "dir") &&
       file.name !== PLACEHOLDER_FILE_NAME
 
-    if (this.isRepoWhitelisted(siteName)) {
+    if (this.isRepoWhitelisted(siteName, sessionData)) {
       const result = await this.gitFileSystemService.listDirectoryContents(
         siteName,
         directoryName
@@ -321,7 +332,7 @@ export default class RepoService extends GitHubService {
       directoryName?: string
     }
   ): Promise<GitCommitResult> {
-    if (this.isRepoWhitelisted(sessionData.siteName)) {
+    if (this.isRepoWhitelisted(sessionData.siteName, sessionData)) {
       logger.info("Updating file in local Git file system")
       const filePath = directoryName ? `${directoryName}/${fileName}` : fileName
       const result = await this.gitFileSystemService.update(
@@ -360,7 +371,7 @@ export default class RepoService extends GitHubService {
       githubSessionData: GithubSessionData
     }
   ): Promise<void> {
-    if (this.isRepoWhitelisted(sessionData.siteName)) {
+    if (this.isRepoWhitelisted(sessionData.siteName, sessionData)) {
       logger.info(
         `Deleting directory in local Git file system for repo: ${sessionData.siteName}, directory name: ${directoryName}`
       )
@@ -419,7 +430,7 @@ export default class RepoService extends GitHubService {
       directoryName: string
     }
   ): Promise<void> {
-    if (this.isRepoWhitelisted(sessionData.siteName)) {
+    if (this.isRepoWhitelisted(sessionData.siteName, sessionData)) {
       logger.info(
         `Deleting file in local Git file system for repo: ${sessionData.siteName}, directory name: ${directoryName}, file name: ${fileName}`
       )
@@ -457,7 +468,7 @@ export default class RepoService extends GitHubService {
     newPath: string,
     message?: string
   ): Promise<GitCommitResult> {
-    if (this.isRepoWhitelisted(sessionData.siteName)) {
+    if (this.isRepoWhitelisted(sessionData.siteName, sessionData)) {
       logger.info("Renaming file/directory in local Git file system")
       const result = await this.gitFileSystemService.renameSinglePath(
         sessionData.siteName,
@@ -542,7 +553,7 @@ export default class RepoService extends GitHubService {
     targetFiles: string[],
     message?: string
   ): Promise<GitCommitResult> {
-    if (this.isRepoWhitelisted(sessionData.siteName)) {
+    if (this.isRepoWhitelisted(sessionData.siteName, sessionData)) {
       logger.info("Moving files in local Git file system")
       const result = await this.gitFileSystemService.moveFiles(
         sessionData.siteName,
@@ -626,7 +637,7 @@ export default class RepoService extends GitHubService {
     branchName: string
   ): Promise<GitHubCommitData> {
     const { siteName } = sessionData
-    if (this.isRepoWhitelisted(siteName)) {
+    if (this.isRepoWhitelisted(siteName, sessionData)) {
       logger.info(
         `Getting latest commit of branch ${branchName} for site ${siteName} from local Git file system`
       )

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -6,9 +6,10 @@ import {
   mockEmail,
   mockGithubId,
   mockGithubSessionData,
+  mockGrowthBook,
   mockIsomerUserId,
   mockSiteName,
-  mockUserWithSiteSessionData,
+  mockUserWithSiteSessionDataAndGrowthBook,
 } from "@fixtures/sessionData"
 import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import { ItemType, MediaFileOutput, MediaDirOutput } from "@root/types"
@@ -52,17 +53,37 @@ describe("RepoService", () => {
     jest.clearAllMocks()
   })
 
+  // load whitelisted sites into growthbook
+  beforeAll(() => {
+    mockGrowthBook.setFeatures({
+      ggs_whitelisted_repos: {
+        defaultValue: {
+          repos: ["fake-repo", mockSiteName],
+        },
+      },
+    })
+  })
+
   describe("isRepoWhitelisted", () => {
     it("should indicate whitelisted repos as whitelisted correctly", () => {
-      const actual1 = RepoService.isRepoWhitelisted("fake-repo")
+      const actual1 = RepoService.isRepoWhitelisted(
+        "fake-repo",
+        mockUserWithSiteSessionDataAndGrowthBook
+      )
       expect(actual1).toBe(true)
 
-      const actual2 = RepoService.isRepoWhitelisted(mockSiteName)
+      const actual2 = RepoService.isRepoWhitelisted(
+        mockSiteName,
+        mockUserWithSiteSessionDataAndGrowthBook
+      )
       expect(actual2).toBe(true)
     })
 
     it("should indicate non-whitelisted repos as non-whitelisted correctly", () => {
-      const actual = RepoService.isRepoWhitelisted("not-whitelisted")
+      const actual = RepoService.isRepoWhitelisted(
+        "not-whitelisted",
+        mockUserWithSiteSessionDataAndGrowthBook
+      )
       expect(actual).toBe(false)
     })
   })
@@ -83,17 +104,20 @@ describe("RepoService", () => {
         okAsync(createOutput)
       )
 
-      const actual = await RepoService.create(mockUserWithSiteSessionData, {
-        content: mockContent,
-        fileName: mockFileName,
-        directoryName: mockDirectoryName,
-        isMedia: false,
-      })
+      const actual = await RepoService.create(
+        mockUserWithSiteSessionDataAndGrowthBook,
+        {
+          content: mockContent,
+          fileName: mockFileName,
+          directoryName: mockDirectoryName,
+          isMedia: false,
+        }
+      )
 
       expect(actual).toEqual(expected)
       expect(MockGitFileSystemService.create).toHaveBeenCalledWith(
-        mockUserWithSiteSessionData.siteName,
-        mockUserWithSiteSessionData.isomerUserId,
+        mockUserWithSiteSessionDataAndGrowthBook.siteName,
+        mockUserWithSiteSessionDataAndGrowthBook.isomerUserId,
         mockContent,
         mockDirectoryName,
         mockFileName,
@@ -116,17 +140,20 @@ describe("RepoService", () => {
         okAsync(createOutput)
       )
 
-      const actual = await RepoService.create(mockUserWithSiteSessionData, {
-        content: mockContent,
-        fileName: mockFileName,
-        directoryName: mockDirectoryName,
-        isMedia: true,
-      })
+      const actual = await RepoService.create(
+        mockUserWithSiteSessionDataAndGrowthBook,
+        {
+          content: mockContent,
+          fileName: mockFileName,
+          directoryName: mockDirectoryName,
+          isMedia: true,
+        }
+      )
 
       expect(actual).toEqual(expected)
       expect(MockGitFileSystemService.create).toHaveBeenCalledWith(
-        mockUserWithSiteSessionData.siteName,
-        mockUserWithSiteSessionData.isomerUserId,
+        mockUserWithSiteSessionDataAndGrowthBook.siteName,
+        mockUserWithSiteSessionDataAndGrowthBook.isomerUserId,
         mockContent,
         mockDirectoryName,
         mockFileName,
@@ -177,10 +204,13 @@ describe("RepoService", () => {
       }
       MockGitFileSystemService.read.mockResolvedValueOnce(okAsync(expected))
 
-      const actual = await RepoService.read(mockUserWithSiteSessionData, {
-        fileName: "test.md",
-        directoryName: "",
-      })
+      const actual = await RepoService.read(
+        mockUserWithSiteSessionDataAndGrowthBook,
+        {
+          fileName: "test.md",
+          directoryName: "",
+        }
+      )
 
       expect(actual).toEqual(expected)
     })
@@ -239,7 +269,7 @@ describe("RepoService", () => {
       )
 
       const actual = await RepoService.readDirectory(
-        mockUserWithSiteSessionData,
+        mockUserWithSiteSessionDataAndGrowthBook,
         {
           directoryName: "test",
         }
@@ -301,12 +331,15 @@ describe("RepoService", () => {
       )
       MockGitFileSystemService.push.mockReturnValueOnce(undefined)
 
-      const actual = await RepoService.update(mockUserWithSiteSessionData, {
-        fileContent: "test content",
-        sha: "fake-original-sha",
-        fileName: "test.md",
-        directoryName: "pages",
-      })
+      const actual = await RepoService.update(
+        mockUserWithSiteSessionDataAndGrowthBook,
+        {
+          fileContent: "test content",
+          sha: "fake-original-sha",
+          fileName: "test.md",
+          directoryName: "pages",
+        }
+      )
 
       expect(actual).toEqual({ newSha: expectedSha })
     })
@@ -343,7 +376,7 @@ describe("RepoService", () => {
       MockGitFileSystemService.push.mockReturnValueOnce(undefined)
 
       const actual = await RepoService.renameSinglePath(
-        mockUserWithSiteSessionData,
+        mockUserWithSiteSessionDataAndGrowthBook,
         mockGithubSessionData,
         "fake-old-path",
         "fake-new-path",
@@ -429,7 +462,7 @@ describe("RepoService", () => {
       MockGitFileSystemService.push.mockReturnValueOnce(undefined)
 
       const actual = await RepoService.moveFiles(
-        mockUserWithSiteSessionData,
+        mockUserWithSiteSessionDataAndGrowthBook,
         mockGithubSessionData,
         "fake-old-path",
         "fake-new-path",
@@ -534,7 +567,7 @@ describe("RepoService", () => {
       )
 
       const actual = await RepoService.getLatestCommitOfBranch(
-        mockUserWithSiteSessionData,
+        mockUserWithSiteSessionDataAndGrowthBook,
         "master"
       )
       expect(actual).toEqual(expected)
@@ -583,7 +616,7 @@ describe("RepoService", () => {
       )
 
       const actual = await RepoService.readMediaFile(
-        mockUserWithSiteSessionData,
+        mockUserWithSiteSessionDataAndGrowthBook,
         {
           directoryName: "test",
           fileName: "test content",
@@ -685,7 +718,7 @@ describe("RepoService", () => {
       )
 
       const actual = await RepoService.readMediaDirectory(
-        mockUserWithSiteSessionData,
+        mockUserWithSiteSessionDataAndGrowthBook,
         "images"
       )
 
@@ -759,7 +792,7 @@ describe("RepoService", () => {
         okAsync("some-fake-sha")
       )
 
-      await RepoService.delete(mockUserWithSiteSessionData, {
+      await RepoService.delete(mockUserWithSiteSessionDataAndGrowthBook, {
         sha: "fake-original-sha",
         fileName: "test.md",
         directoryName: "pages",
@@ -767,15 +800,15 @@ describe("RepoService", () => {
 
       expect(MockGitFileSystemService.delete).toBeCalledTimes(1)
       expect(MockGitFileSystemService.delete).toBeCalledWith(
-        mockUserWithSiteSessionData.siteName,
+        mockUserWithSiteSessionDataAndGrowthBook.siteName,
         "pages/test.md",
         "fake-original-sha",
-        mockUserWithSiteSessionData.isomerUserId,
+        mockUserWithSiteSessionDataAndGrowthBook.isomerUserId,
         false
       )
       expect(MockGitFileSystemService.push).toBeCalledTimes(1)
       expect(MockGitFileSystemService.push).toBeCalledWith(
-        mockUserWithSiteSessionData.siteName
+        mockUserWithSiteSessionDataAndGrowthBook.siteName
       )
     })
 

--- a/src/types/express/request.d.ts
+++ b/src/types/express/request.d.ts
@@ -9,7 +9,7 @@ export {}
 declare global {
   namespace Express {
     export interface Request {
-      growthbook: GrowthBook<FeatureFlags>
+      growthbook?: GrowthBook<FeatureFlags>
     }
   }
 }

--- a/src/types/featureFlags.ts
+++ b/src/types/featureFlags.ts
@@ -1,15 +1,7 @@
 // Use for type safety with GrowthBook
 // Add BE feature flags here to mirror that on GrowthBook
 export interface FeatureFlags {
-  samplekey: string
-}
-
-// List of attributes we set in GrowthBook Instance in auth middleware
-export type GrowthBookAttributes = {
-  isomerUserId: string
-  email: string
-  githubId?: string
-  siteName?: string
+  ggs_whitelisted_repos: { repos: string[] }
 }
 
 // List of attributes we set in GrowthBook Instance in auth middleware

--- a/src/types/featureFlags.ts
+++ b/src/types/featureFlags.ts
@@ -11,3 +11,12 @@ export type GrowthBookAttributes = {
   githubId?: string
   siteName?: string
 }
+
+// List of attributes we set in GrowthBook Instance in auth middleware
+export type GrowthBookAttributes = {
+  isomerUserId: string
+  email: string
+  githubId?: string
+  siteName?: string
+  role?: "email" | "admin"
+}

--- a/src/types/featureFlags.ts
+++ b/src/types/featureFlags.ts
@@ -10,5 +10,4 @@ export type GrowthBookAttributes = {
   email: string
   githubId?: string
   siteName?: string
-  role?: "email" | "admin"
 }

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -15,7 +15,7 @@ export type RequestHandler<
 > = ExpressHandler<P, ResBody, ReqBody, ReqQuery, Locals>
 
 export interface RequestWithGrowthBook extends ExpressRequest {
-  growthbook: GrowthBook
+  growthbook?: GrowthBook
 }
 
 /**

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -6,6 +6,8 @@ import {
   NextFunction,
 } from "express"
 
+import { FeatureFlags } from "./featureFlags"
+
 export type RequestHandler<
   P = unknown,
   ResBody = unknown,
@@ -15,7 +17,7 @@ export type RequestHandler<
 > = ExpressHandler<P, ResBody, ReqBody, ReqQuery, Locals>
 
 export interface RequestWithGrowthBook extends ExpressRequest {
-  growthbook?: GrowthBook
+  growthbook?: GrowthBook<FeatureFlags>
 }
 
 /**

--- a/src/utils/growthbook-utils.ts
+++ b/src/utils/growthbook-utils.ts
@@ -1,14 +1,15 @@
 import { GrowthBook, setPolyfills } from "@growthbook/growthbook"
 
+import config from "@root/config/config"
 import { FeatureFlags } from "@root/types/featureFlags"
 
 const GROWTHBOOK_API_HOST = "https://cdn.growthbook.io"
 
-export const getNewGrowthbookInstance = (clientKey: string, isDev = false) =>
+export const getNewGrowthbookInstance = (clientKey: string) =>
   new GrowthBook<FeatureFlags>({
     apiHost: GROWTHBOOK_API_HOST,
     clientKey,
-    enableDevMode: isDev,
+    enableDevMode: config.get("env") === "dev",
   })
 
 export const setBrowserPolyfills = () => {


### PR DESCRIPTION
## Problem

We are currently using env vars to rollout GGS implementation which requires a rebuild each time we change something.

Closes IS-506

## Solution

Use GrowthBook feature flag. Introduces a new flag `ggs_whitelisted_repos` with a json structure of `{ "repos": string[] }`. Please check the portal for more info.

Note: To be reviewed in conjunction with IS-310 and IS-312

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Tests

- Ensure whitelisted repos are being read in from GB. To do so, can add a simple `console.log` in `isRepoWhitelisted` function of `RepoService`.
- Ensure all unit tests pass especially for `RepoService.spec.ts`

## Deploy Notes

Please remove existing env var of `WHITELISTED_GIT_SERVICE_REPOS` from EB.

**Deprecated environment variables**:

- `WHITELISTED_GIT_SERVICE_REPOS`

**New feature flags**

- `ggs_whitelisted_repos`: ensure correct values are set on GB portal