### PR TITLE
feat: add new admin endpoint to reset repository

### DIFF
--- a/src/routes/v2/authenticatedSites/__tests__/RepoManagement.spec.ts
+++ b/src/routes/v2/authenticatedSites/__tests__/RepoManagement.spec.ts
@@ -1,0 +1,116 @@
+import express from "express"
+import { errAsync, okAsync } from "neverthrow"
+import request from "supertest"
+
+import { BadRequestError } from "@errors/BadRequestError"
+import { ForbiddenError } from "@errors/ForbiddenError"
+import GitFileSystemError from "@errors/GitFileSystemError"
+import GitHubApiError from "@errors/GitHubApiError"
+
+import { AuthorizationMiddleware } from "@middleware/authorization"
+import { attachReadRouteHandlerWrapper } from "@middleware/routeHandler"
+
+import {
+  generateRouter,
+  generateRouterForDefaultUserWithSite,
+} from "@fixtures/app"
+import RepoManagementService from "@services/admin/RepoManagementService"
+
+import { RepoManagementRouter } from "../repoManagement"
+
+describe("RepoManagementRouter", () => {
+  const mockRepoManagementService = {
+    resetRepo: jest.fn(),
+  }
+
+  const mockAuthorizationMiddleware = {
+    verifySiteAdmin: jest.fn(),
+  }
+
+  const router = new RepoManagementRouter({
+    repoManagementService: (mockRepoManagementService as unknown) as RepoManagementService,
+    authorizationMiddleware: (mockAuthorizationMiddleware as unknown) as AuthorizationMiddleware,
+  })
+
+  const subrouter = express()
+  // We can use read route handler here because we don't need to lock the repo
+  subrouter.post("/resetRepo", attachReadRouteHandlerWrapper(router.resetRepo))
+
+  const app = generateRouter(subrouter)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("resetRepo", () => {
+    it("should return 200 if repo was successfully reset", async () => {
+      mockRepoManagementService.resetRepo.mockReturnValueOnce(
+        okAsync(undefined)
+      )
+
+      const response = await request(app).post("/resetRepo").send({
+        branchName: "branch-name",
+        commitSha: "commit-sha",
+      })
+
+      expect(response.status).toBe(200)
+      expect(mockRepoManagementService.resetRepo).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 400 if a BadRequestError is received", async () => {
+      mockRepoManagementService.resetRepo.mockReturnValueOnce(
+        errAsync(new BadRequestError("error"))
+      )
+
+      const response = await request(app).post("/resetRepo").send({
+        branchName: "branch-name",
+        commitSha: "commit-sha",
+      })
+
+      expect(response.status).toBe(400)
+      expect(mockRepoManagementService.resetRepo).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 403 if a ForbiddenError is received", async () => {
+      mockRepoManagementService.resetRepo.mockReturnValueOnce(
+        errAsync(new ForbiddenError())
+      )
+
+      const response = await request(app).post("/resetRepo").send({
+        branchName: "branch-name",
+        commitSha: "commit-sha",
+      })
+
+      expect(response.status).toBe(403)
+      expect(mockRepoManagementService.resetRepo).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 500 if a GitFileSystemError is received", async () => {
+      mockRepoManagementService.resetRepo.mockReturnValueOnce(
+        errAsync(new GitFileSystemError("error"))
+      )
+
+      const response = await request(app).post("/resetRepo").send({
+        branchName: "branch-name",
+        commitSha: "commit-sha",
+      })
+
+      expect(response.status).toBe(500)
+      expect(mockRepoManagementService.resetRepo).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return 502 if a GitHubApiError error is received", async () => {
+      mockRepoManagementService.resetRepo.mockReturnValueOnce(
+        errAsync(new GitHubApiError("error"))
+      )
+
+      const response = await request(app).post("/resetRepo").send({
+        branchName: "branch-name",
+        commitSha: "commit-sha",
+      })
+
+      expect(response.status).toBe(502)
+      expect(mockRepoManagementService.resetRepo).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/routes/v2/authenticatedSites/index.js
+++ b/src/routes/v2/authenticatedSites/index.js
@@ -16,6 +16,9 @@ const {
 const { MediaFilesRouter } = require("@routes/v2/authenticatedSites/mediaFiles")
 const { NavigationRouter } = require("@routes/v2/authenticatedSites/navigation")
 const {
+  RepoManagementRouter,
+} = require("@routes/v2/authenticatedSites/repoManagement")
+const {
   ResourceCategoriesRouter,
 } = require("@routes/v2/authenticatedSites/resourceCategories")
 const {
@@ -92,6 +95,7 @@ const getAuthenticatedSitesSubrouter = ({
   notificationOnEditHandler,
   sitesService,
   deploymentsService,
+  repoManagementService,
 }) => {
   const collectionYmlService = new CollectionYmlService({ gitHubService })
   const homepagePageService = new HomepagePageService({ gitHubService })
@@ -196,6 +200,10 @@ const getAuthenticatedSitesSubrouter = ({
   const navigationV2Router = new NavigationRouter({
     navigationYmlService: navYmlService,
   })
+  const repoManagementV2Router = new RepoManagementRouter({
+    repoManagementService,
+    authorizationMiddleware,
+  })
 
   const authenticatedSitesSubrouter = express.Router({ mergeParams: true })
 
@@ -236,6 +244,7 @@ const getAuthenticatedSitesSubrouter = ({
   authenticatedSitesSubrouter.use("/contactUs", contactUsV2Router.getRouter())
   authenticatedSitesSubrouter.use("/homepage", homepageV2Router.getRouter())
   authenticatedSitesSubrouter.use("/settings", settingsV2Router.getRouter())
+  authenticatedSitesSubrouter.use("/admin", repoManagementV2Router.getRouter())
   authenticatedSitesSubrouter.use(notificationOnEditHandler.createNotification)
 
   return authenticatedSitesSubrouter

--- a/src/routes/v2/authenticatedSites/repoManagement.ts
+++ b/src/routes/v2/authenticatedSites/repoManagement.ts
@@ -1,0 +1,71 @@
+import autoBind from "auto-bind"
+import express from "express"
+
+import { BadRequestError } from "@errors/BadRequestError"
+import { ForbiddenError } from "@errors/ForbiddenError"
+
+import { AuthorizationMiddleware } from "@middleware/authorization"
+import { attachWriteRouteHandlerWrapper } from "@middleware/routeHandler"
+
+import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
+import GitFileSystemError from "@root/errors/GitFileSystemError"
+import { attachSiteHandler } from "@root/middleware"
+import type { RequestHandler } from "@root/types"
+import RepoManagementService from "@services/admin/RepoManagementService"
+
+interface RepoManagementRouterProps {
+  repoManagementService: RepoManagementService
+  authorizationMiddleware: AuthorizationMiddleware
+}
+
+export class RepoManagementRouter {
+  private readonly repoManagementService
+
+  private readonly authorizationMiddleware
+
+  constructor({
+    repoManagementService,
+    authorizationMiddleware,
+  }: RepoManagementRouterProps) {
+    this.repoManagementService = repoManagementService
+    this.authorizationMiddleware = authorizationMiddleware
+    autoBind(this)
+  }
+
+  resetRepo: RequestHandler<
+    never,
+    void | { message: string },
+    { branchName: string; commitSha: string },
+    unknown,
+    { userWithSiteSessionData: UserWithSiteSessionData }
+  > = async (req, res) => {
+    const { userWithSiteSessionData } = res.locals
+    const { branchName, commitSha } = req.body
+
+    return this.repoManagementService
+      .resetRepo(userWithSiteSessionData, branchName, commitSha)
+      .map(() => res.status(200).send())
+      .mapErr((error) => {
+        if (error instanceof BadRequestError) {
+          return res.status(400).json({ message: error.message })
+        }
+        if (error instanceof ForbiddenError) {
+          return res.status(403).json({ message: error.message })
+        }
+        if (error instanceof GitFileSystemError) {
+          return res.status(500).json({ message: error.message })
+        }
+        return res.status(502).json({ message: error.message })
+      })
+  }
+
+  getRouter() {
+    const router = express.Router({ mergeParams: true })
+    router.use(attachSiteHandler)
+    router.use(this.authorizationMiddleware.verifySiteMember)
+
+    router.post("/resetRepo", attachWriteRouteHandlerWrapper(this.resetRepo))
+
+    return router
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -76,6 +76,7 @@ import getAuthenticatedSubrouter from "./routes/v2/authenticated"
 import { ReviewsRouter } from "./routes/v2/authenticated/review"
 import getAuthenticatedSitesSubrouter from "./routes/v2/authenticatedSites"
 import { SgidAuthRouter } from "./routes/v2/sgidAuth"
+import RepoManagementService from "./services/admin/RepoManagementService"
 import GitFileSystemService from "./services/db/GitFileSystemService"
 import RepoService from "./services/db/RepoService"
 import { PageService } from "./services/fileServices/MdPageServices/PageService"
@@ -165,6 +166,9 @@ const gitHubService = new RepoService(
   isomerRepoAxiosInstance,
   gitFileSystemService
 )
+const repoManagementService = new RepoManagementService({
+  repoService: gitHubService,
+})
 const configYmlService = new ConfigYmlService({ gitHubService })
 const footerYmlService = new FooterYmlService({ gitHubService })
 const collectionYmlService = new CollectionYmlService({ gitHubService })
@@ -338,6 +342,7 @@ const authenticatedSitesSubrouterV2 = getAuthenticatedSitesSubrouter({
   notificationOnEditHandler,
   sitesService,
   deploymentsService,
+  repoManagementService,
 })
 const sgidAuthRouter = new SgidAuthRouter({
   usersService,

--- a/src/services/admin/RepoManagementService.ts
+++ b/src/services/admin/RepoManagementService.ts
@@ -1,0 +1,53 @@
+import { ResultAsync, errAsync } from "neverthrow"
+
+import { BadRequestError } from "@errors/BadRequestError"
+import { ForbiddenError } from "@errors/ForbiddenError"
+import GitFileSystemError from "@errors/GitFileSystemError"
+import GitHubApiError from "@errors/GitHubApiError"
+
+import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
+import { ISOMER_E2E_TEST_REPOS } from "@root/constants"
+import RepoService from "@services/db/RepoService"
+
+interface RepoManagementServiceProps {
+  repoService: RepoService
+}
+
+class RepoManagementService {
+  private readonly repoService: RepoManagementServiceProps["repoService"]
+
+  constructor({ repoService }: RepoManagementServiceProps) {
+    this.repoService = repoService
+  }
+
+  resetRepo(
+    sessionData: UserWithSiteSessionData,
+    branchName: string,
+    commitSha: string
+  ): ResultAsync<
+    void,
+    ForbiddenError | BadRequestError | GitFileSystemError | GitHubApiError
+  > {
+    const { siteName } = sessionData
+
+    if (!ISOMER_E2E_TEST_REPOS.includes(siteName)) {
+      return errAsync(new ForbiddenError(`${siteName} is not an e2e test repo`))
+    }
+
+    return ResultAsync.fromPromise(
+      this.repoService.updateRepoState(sessionData, { commitSha, branchName }),
+      (error) => {
+        if (error instanceof BadRequestError) {
+          return new BadRequestError(error.message)
+        }
+        if (error instanceof GitFileSystemError) {
+          return new GitFileSystemError(error.message)
+        }
+
+        return new GitHubApiError(`Failed to reset repo to commit ${commitSha}`)
+      }
+    ).map(() => undefined)
+  }
+}
+
+export default RepoManagementService

--- a/src/services/admin/RepoManagementService.ts
+++ b/src/services/admin/RepoManagementService.ts
@@ -46,7 +46,7 @@ class RepoManagementService {
 
         return new GitHubApiError(`Failed to reset repo to commit ${commitSha}`)
       }
-    ).map(() => undefined)
+    )
   }
 }
 

--- a/src/services/admin/__tests__/RepoManagementService.spec.ts
+++ b/src/services/admin/__tests__/RepoManagementService.spec.ts
@@ -1,0 +1,60 @@
+import { ForbiddenError } from "@errors/ForbiddenError"
+
+import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
+import { ISOMER_E2E_TEST_REPOS } from "@root/constants"
+import _RepoManagementService from "@services/admin/RepoManagementService"
+import RepoService from "@services/db/RepoService"
+
+const MockRepoService = {
+  updateRepoState: jest.fn(),
+}
+
+const RepoManagementService = new _RepoManagementService({
+  repoService: (MockRepoService as unknown) as RepoService,
+})
+
+describe("RepoManagementService", () => {
+  // Prevent inter-test pollution of mocks
+  afterEach(() => jest.clearAllMocks())
+
+  describe("resetRepo", () => {
+    it("should reset an e2e test repo successfully", async () => {
+      const mockSessionData = new UserWithSiteSessionData({
+        githubId: "githubId",
+        accessToken: "accessToken",
+        isomerUserId: "isomerUserId",
+        email: "email",
+        siteName: ISOMER_E2E_TEST_REPOS[0],
+      })
+      MockRepoService.updateRepoState.mockResolvedValueOnce(undefined)
+
+      await RepoManagementService.resetRepo(
+        mockSessionData,
+        "branchName",
+        "commitSha"
+      )
+
+      expect(MockRepoService.updateRepoState).toHaveBeenCalledTimes(1)
+    })
+
+    it("should not reset a non-e2e test repo", async () => {
+      const mockSessionData = new UserWithSiteSessionData({
+        githubId: "githubId",
+        accessToken: "accessToken",
+        isomerUserId: "isomerUserId",
+        email: "email",
+        siteName: "some-other-site",
+      })
+
+      const result = await RepoManagementService.resetRepo(
+        mockSessionData,
+        "branchName",
+        "commitSha"
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ForbiddenError)
+      expect(MockRepoService.updateRepoState).toHaveBeenCalledTimes(0)
+    })
+  })
+})

--- a/src/services/middlewareServices/AuthenticationMiddlewareService.ts
+++ b/src/services/middlewareServices/AuthenticationMiddlewareService.ts
@@ -28,6 +28,7 @@ export const E2E_EMAIL_TEST_SITE = {
   name: "e2e email test site",
   repo: "e2e-email-test-repo",
 }
+export const E2E_NOTGGS_TEST_REPO = "e2e-notggs-test-repo"
 const E2E_TEST_SECRET = config.get("cypress.e2eTestSecret")
 
 export const E2E_TEST_GH_TOKEN = config.get("cypress.e2eTestGithubToken")
@@ -190,7 +191,8 @@ export default class AuthenticationMiddlewareService {
       (userType === E2E_USERS.Email.Admin ||
         userType === E2E_USERS.Email.Collaborator)
     const isGithubE2eAccess =
-      repo === E2E_TEST_REPO && userType === "Github user"
+      (repo === E2E_TEST_REPO || repo === E2E_NOTGGS_TEST_REPO) &&
+      userType === "Github user"
 
     if (!isGithubE2eAccess && !isEmailE2eAccess)
       throw new AuthError(

--- a/src/services/middlewareServices/AuthenticationMiddlewareService.ts
+++ b/src/services/middlewareServices/AuthenticationMiddlewareService.ts
@@ -28,7 +28,7 @@ export const E2E_EMAIL_TEST_SITE = {
   name: "e2e email test site",
   repo: "e2e-email-test-repo",
 }
-export const E2E_NOTGGS_TEST_REPO = "e2e-notggs-test-repo"
+export const E2E_NOT_GGS_TEST_REPO = "e2e-notggs-test-repo"
 const E2E_TEST_SECRET = config.get("cypress.e2eTestSecret")
 
 export const E2E_TEST_GH_TOKEN = config.get("cypress.e2eTestGithubToken")
@@ -191,7 +191,7 @@ export default class AuthenticationMiddlewareService {
       (userType === E2E_USERS.Email.Admin ||
         userType === E2E_USERS.Email.Collaborator)
     const isGithubE2eAccess =
-      (repo === E2E_TEST_REPO || repo === E2E_NOTGGS_TEST_REPO) &&
+      (repo === E2E_TEST_REPO || repo === E2E_NOT_GGS_TEST_REPO) &&
       userType === "Github user"
 
     if (!isGithubE2eAccess && !isEmailE2eAccess)

--- a/src/utils/mutex-utils.js
+++ b/src/utils/mutex-utils.js
@@ -12,7 +12,11 @@ const NODE_ENV = config.get("env")
 const MUTEX_TABLE_NAME = config.get("mutexTableName")
 
 const IS_DEV = NODE_ENV === "dev" || NODE_ENV === "test" || NODE_ENV === "vapt"
-const E2E_TEST_REPOS = ["e2e-email-test-repo", "e2e-test-repo"]
+const E2E_TEST_REPOS = [
+  "e2e-email-test-repo",
+  "e2e-test-repo",
+  "e2e-notggs-test-repo",
+]
 const mockMutexObj = {}
 
 // Dynamodb constants


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Part of IS-446.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- A new endpoint `/v2/sites/:siteName/admin/resetRepo` has been added to allow for e2e test repos to be easily reset to the specified commit.
    - If the repository is GGS-whitelisted, it will execute the Git commands on the local file system (`git reset --hard` and `git push -f origin`). It also checks beforehand that the commit exists, otherwise a 400 error is returned.
    - If the repository is not GGS-whitelisted, it will call an existing GitHub endpoint to update the repo state, which is an existing functionality used on the frontend to reset repos. GitHub automatically checks if the commit exists and will reject if it does not, but we return a 502 error as we cannot differentiate between this issue vs GitHub-related issues.

**Further notes**

This endpoint is located in a new `admin/` folder to lay the foundations for future admin-related endpoints and hopefully we can move towards having an admin dashboard.

## Tests

<!-- What tests should be run to confirm functionality? -->

Unit tests.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*