### PR TITLE
Fix/e2e mutex

### DIFF
--- a/src/utils/mutex-utils.js
+++ b/src/utils/mutex-utils.js
@@ -12,12 +12,15 @@ const NODE_ENV = config.get("env")
 const MUTEX_TABLE_NAME = config.get("mutexTableName")
 
 const IS_DEV = NODE_ENV === "dev" || NODE_ENV === "test" || NODE_ENV === "vapt"
+const E2E_TEST_REPOS = ["e2e-email-test-repo", "e2e-test-repo"]
 const mockMutexObj = {}
 
 // Dynamodb constants
 const AWS_REGION_NAME = config.get("aws.region")
 AWS.config.update({ region: AWS_REGION_NAME })
 const docClient = new AWS.DynamoDB.DocumentClient()
+
+const isE2eTestRepo = (siteName) => E2E_TEST_REPOS.includes(siteName)
 
 const mockLock = (siteName) => {
   if (mockMutexObj[siteName]) throw new Error("Mock lock error")
@@ -33,7 +36,7 @@ const lock = async (siteName) => {
     const ONE_MIN_FROM_CURR_DATE_IN_SECONDS_FROM_EPOCH_TIME =
       Math.floor(new Date().valueOf() / 1000) + 60
 
-    if (!IS_DEV) {
+    if (!IS_DEV && !isE2eTestRepo(siteName)) {
       const params = {
         TableName: MUTEX_TABLE_NAME,
         Item: {
@@ -59,7 +62,7 @@ const lock = async (siteName) => {
 }
 
 const unlock = async (siteName) => {
-  if (IS_DEV) return mockUnlock(siteName)
+  if (IS_DEV || isE2eTestRepo(siteName)) return mockUnlock(siteName)
 
   try {
     const params = {

--- a/src/utils/mutex-utils.js
+++ b/src/utils/mutex-utils.js
@@ -36,7 +36,8 @@ const lock = async (siteName) => {
     const ONE_MIN_FROM_CURR_DATE_IN_SECONDS_FROM_EPOCH_TIME =
       Math.floor(new Date().valueOf() / 1000) + 60
 
-    if (!IS_DEV && !isE2eTestRepo(siteName)) {
+    if (isE2eTestRepo(siteName)) return
+    if (!IS_DEV) {
       const params = {
         TableName: MUTEX_TABLE_NAME,
         Item: {
@@ -62,7 +63,8 @@ const lock = async (siteName) => {
 }
 
 const unlock = async (siteName) => {
-  if (IS_DEV || isE2eTestRepo(siteName)) return mockUnlock(siteName)
+  if (isE2eTestRepo(siteName)) return
+  if (IS_DEV) return mockUnlock(siteName)
 
   try {
     const params = {


### PR DESCRIPTION
## Problem

This PR provides a temporary fix for the failing e2e tests due to our (now fixed) mutex lock. It removes the mutex lock from any endpoints hitting our e2e test repos. Note that this does not allow the tests to work with e2e test repos on the GGS system - those will still get blocked by the internal git system file lock which we are unable to bypass.

This solution is not ideal, but I've opted for this because it is the quickest way to resolve the issues - other methods require a more extensive sweep through our codebase to fix the failing tests. Swapping e2e test repo to use the mock lock also doesn't work as intended - this is because endpoints which lock the repo are being called concurrently (such as removeCollaborator), among others.

Resolves IS-535