### PR TITLE
fix(contactus): allow location section to be empty but not contact information

### DIFF
--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -19,22 +19,20 @@ const UpdateContactUsSchema = Joi.object({
       permalink: Joi.string().required(),
       feedback: Joi.string().allow(""),
       agency_name: Joi.string().required(),
-      locations: Joi.array()
-        .items(
-          Joi.object({
-            address: Joi.array().items(Joi.string().allow("")),
-            operating_hours: Joi.array().items(
-              Joi.object({
-                days: Joi.string().allow(""),
-                time: Joi.string().allow(""),
-                description: Joi.string().allow(""),
-              })
-            ),
-            maps_link: Joi.string().allow(""),
-            title: Joi.string().allow(""),
-          })
-        )
-        .required(),
+      locations: Joi.array().items(
+        Joi.object({
+          address: Joi.array().items(Joi.string().allow("")),
+          operating_hours: Joi.array().items(
+            Joi.object({
+              days: Joi.string().allow(""),
+              time: Joi.string().allow(""),
+              description: Joi.string().allow(""),
+            })
+          ),
+          maps_link: Joi.string().allow(""),
+          title: Joi.string().allow(""),
+        })
+      ),
       contacts: Joi.array()
         .items(
           Joi.object({


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes IS-471.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- The location section of the contact us frontmatter is now optional. Code changes are mostly just indentation, except for the last line where the `required()` part is removed.

## Tests

<!-- What tests should be run to confirm functionality? -->

Testable only with frontend.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*