### PR TITLE
docs(pr-template): add checkbox for ssm and 1pw for env var

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,6 +50,7 @@ Closes [insert issue #]
 **New environment variables**:
 
 - `env var` : env var details
+    - [ ] added env var to 1PW + SSM script (`fetch_ssm_parameters.sh`)
 
 **New scripts**:
 


### PR DESCRIPTION
## Problem
Env vars are required in quite a few places but we have to remember this manually. This PR updates the PR template so there's a reminder

## Solution
Update PR template to have check for env var to add to 1pw + ssm