### PR TITLE
IS-342: Clone repos into EFS vol path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "http-errors": "~1.8.0",
         "is-svg": "^4.4.0",
         "isomorphic-dompurify": "^0.24.0",
-        "isomorphic-git": "^1.18.2",
         "joi": "^17.4.0",
         "js-base64": "^3.7.5",
         "jsdom": "^16.7.0",
@@ -5269,11 +5268,6 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
-    "node_modules/async-lock": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
-      "integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ=="
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -5999,11 +5993,6 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
     },
-    "node_modules/clean-git-ref": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
-      "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw=="
-    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -6466,17 +6455,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -6718,31 +6696,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-response/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -6905,11 +6858,6 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
-    },
-    "node_modules/diff3": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-      "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g=="
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -9991,38 +9939,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/isomorphic-git": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.24.4.tgz",
-      "integrity": "sha512-44pHxpUw9w7BUjbHYTji3I7Guf75CBTxV2/fJnfeA6IlIOgZkroabgYlroleqMs4mqiCG8nLbS/FBEBQEoexHA==",
-      "dependencies": {
-        "async-lock": "^1.1.0",
-        "clean-git-ref": "^2.0.1",
-        "crc-32": "^1.2.0",
-        "diff3": "0.0.3",
-        "ignore": "^5.1.4",
-        "minimisted": "^2.0.0",
-        "pako": "^1.0.10",
-        "pify": "^4.0.1",
-        "readable-stream": "^3.4.0",
-        "sha.js": "^2.4.9",
-        "simple-get": "^4.0.1"
-      },
-      "bin": {
-        "isogit": "cli.cjs"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/isomorphic-git/node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -12798,16 +12714,9 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minimisted": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
-      "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
-      "dependencies": {
-        "minimist": "^1.2.5"
       }
     },
     "node_modules/minipass": {
@@ -13576,11 +13485,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
-    },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -14820,18 +14724,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
-    "node_modules/sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      },
-      "bin": {
-        "sha.js": "bin.js"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -14879,49 +14771,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "node_modules/simple-git": {
       "version": "3.19.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "http-errors": "~1.8.0",
     "is-svg": "^4.4.0",
     "isomorphic-dompurify": "^0.24.0",
-    "isomorphic-git": "^1.18.2",
     "joi": "^17.4.0",
     "js-base64": "^3.7.5",
     "jsdom": "^16.7.0",

--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -151,7 +151,10 @@ const authorizationMiddleware = getAuthorizationMiddleware({
   collaboratorsService,
 })
 
-const reposService = new ReposService({ repository: Repo })
+const reposService = new ReposService({
+  repository: Repo,
+  simpleGit: simpleGit(),
+})
 const deploymentsService = new DeploymentsService({
   deploymentsRepository: Deployment,
 })

--- a/src/server.js
+++ b/src/server.js
@@ -157,9 +157,10 @@ const { AuthService } = require("@services/utilServices/AuthService")
 setBrowserPolyfills()
 
 const authService = new AuthService({ usersService })
-const gitFileSystemService = new GitFileSystemService(
-  new simpleGit({ maxConcurrentProcesses: MAX_CONCURRENT_GIT_PROCESSES })
-)
+const simpleGitInstance = new simpleGit({
+  maxConcurrentProcesses: MAX_CONCURRENT_GIT_PROCESSES,
+})
+const gitFileSystemService = new GitFileSystemService(simpleGitInstance)
 const gitHubService = new RepoService(
   isomerRepoAxiosInstance,
   gitFileSystemService
@@ -224,7 +225,10 @@ const sitesService = new SitesService({
   sitesCacheService,
   previewService,
 })
-const reposService = new ReposService({ repository: Repo })
+const reposService = new ReposService({
+  repository: Repo,
+  simpleGit: simpleGitInstance,
+})
 const deploymentsService = new DeploymentsService({
   deploymentsRepository: Deployment,
 })

--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -124,16 +124,16 @@ export default class ReposService {
       .commit("Set URLs")
 
     // 3. Push changes to staging branch
-    await this.simpleGit.push("origin", "staging")
+    await this.simpleGit.cwd(dir).push("origin", "staging")
 
     // 4. Merge these changes into master branch
-    await this.simpleGit.checkout("master").merge(["staging"])
+    await this.simpleGit.cwd(dir).checkout("master").merge(["staging"])
 
     // 5. Push changes to master branch
-    await this.simpleGit.push("origin", "master")
+    await this.simpleGit.cwd(dir).push("origin", "master")
 
     // 6. Checkout back to staging branch
-    await this.simpleGit.checkout("staging")
+    await this.simpleGit.cwd(dir).checkout("staging")
   }
 
   private setUrlsInLocalConfig(
@@ -229,16 +229,18 @@ export default class ReposService {
       .checkoutLocalBranch("staging")
 
     // Add all the changes
-    await this.simpleGit.add(".")
+    await this.simpleGit.cwd(dir).add(".")
 
     // Commit
     await this.simpleGit
+      .cwd(dir)
       .addConfig("user.name", "isomeradmin")
       .addConfig("user.email", ISOMER_GITHUB_EMAIL)
       .commit("Initial commit")
 
     // Push to origin
     await this.simpleGit
+      .cwd(dir)
       .addRemote("origin", repoUrl)
       .checkout("staging")
       .push(["-u", "origin", "staging"]) // push to staging first to make it the default branch on GitHub

--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -82,7 +82,7 @@ export default class ReposService {
   }): Promise<Repo> => {
     const repoUrl = `https://github.com/isomerpages/${repoName}`
 
-    // await this.createRepoOnGithub(repoName)
+    await this.createRepoOnGithub(repoName)
     if (!isEmailLogin) {
       await this.createTeamOnGitHub(repoName)
     }

--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -31,6 +31,8 @@ const SITE_CREATION_BASE_REPO_URL =
   "https://github.com/isomerpages/site-creation-base"
 const ISOMER_GITHUB_ORGANIZATION_NAME = "isomerpages"
 
+const EFS_VOL_PATH = config.get("aws.efs.volPath")
+
 interface ReposServiceProps {
   repository: ModelStatic<Repo>
 }
@@ -59,7 +61,7 @@ export default class ReposService {
     this.repository = repository
   }
 
-  getLocalRepoPath = (repoName: string) => `/tmp/${repoName}`
+  getLocalRepoPath = (repoName: string) => `${EFS_VOL_PATH}/${repoName}`
 
   create = (createParams: repoCreateParamsType): Promise<Repo> =>
     this.repository.create(createParams)
@@ -79,7 +81,8 @@ export default class ReposService {
     if (!isEmailLogin) {
       await this.createTeamOnGitHub(repoName)
     }
-    await this.generateRepoAndPublishToGitHub(repoName, repoUrl)
+    const sshRepoUrl = `git@github.com:${ISOMER_GITHUB_ORGANIZATION_NAME}/${repoName}.git`
+    await this.generateRepoAndPublishToGitHub(repoName, sshRepoUrl)
     return this.create({
       name: repoName,
       url: repoUrl,


### PR DESCRIPTION
## Problem

We need to ensure new repos/site creations are automatically cloned into the EFS

Closes IS-342

## Solution

We are already creating a local git folder with the base template under `/tmp` and doing a `git push` to create it on github. Instead of creating it in `/tmp`, now it will create within the `EFS_VOL_PATH` and instead of http git remote, it uses ssh protocol.

Note: Had to change from isomorphic-git to using simple-git as we are using SSH auth. SSH auth is not supported in isomorphic git.

Example of site created with this code: https://github.com/isomerpages/harish-test-staging/tree/staging

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Tests
1. Create a site using the staging site-creation form
2. Ensure the site is created on GitHub. Default branch should be staging as shown in below screenshot.
3. Both staging and master should have 2 commits - "Initial commit" and "Set URLs" from `isomeradmin` user
4. Visit CMS Staging and you should see the new site there
5. Ensure the repo exists on EFS staging

## Depedency Changes

Removes `isomorphic-git`. No longer required as we are using `simple-git`
