### PR TITLE
feat(template): add ffs as a manual check-in

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,11 @@ Closes [insert issue #]
 
 - [ ] Yes - this PR contains breaking changes
   - Details ...
-- [ ] No - this PR is backwards compatible
+- No - this PR is backwards compatible with ALL of the following feature flags
+  - [ ] ggs_whitelisted_repos
+  - [ ] styles
+  - [ ] REACT_APP_IS_SITE_PRIVATISATION_ACTIVE
+  - [ ] REACT_APP_SITE_LAUNCH_FEATURE_WHITELISTED_REPOS 
 
 **Features**:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,11 +14,7 @@ Closes [insert issue #]
 
 - [ ] Yes - this PR contains breaking changes
   - Details ...
-- No - this PR is backwards compatible with ALL of the following feature flags
-  - [ ] ggs_whitelisted_repos
-  - [ ] styles
-  - [ ] REACT_APP_IS_SITE_PRIVATISATION_ACTIVE
-  - [ ] REACT_APP_SITE_LAUNCH_FEATURE_WHITELISTED_REPOS 
+- [ ] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)
 
 **Features**:
 


### PR DESCRIPTION
## Problem

It is becoming harder for one eng to keep track of all the other feature flags that are avail. It is also well known a lot of production bugs in big tech companies are results for failed roll outs for experiments. (eg, amplify build times vs repo privatisation) 


Closes [insert issue #]

## Solution

Eng to manually tick off that their features are compat with the permutations of the features (or at least spend some time thinking intentionallu about it) 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

