### PR TITLE
feat(formsg): clone repo on webhook trigger from forms

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -22,6 +22,7 @@ export SYSTEM_GITHUB_TOKEN="github_token"
 # FormSG keys
 export SITE_CREATE_FORM_KEY="site_form_key"
 export SITE_LAUNCH_FORM_KEY="site_launch_form_key"
+export SITE_CLONE_FORM_KEY="site_clone_form_key"
 
 # Required to connect to DynamoDB
 export AWS_ACCESS_KEY_ID="abc123"

--- a/.platform/hooks/predeploy/06_fetch_ssm_parameters.sh
+++ b/.platform/hooks/predeploy/06_fetch_ssm_parameters.sh
@@ -20,100 +20,101 @@ fi
 ENV_TYPE=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_PREFIX)
 TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
 
-echo "Timestamp: $TIMESTAMP - ENV TYPE: $ENV_TYPE" > /tmp/ssm-type.txt
+echo "Timestamp: $TIMESTAMP - ENV TYPE: $ENV_TYPE" >/tmp/ssm-type.txt
 
 # List of all env vars to fetch
 ENV_VARS=(
-  "AUTH_TOKEN_EXPIRY_DURATION_IN_MILLISECONDS"
-  "AWS_BACKEND_EB_ENV_NAME"
-  "AWS_REGION"
-  "CLIENT_ID"
-  "CLIENT_SECRET"
-  "CLOUDMERSIVE_API_KEY"
-  "COOKIE_DOMAIN"
-  "DB_ACQUIRE"
-  "DB_MAX_POOL"
-  "DB_MIN_POOL"
-  "DB_TIMEOUT"
-  "DB_URI"
-  "DD_AGENT_MAJOR_VERSION"
-  "DD_ENV"
-  "DD_LOGS_INJECTION"
-  "DD_SERVICE"
-  "DD_TAGS"
-  "DD_TRACE_STARTUP_LOGS"
-  "E2E_TEST_GH_TOKEN"
-  "E2E_TEST_REPO"
-  "E2E_TEST_SECRET"
-  "EFS_VOL_PATH"
-  "ENCRYPTION_SECRET"
-  "FF_DEPRECATE_SITE_QUEUES"
-  "FRONTEND_URL"
-  "GGS_EXPERIMENTAL_TRACKING_SITES"
-  "GITHUB_BUILD_ORG_NAME"
-  "GITHUB_BUILD_REPO_NAME"
-  "GITHUB_ORG_NAME"
-  "GROWTHBOOK_CLIENT_KEY"
-  "INCOMING_QUEUE_URL"
-  "ISOMERPAGES_REPO_PAGE_COUNT"
-  "JWT_SECRET"
-  "MAX_NUM_OTP_ATTEMPTS"
-  "MOCK_AMPLIFY_DOMAIN_ASSOCIATION_CALLS"
-  "MUTEX_TABLE_NAME"
-  "NETLIFY_ACCESS_TOKEN"
-  "NODE_ENV"
-  "OTP_EXPIRY"
-  "OTP_SECRET"
-  "OUTGOING_QUEUE_URL"
-  "POSTMAN_API_KEY"
-  "POSTMAN_SMS_CRED_NAME"
-  "REDIRECT_URI"
-  "SESSION_SECRET"
-  "SGID_CLIENT_ID" 
-  "SGID_CLIENT_SECRET" 
-  "SGID_PRIVATE_KEY" 
-  "SGID_REDIRECT_URI"
-  "SITE_CREATE_FORM_KEY"
-  "SITE_LAUNCH_DYNAMO_DB_TABLE_NAME"
-  "SITE_LAUNCH_FORM_KEY"
-  "SITE_PASSWORD_SECRET_KEY"
-  "SSM_PREFIX"
-  "STEP_FUNCTIONS_ARN"
-  "SYSTEM_GITHUB_TOKEN"
+    "AUTH_TOKEN_EXPIRY_DURATION_IN_MILLISECONDS"
+    "AWS_BACKEND_EB_ENV_NAME"
+    "AWS_REGION"
+    "CLIENT_ID"
+    "CLIENT_SECRET"
+    "CLOUDMERSIVE_API_KEY"
+    "COOKIE_DOMAIN"
+    "DB_ACQUIRE"
+    "DB_MAX_POOL"
+    "DB_MIN_POOL"
+    "DB_TIMEOUT"
+    "DB_URI"
+    "DD_AGENT_MAJOR_VERSION"
+    "DD_ENV"
+    "DD_LOGS_INJECTION"
+    "DD_SERVICE"
+    "DD_TAGS"
+    "DD_TRACE_STARTUP_LOGS"
+    "E2E_TEST_GH_TOKEN"
+    "E2E_TEST_REPO"
+    "E2E_TEST_SECRET"
+    "EFS_VOL_PATH"
+    "ENCRYPTION_SECRET"
+    "FF_DEPRECATE_SITE_QUEUES"
+    "FRONTEND_URL"
+    "GGS_EXPERIMENTAL_TRACKING_SITES"
+    "GITHUB_BUILD_ORG_NAME"
+    "GITHUB_BUILD_REPO_NAME"
+    "GITHUB_ORG_NAME"
+    "GROWTHBOOK_CLIENT_KEY"
+    "INCOMING_QUEUE_URL"
+    "ISOMERPAGES_REPO_PAGE_COUNT"
+    "JWT_SECRET"
+    "MAX_NUM_OTP_ATTEMPTS"
+    "MOCK_AMPLIFY_DOMAIN_ASSOCIATION_CALLS"
+    "MUTEX_TABLE_NAME"
+    "NETLIFY_ACCESS_TOKEN"
+    "NODE_ENV"
+    "OTP_EXPIRY"
+    "OTP_SECRET"
+    "OUTGOING_QUEUE_URL"
+    "POSTMAN_API_KEY"
+    "POSTMAN_SMS_CRED_NAME"
+    "REDIRECT_URI"
+    "SESSION_SECRET"
+    "SGID_CLIENT_ID"
+    "SGID_CLIENT_SECRET"
+    "SGID_PRIVATE_KEY"
+    "SGID_REDIRECT_URI"
+    "SITE_CREATE_FORM_KEY"
+    "SITE_LAUNCH_DYNAMO_DB_TABLE_NAME"
+    "SITE_LAUNCH_FORM_KEY"
+    "SITE_CLONE_FORM_KEY"
+    "SITE_PASSWORD_SECRET_KEY"
+    "SSM_PREFIX"
+    "STEP_FUNCTIONS_ARN"
+    "SYSTEM_GITHUB_TOKEN"
 )
 
 echo "Set AWS region"
 aws configure set default.region ap-southeast-1
 
