### PR TITLE
fix(sl): add retries when creating indirection domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@aws-sdk/client-secrets-manager": "^3.370.0",
         "@aws-sdk/lib-dynamodb": "^3.370.0",
         "@growthbook/growthbook": "^0.27.0",
+        "@octokit/plugin-retry": "^6.0.0",
         "@octokit/rest": "^18.12.0",
         "@opengovsg/formsg-sdk": "^0.10.0",
         "@opengovsg/sgid-client": "^2.0.0",
@@ -2943,45 +2944,103 @@
       }
     },
     "node_modules/@octokit/auth-token": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
-      "dependencies": {
-        "@octokit/types": "^6.0.3"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "peer": true,
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/core": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
-      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.0.tgz",
+      "integrity": "sha512-YbAtMWIrbZ9FCXbLwT9wWB8TyLjq9mxpKdgB3dUNxQcIVTf9hJ70gRPwAcqGZdY6WdJPZ0I7jLaaNDCiloGN2A==",
+      "peer": true,
       "dependencies": {
-        "@octokit/auth-token": "^2.4.4",
-        "@octokit/graphql": "^4.5.8",
-        "@octokit/request": "^5.6.3",
-        "@octokit/request-error": "^2.0.5",
-        "@octokit/types": "^6.0.3",
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.0.0",
+        "@octokit/request": "^8.0.2",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^11.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+      "peer": true
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/types": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
+      "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+      "peer": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
+      "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
+      "peer": true,
       "dependencies": {
-        "@octokit/types": "^6.0.3",
+        "@octokit/types": "^11.0.0",
         "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+      "peer": true
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
+      "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+      "peer": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
-      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.1.tgz",
+      "integrity": "sha512-T5S3oZ1JOE58gom6MIcrgwZXzTaxRnxBso58xhozxHpOqSTgDS6YNeEUvZ/kRvXgPrRz/KHnZhtb7jUMRi9E6w==",
+      "peer": true,
       "dependencies": {
-        "@octokit/request": "^5.6.0",
-        "@octokit/types": "^6.0.3",
+        "@octokit/request": "^8.0.1",
+        "@octokit/types": "^11.0.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+      "peer": true
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/types": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
+      "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+      "peer": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/openapi-types": {
@@ -3020,7 +3079,146 @@
         "@octokit/core": ">=3"
       }
     },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.0.0.tgz",
+      "integrity": "sha512-a1/A4A+PB1QoAHQfLJxGHhLfSAT03bR1jJz3GgQJZvty2ozawFWs93MiBQXO7SL2YbO7CIq0Goj4qLOBj8JeMQ==",
+      "dependencies": {
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^11.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=5"
+      }
+    },
+    "node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
+    },
+    "node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
+      "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
+      }
+    },
     "node_modules/@octokit/request": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.1.tgz",
+      "integrity": "sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==",
+      "peer": true,
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.0",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^11.1.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.0.tgz",
+      "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
+      "dependencies": {
+        "@octokit/types": "^11.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
+      "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+      "peer": true
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/types": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
+      "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+      "peer": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "18.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+      "dependencies": {
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "dependencies": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/request": {
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
       "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
@@ -3033,7 +3231,7 @@
         "universal-user-agent": "^6.0.0"
       }
     },
-    "node_modules/@octokit/request-error": {
+    "node_modules/@octokit/rest/node_modules/@octokit/request-error": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
       "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
@@ -3041,17 +3239,6 @@
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/@octokit/rest": {
-      "version": "18.12.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
-      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
-      "dependencies": {
-        "@octokit/core": "^3.5.1",
-        "@octokit/plugin-paginate-rest": "^2.16.8",
-        "@octokit/plugin-request-log": "^1.0.4",
-        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
       }
     },
     "node_modules/@octokit/types": {
@@ -5482,6 +5669,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
     "node_modules/bowser": {
       "version": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@aws-sdk/client-secrets-manager": "^3.370.0",
     "@aws-sdk/lib-dynamodb": "^3.370.0",
     "@growthbook/growthbook": "^0.27.0",
+    "@octokit/plugin-retry": "^6.0.0",
     "@octokit/rest": "^18.12.0",
     "@opengovsg/formsg-sdk": "^0.10.0",
     "@opengovsg/sgid-client": "^2.0.0",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Creating the DNS indirection domain will fail when multiple site launches are performed in a single site launch form submission.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- An octokit plugin (`@octokit/plugin-retry`) is used to automatically retry on retry-able errors. This includes the 409 error code returned by GitHub due to concurrent edits made to the indirection repository.

## Tests

<!-- What tests should be run to confirm functionality? -->

Unable to test directly as this is a site launch change. However, the following code was used to simulate concurrent creation of files:

```javascript
const { Octokit } = require("@octokit/rest");
const { retry } = require("@octokit/plugin-retry");

const FILE_CONTENTS = "Hello, world!";
const GITHUB_TOKEN = "TOKEN_HERE";

const MyOctokit = Octokit.plugin(retry);
const octokit = new MyOctokit({
  auth: GITHUB_TOKEN,
  request: { retries: 5 },
});

async function main() {
  const files = [
    "test-file-1.txt",
    "test-file-2.txt",
    "test-file-3.txt",
    "test-file-4.txt",
    "test-file-5.txt",
    "test-file-6.txt",
    "test-file-7.txt",
    "test-file-8.txt",
    "test-file-9.txt",
    "test-file-10.txt",
  ];
  await Promise.all(
    files.map(async (file) => {
      await octokit.repos.createOrUpdateFileContents({
        owner: "dcshzj",
        repo: "test",
        path: file,
        message: `Add ${file}`,
        content: Buffer.from(FILE_CONTENTS).toString("base64"),
      });
    })
  );
}

main();
```

Without the retries, only one file will be created and the rest will have an error. Adding the retry plugin will allow all 10 files to be created successfully.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dependencies**:

- `@octokit/plugin-retry` : An octokit plugin to automatically retry on retry-able errors.