### PR TITLE
feat: add ability to update repo state for GGS

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -40,6 +40,7 @@ export const ISOMER_ADMIN_REPOS = [
   "isomercms-backend",
   "isomercms-frontend",
   "isomer-redirection",
+  "isomer-indirection",
   "isomerpages-template",
   "isomer-conversion-scripts",
   "isomer-wysiwyg",
@@ -52,6 +53,11 @@ export const ISOMER_ADMIN_REPOS = [
   "ci-test",
   "infra",
   "markdown-helper",
+]
+export const ISOMER_E2E_TEST_REPOS = [
+  "e2e-test-repo",
+  "e2e-email-test-repo",
+  "e2e-notggs-test-repo",
 ]
 
 export const INACTIVE_USER_THRESHOLD_DAYS = 60

--- a/src/services/db/GitHubService.js
+++ b/src/services/db/GitHubService.js
@@ -455,10 +455,10 @@ class GitHubService {
     return newCommitSha
   }
 
-  async updateRepoState(sessionData, { commitSha }) {
+  async updateRepoState(sessionData, { commitSha, branchName = BRANCH_REF }) {
     const { accessToken } = sessionData
     const { siteName } = sessionData
-    const refEndpoint = `${siteName}/git/refs/heads/${BRANCH_REF}`
+    const refEndpoint = `${siteName}/git/refs/heads/${branchName}`
     const headers = {
       Authorization: `token ${accessToken}`,
     }

--- a/src/services/db/__tests__/GitHubService.spec.ts
+++ b/src/services/db/__tests__/GitHubService.spec.ts
@@ -897,6 +897,20 @@ describe("Github Service", () => {
         authHeader
       )
     })
+
+    it("should update a repo state for a non-standard branch correctly", async () => {
+      const branchName = "test-branch"
+      const branchRefEndpoint = `${siteName}/git/refs/heads/${branchName}`
+      await service.updateRepoState(sessionData, {
+        commitSha: sha,
+        branchName,
+      })
+      expect(mockAxiosInstance.patch).toHaveBeenCalledWith(
+        branchRefEndpoint,
+        { sha, force: true },
+        authHeader
+      )
+    })
   })
 
   describe("checkHasAccess", () => {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Part of IS-446.

## Solution

<!-- How did you solve the problem? -->

⚠️ **Most of the lines changed are due to reordering of lines, feel free to review commit-by-commit if you prefer** ⚠️ 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- The existing `updateRepoState` functionality has been enhanced such that it can also be used for Git repositories on the local file system (i.e. GGS). This is the first step required to allow E2E test repos to be reset on the local file system.

**Improvements**:

- The `isomer-indirection` repository was not present in the list of admin repos, and has now been added.

## Tests

<!-- What tests should be run to confirm functionality? -->

Unit tests.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*