-set +e  # Do not exit if a command fails
+set +e # Do not exit if a command fails
 
 for ENV_VAR in "${ENV_VARS[@]}"; do
     echo "Fetching ${ENV_VAR} from SSM"
-    
+
     VALUE=$(aws ssm get-parameter --name "${ENV_TYPE}_${ENV_VAR}" --with-decryption --query "Parameter.Value" --output text 2>/dev/null)
-    STATUS=$?  # Capture exit status of the aws ssm command
-    
+    STATUS=$? # Capture exit status of the aws ssm command
+
     if [ $STATUS -ne 0 ]; then
         echo "Failed to fetch ${ENV_VAR}. Skipping."
         continue
     fi
-    
-    echo "${ENV_VAR}=${VALUE}" >> /tmp/isomer/.isomer.env
+
+    echo "${ENV_VAR}=${VALUE}" >>/tmp/isomer/.isomer.env
     echo "Saved ${ENV_VAR}"
 done
 
-set -e  # Exit on command failure from this point onwards
+set -e # Exit on command failure from this point onwards
 
 # Use flock to ensure that the EFS file is locked during the copy operation
 (
-  flock -n 200 || exit 1
+    flock -n 200 || exit 1
 
-  # Copy the local file to EFS
-  echo "Copying local env file to EFS"
-  cp /tmp/isomer/.isomer.env /efs/isomer/.isomer.env
+    # Copy the local file to EFS
+    echo "Copying local env file to EFS"
+    cp /tmp/isomer/.isomer.env /efs/isomer/.isomer.env
 
-  # Ensure the file on EFS is owned by webapp so it has access
-  chown webapp:webapp /efs/isomer/.isomer.env
+    # Ensure the file on EFS is owned by webapp so it has access
+    chown webapp:webapp /efs/isomer/.isomer.env
 
 ) 200>/efs/isomer/.isomer.lock
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -283,6 +283,13 @@ const config = convict({
       format: "required-string",
       default: "",
     },
+    siteCloneFormKey: {
+      doc: "FormSG API key for site clone form",
+      env: "SITE_CLONE_FORM_KEY",
+      sensitive: true,
+      format: "required-string",
+      default: "",
+    },
   },
   postman: {
     apiKey: {

--- a/src/routes/formsgSiteClone.ts
+++ b/src/routes/formsgSiteClone.ts
@@ -1,0 +1,125 @@
+import { DecryptedContent } from "@opengovsg/formsg-sdk/dist/types"
+import autoBind from "auto-bind"
+import express, { RequestHandler } from "express"
+
+import { config } from "@config/config"
+
+import logger from "@logger/logger"
+
+import { getField } from "@utils/formsg-utils"
+
+import { ISOMER_ADMIN_EMAIL } from "@root/constants"
+import { attachFormSGHandler } from "@root/middleware"
+import GitFileSystemService from "@services/db/GitFileSystemService"
+import UsersService from "@services/identity/UsersService"
+import InfraService from "@services/infra/InfraService"
+import { mailer } from "@services/utilServices/MailClient"
+
+const SITE_CLONE_FORM_KEY = config.get("formSg.siteCloneFormKey")
+
+export interface FormsgSiteCloneRouterProps {
+  usersService: UsersService
+  infraService: InfraService
+  gitFileSystemService: GitFileSystemService
+}
+
+export class FormsgSiteCloneRouter {
+  private readonly gitFileSystemService: FormsgSiteCloneRouterProps["gitFileSystemService"]
+
+  constructor({ gitFileSystemService }: FormsgSiteCloneRouterProps) {
+    this.gitFileSystemService = gitFileSystemService
+    // We need to bind all methods because we don't invoke them from the class directly
+    autoBind(this)
+  }
+
+  cloneSiteToEfs: RequestHandler<
+    never,
+    Record<string, never>,
+    { data: { submissionId: string } },
+    never,
+    { submission: DecryptedContent }
+  > = async (req, res) => {
+    // 1. Extract arguments
+    const { submissionId } = req.body.data
+    const { responses } = res.locals.submission
+    const requesterEmail = getField(responses, "Email")
+    // NOTE: The field is required by our form so this cannot be empty or undefined
+    const githubRepoName = getField(responses, "Github Repo Name") as string
+
+    if (
+      !requesterEmail ||
+      !githubRepoName ||
+      !requesterEmail.endsWith("@open.gov.sg")
+    ) {
+      return this.sendCloneError(
+        ISOMER_ADMIN_EMAIL,
+        githubRepoName,
+        submissionId,
+        "Invalid email or missing github repo name detected for submission"
+      )
+    }
+
+    logger.info(
+      `${requesterEmail} requested for ${githubRepoName} to be cloned onto EFS`
+    )
+
+    this.gitFileSystemService
+      .clone(githubRepoName)
+      .map((path) => {
+        logger.info(`Cloned ${githubRepoName} to ${path}`)
+        this.sendCloneSuccess(
+          requesterEmail,
+          githubRepoName,
+          submissionId,
+          path
+        )
+      })
+      .mapErr((err) => {
+        logger.error(
+          `Cloning repo: ${githubRepoName} to EFS failed with error: ${JSON.stringify(
+            err
+          )}`
+        )
+        this.sendCloneError(
+          requesterEmail,
+          githubRepoName,
+          submissionId,
+          err.message
+        )
+      })
+  }
+
+  sendCloneSuccess = async (
+    requesterEmail: string,
+    githubRepoName: string,
+    submissionId: string,
+    path: string
+  ) => {
+    const subject = `[Isomer] Clone site ${githubRepoName} SUCCESS`
+    const html = `<p>Isomer site ${githubRepoName} was cloned successfully to EFS path: ${path}. (Form submission id [${submissionId}])</p>`
+    await mailer.sendMail(requesterEmail, subject, html)
+  }
+
+  async sendCloneError(
+    requesterEmail: string,
+    githubRepoName: string,
+    submissionId: string,
+    message: string
+  ) {
+    const subject = `[Isomer] Clone site ${githubRepoName} FAILURE`
+    const html = `<p>Isomer site ${githubRepoName} was <b>not</b> cloned successfully. Cloning failed with error: ${message} (Form submission id [${submissionId}])</p>`
+    await mailer.sendMail(requesterEmail, subject, html)
+  }
+
+  getRouter() {
+    const router = express.Router({ mergeParams: true })
+
+    router.post(
+      "/clone-site",
+      attachFormSGHandler(SITE_CLONE_FORM_KEY),
+      this.cloneSiteToEfs
+    )
+
+    return router
+  }
+}

--- a/src/routes/formsgSiteCreation.ts
+++ b/src/routes/formsgSiteCreation.ts
@@ -11,10 +11,12 @@ import { BadRequestError } from "@errors/BadRequestError"
 import { getField } from "@utils/formsg-utils"
 
 import { attachFormSGHandler } from "@root/middleware"
+import GitFileSystemService from "@services/db/GitFileSystemService"
 import UsersService from "@services/identity/UsersService"
 import InfraService from "@services/infra/InfraService"
 import { mailer } from "@services/utilServices/MailClient"
 
+const SITE_CLONE_FORM_KEY = config.get("formSg.siteCloneFormKey")
 const SITE_CREATE_FORM_KEY = config.get("formSg.siteCreateFormKey")
 const REQUESTER_EMAIL_FIELD = "Government E-mail"
 const SITE_NAME_FIELD = "Site Name"
@@ -25,6 +27,7 @@ const LOGIN_TYPE_FIELD = "Login Type"
 export interface FormsgRouterProps {
   usersService: UsersService
   infraService: InfraService
+  gitFileSystemService: GitFileSystemService
 }
 
 export class FormsgRouter {
@@ -32,9 +35,16 @@ export class FormsgRouter {
 
   private readonly infraService: FormsgRouterProps["infraService"]
 
-  constructor({ usersService, infraService }: FormsgRouterProps) {
+  private readonly gitFileSystemService: FormsgRouterProps["gitFileSystemService"]
+
+  constructor({
+    usersService,
+    infraService,
+    gitFileSystemService,
+  }: FormsgRouterProps) {
     this.usersService = usersService
     this.infraService = infraService
+    this.gitFileSystemService = gitFileSystemService
     // We need to bind all methods because we don't invoke them from the class directly
     autoBind(this)
   }
@@ -157,8 +167,82 @@ export class FormsgRouter {
     await mailer.sendMail(email, subject, html)
   }
 
+  cloneSiteToEfs: RequestHandler<
+    never,
+    Record<string, never>,
+    { data: { submissionId: string } },
+    never,
+    { submission: DecryptedContent }
+  > = async (req, res) => {
+    // 1. Extract arguments
+    const { submissionId } = req.body.data
+    const { responses } = res.locals.submission
+    // NOTE: This is validated by formsg to be of domain `@open.gov.sg`;
+    // hence, not revalidating here
+    const requesterEmail = getField(responses, "Email") as string
+    // NOTE: The field is required by our form so this cannot be empty or undefined
+    const githubRepoName = getField(responses, "Github Repo Name") as string
+
+    logger.info(
+      `${requesterEmail} requested for ${githubRepoName} to be cloned onto EFS`
+    )
+
+    this.gitFileSystemService
+      .clone(githubRepoName)
+      .map((path) => {
+        logger.info(`Cloned ${githubRepoName} to ${path}`)
+        this.sendCloneSuccess(
+          requesterEmail,
+          githubRepoName,
+          submissionId,
+          path
+        )
+      })
+      .mapErr((err) => {
+        logger.error(
+          `Cloning repo: ${githubRepoName} to EFS failed with error: ${JSON.stringify(
+            err
+          )}`
+        )
+        this.sendCloneError(
+          requesterEmail,
+          githubRepoName,
+          submissionId,
+          err.message
+        )
+      })
+  }
+
+  sendCloneSuccess = async (
+    requesterEmail: string,
+    githubRepoName: string,
+    submissionId: string,
+    path: string
+  ) => {
+    const subject = `[Isomer] Clone site ${githubRepoName} SUCCESS`
+    const html = `<p>Isomer site ${githubRepoName} was cloned successfully to EFS path: ${path}. (Form submission id [${submissionId}])</p>`
+    await mailer.sendMail(requesterEmail, subject, html)
+  }
+
+  async sendCloneError(
+    requesterEmail: string,
+    githubRepoName: string,
+    submissionId: string,
+    message: string
+  ) {
+    const subject = `[Isomer] Clone site ${githubRepoName} FAILURE`
+    const html = `<p>Isomer site ${githubRepoName} was <b>not</b> cloned successfully. Cloning failed with error: ${message} (Form submission id [${submissionId}])</p>`
+    await mailer.sendMail(requesterEmail, subject, html)
+  }
+
   getRouter() {
     const router = express.Router({ mergeParams: true })
+
+    router.post(
+      "/clone-site",
+      attachFormSGHandler(SITE_CLONE_FORM_KEY),
+      this.cloneSiteToEfs
+    )
 
     router.post(
       "/create-site",

--- a/src/server.js
+++ b/src/server.js
@@ -147,6 +147,7 @@ const FRONTEND_URL = config.get("app.frontendUrl")
 // Import routes
 const { errorHandler } = require("@middleware/errorHandler")
 
+const { FormsgSiteCloneRouter } = require("@routes/formsgSiteClone")
 const { FormsgRouter } = require("@routes/formsgSiteCreation")
 const { FormsgSiteLaunchRouter } = require("@routes/formsgSiteLaunch")
 const { AuthRouter } = require("@routes/v2/auth")
@@ -360,6 +361,9 @@ const formsgSiteLaunchRouter = new FormsgSiteLaunchRouter({
   usersService,
   infraService,
 })
+const formsgSiteCloneRouter = new FormsgSiteCloneRouter({
+  gitFileSystemService,
+})
 
 const app = express()
 
@@ -407,6 +411,7 @@ app.use("/v2/sites/:siteName", authenticatedSitesSubrouterV2)
 // FormSG Backend handler routes
 app.use("/formsg", formsgRouter.getRouter())
 app.use("/formsg", formsgSiteLaunchRouter.getRouter())
+app.use("/formsg", formsgSiteCloneRouter.getRouter())
 
 // catch unknown routes
 app.use((req, res, next) => {

--- a/src/server.js
+++ b/src/server.js
@@ -351,7 +351,11 @@ const authV2Router = new AuthRouter({
   statsMiddleware,
   sgidAuthRouter,
 })
-const formsgRouter = new FormsgRouter({ usersService, infraService })
+const formsgRouter = new FormsgRouter({
+  usersService,
+  infraService,
+  gitFileSystemService,
+})
 const formsgSiteLaunchRouter = new FormsgSiteLaunchRouter({
   usersService,
   infraService,


### PR DESCRIPTION
## Problem
See [here](https://isomeropengov.atlassian.net/browse/IS-558?atlOrigin=eyJpIjoiOTQyOTA0ZWIyZDNjNDhmYzhiYzJjMDgxZTY5ZjJmMTYiLCJwIjoiaiJ9)

## Solution
1. add an endpoint at `/formsg/clone-repo`
2. add handler to clone at that endpoint based on the [form's](https://form.gov.sg/6512935d3efe7a0012034f61) reply. The form has validation build in (email domain **must** be `.open.gov.sg` and **must** verify email + repo is a required field)

## New env vars
- `SITE_CLONE_FORM_KEY`: used to decrypt the form sg submissions (already added to 1PW on both `staging` and `prod` env vars; not yet added to `staging` EB yet)


## Notes
this was tested **locally** through updating the `EFS_VOL_PATH` + `originUrl` (use `https` instead of `ssh` as i was facing auth issues) and found working
![Screenshot 2023-09-26 at 7 01 04 PM](https://github.com/isomerpages/isomercms-backend/assets/44049504/a9747eb3-10ba-4e39-9633-11c6d9d65cd9)
![Screenshot 2023-09-26 at 7 01 37 PM](https://github.com/isomerpages/isomercms-backend/assets/44049504/4d92b329-49de-4b06-993f-bacc466859d9)

