### PR TITLE
IS-548: Add max concurrent git processes

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -61,3 +61,5 @@ export const DNS_INDIRECTION_DOMAIN = "hostedon.isomer.gov.sg"
 export const DNS_INDIRECTION_REPO = "isomer-indirection"
 export const ISOMER_ADMIN_EMAIL = "admin@isomer.gov.sg"
 export const ISOMER_SUPPORT_EMAIL = "support@isomer.gov.sg"
+
+export const MAX_CONCURRENT_GIT_PROCESSES = 150

--- a/src/middleware/routeHandler.js
+++ b/src/middleware/routeHandler.js
@@ -10,6 +10,8 @@ const { default: GithubSessionData } = require("@classes/GithubSessionData")
 const { lock, unlock } = require("@utils/mutex-utils")
 const { getCommitAndTreeSha, revertCommit } = require("@utils/utils.js")
 
+const { MAX_CONCURRENT_GIT_PROCESSES } = require("@constants/constants")
+
 const { FEATURE_FLAGS } = require("@root/constants/featureFlags")
 const GitFileSystemError = require("@root/errors/GitFileSystemError").default
 const LockedError = require("@root/errors/LockedError").default
@@ -19,7 +21,9 @@ const {
 
 const BRANCH_REF = config.get("github.branchRef")
 
-const gitFileSystemService = new GitFileSystemService(new SimpleGit())
+const gitFileSystemService = new GitFileSystemService(
+  new SimpleGit({ maxConcurrentProcesses: MAX_CONCURRENT_GIT_PROCESSES })
+)
 
 const isRepoWhitelisted = (siteName, ggsWhitelistedRepos) => {
   // TODO: adding log to simplify debugging, to be removed after stabilising

--- a/src/server.js
+++ b/src/server.js
@@ -12,6 +12,8 @@ import { config } from "@config/config"
 
 import logger from "@logger/logger"
 
+import { MAX_CONCURRENT_GIT_PROCESSES } from "@constants/constants"
+
 import initSequelize from "@database/index"
 import {
   Site,
@@ -155,7 +157,9 @@ const { AuthService } = require("@services/utilServices/AuthService")
 setBrowserPolyfills()
 
 const authService = new AuthService({ usersService })
-const gitFileSystemService = new GitFileSystemService(new simpleGit())
+const gitFileSystemService = new GitFileSystemService(
+  new simpleGit({ maxConcurrentProcesses: MAX_CONCURRENT_GIT_PROCESSES })
+)
 const gitHubService = new RepoService(
   isomerRepoAxiosInstance,
   gitFileSystemService


### PR DESCRIPTION
## Problem

We are rolling out GGS to more sites and we need to ensure that GGS scales with increase in number of concurrent sites.

Closes IS-548

## Solution

With relation to https://github.com/isomerpages/isomer-tooling/pull/51, we found out the following:

> Having a shared simple-git instance for all repos works fine without errors, provided that we increase the MAX_CONCURRENT_PROCESSES to be equal the the number of repos we want to support concurrently.

Assuming each Git process has an upper bound of 10MB of memory usage, and given a RAM size of 2GB, we can support a max of 200 processes.

Allowing for some buffer, we will make this number 150 as a upper bound. Note that this is still way higher than our realistic expected usage.

We observed a total of 3500 calls / hour which works to be roughly 60 per minute. Hence, 150 **concurrent** works out to be a sufficiently high enough buffer.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Tests

Ensure all unit tests pass