### PR TITLE
refactor(ff): make site launch flag a bool flag

### DIFF
--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -1,5 +1,4 @@
 export const FEATURE_FLAGS = {
-  GGS_WHITELISTED_REPOS: "ggs_whitelisted_repos",
   IS_BUILD_TIMES_REDUCTION_ENABLED: "is_build_times_reduction_enabled",
   IS_GGS_ENABLED: "is_ggs_enabled",
 } as const

--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -1,4 +1,5 @@
 export const FEATURE_FLAGS = {
   GGS_WHITELISTED_REPOS: "ggs_whitelisted_repos",
   IS_BUILD_TIMES_REDUCTION_ENABLED: "is_build_times_reduction_enabled",
+  IS_GGS_WHITELISTED: "is_ggs_whitelisted",
 } as const

--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -1,5 +1,5 @@
 export const FEATURE_FLAGS = {
   GGS_WHITELISTED_REPOS: "ggs_whitelisted_repos",
   IS_BUILD_TIMES_REDUCTION_ENABLED: "is_build_times_reduction_enabled",
-  IS_GGS_WHITELISTED: "is_ggs_whitelisted",
+  IS_GGS_ENABLED: "is_ggs_enabled",
 } as const

--- a/src/middleware/routeHandler.js
+++ b/src/middleware/routeHandler.js
@@ -104,7 +104,7 @@ const attachRollbackRouteHandlerWrapper = (routeHandler) => async (
   const { growthbook } = req
 
   const shouldUseGitFileSystem = !!growthbook?.getFeatureValue(
-    FEATURE_FLAGS.IS_GGS_WHITELISTED,
+    FEATURE_FLAGS.IS_GGS_ENABLED,
     false
   )
 

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -101,13 +101,14 @@ export default class RepoService extends GitHubService {
     ggsWhitelistedRepos: string[]
   ): boolean {
     // TODO: Adding for initial debugging if required. Remove once stabilised
-    logger.info(
-      `Evaluating if ${repoName} is GGS whitelisted: ${ggsWhitelistedRepos.includes(
-        repoName
-      )}`
+    logger.info(`Evaluating if ${repoName} is GGS whitelisted.`)
+    // NOTE: Growthbook has to be optional
+    // as we cannot guarantee its presence on `sessionData`.
+    // It is present iff there is a `siteHandler` attached.
+    return !!growthbook?.getFeatureValue(
+      FEATURE_FLAGS.IS_GGS_WHITELISTED,
+      false
     )
-
-    return ggsWhitelistedRepos.includes(repoName)
   }
 
   getCommitDiff(siteName: string, base?: string, head?: string) {

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -84,33 +84,6 @@ export default class RepoService extends GitHubService {
     this.githubCommitService = gitHubCommitService
   }
 
-  getGgsWhitelistedRepos(
-    growthbook: GrowthBook<FeatureFlags> | undefined
-  ): string[] {
-    if (!growthbook) return []
-
-    const whitelistedGgsRepos = growthbook.getFeatureValue(
-      FEATURE_FLAGS.GGS_WHITELISTED_REPOS,
-      { repos: [] }
-    )
-    return whitelistedGgsRepos.repos
-  }
-
-  isRepoGgsWhitelisted(
-    repoName: string,
-    ggsWhitelistedRepos: string[]
-  ): boolean {
-    // TODO: Adding for initial debugging if required. Remove once stabilised
-    logger.info(`Evaluating if ${repoName} is GGS whitelisted.`)
-    // NOTE: Growthbook has to be optional
-    // as we cannot guarantee its presence on `sessionData`.
-    // It is present iff there is a `siteHandler` attached.
-    return !!growthbook?.getFeatureValue(
-      FEATURE_FLAGS.IS_GGS_WHITELISTED,
-      false
-    )
-  }
-
   getCommitDiff(siteName: string, base?: string, head?: string) {
     return ReviewApi.getCommitDiff(siteName, base, head)
   }
@@ -203,9 +176,9 @@ export default class RepoService extends GitHubService {
     }
   ): Promise<{ sha: string }> {
     if (
-      this.isRepoGgsWhitelisted(
-        sessionData.siteName,
-        this.getGgsWhitelistedRepos(sessionData.growthbook)
+      sessionData.growthbook?.getFeatureValue(
+        FEATURE_FLAGS.IS_GGS_ENABLED,
+        false
       )
     ) {
       logger.info(
@@ -232,9 +205,9 @@ export default class RepoService extends GitHubService {
     { fileName, directoryName }: { fileName: string; directoryName?: string }
   ): Promise<GitFile> {
     if (
-      this.isRepoGgsWhitelisted(
-        sessionData.siteName,
-        this.getGgsWhitelistedRepos(sessionData.growthbook)
+      sessionData.growthbook?.getFeatureValue(
+        FEATURE_FLAGS.IS_GGS_ENABLED,
+        false
       )
     ) {
       logger.info("Reading file from local Git file system")
@@ -267,9 +240,9 @@ export default class RepoService extends GitHubService {
 
     // fetch from local disk
     if (
-      this.isRepoGgsWhitelisted(
-        siteName,
-        this.getGgsWhitelistedRepos(sessionData.growthbook)
+      sessionData.growthbook?.getFeatureValue(
+        FEATURE_FLAGS.IS_GGS_ENABLED,
+        false
       )
     ) {
       logger.info(
@@ -313,9 +286,9 @@ export default class RepoService extends GitHubService {
   ): Promise<GitDirectoryItem[]> {
     const defaultBranch = STAGING_BRANCH
     if (
-      this.isRepoGgsWhitelisted(
-        sessionData.siteName,
-        this.getGgsWhitelistedRepos(sessionData.growthbook)
+      sessionData.growthbook?.getFeatureValue(
+        FEATURE_FLAGS.IS_GGS_ENABLED,
+        false
       )
     ) {
       logger.info("Reading directory from local Git file system")
@@ -356,9 +329,9 @@ export default class RepoService extends GitHubService {
     let dirContent: GitDirectoryItem[] = []
 
     if (
-      this.isRepoGgsWhitelisted(
-        siteName,
-        this.getGgsWhitelistedRepos(sessionData.growthbook)
+      sessionData.growthbook?.getFeatureValue(
+        FEATURE_FLAGS.IS_GGS_ENABLED,
+        false
       )
     ) {
       const result = await this.gitFileSystemService.listDirectoryContents(
@@ -409,9 +382,9 @@ export default class RepoService extends GitHubService {
     }
   ): Promise<GitCommitResult> {
     if (
-      this.isRepoGgsWhitelisted(
-        sessionData.siteName,
-        this.getGgsWhitelistedRepos(sessionData.growthbook)
+      sessionData.growthbook?.getFeatureValue(
+        FEATURE_FLAGS.IS_GGS_ENABLED,
+        false
       )
     ) {
       return this.gitFileCommitService.update(sessionData, {
@@ -443,9 +416,9 @@ export default class RepoService extends GitHubService {
     }
   ): Promise<void> {
     if (
-      this.isRepoGgsWhitelisted(
-        sessionData.siteName,
-        this.getGgsWhitelistedRepos(sessionData.growthbook)
+      sessionData.growthbook?.getFeatureValue(
+        FEATURE_FLAGS.IS_GGS_ENABLED,
+        false
       )
     ) {
       await this.gitFileCommitService.deleteDirectory(sessionData, {
@@ -475,9 +448,9 @@ export default class RepoService extends GitHubService {
     }
   ): Promise<void> {
     if (
-      this.isRepoGgsWhitelisted(
-        sessionData.siteName,
-        this.getGgsWhitelistedRepos(sessionData.growthbook)
+      sessionData.growthbook?.getFeatureValue(
+        FEATURE_FLAGS.IS_GGS_ENABLED,
+        false
       )
     ) {
       await this.gitFileCommitService.delete(sessionData, {
@@ -504,9 +477,9 @@ export default class RepoService extends GitHubService {
     message?: string
   ): Promise<GitCommitResult> {
     if (
-      this.isRepoGgsWhitelisted(
-        sessionData.siteName,
-        this.getGgsWhitelistedRepos(sessionData.growthbook)
+      sessionData.growthbook?.getFeatureValue(
+        FEATURE_FLAGS.IS_GGS_ENABLED,
+        false
       )
     ) {
       return this.gitFileCommitService.renameSinglePath(
@@ -535,9 +508,9 @@ export default class RepoService extends GitHubService {
     message?: string
   ): Promise<GitCommitResult> {
     if (
-      this.isRepoGgsWhitelisted(
-        sessionData.siteName,
-        this.getGgsWhitelistedRepos(sessionData.growthbook)
+      sessionData.growthbook?.getFeatureValue(
+        FEATURE_FLAGS.IS_GGS_ENABLED,
+        false
       )
     ) {
       return this.gitFileCommitService.moveFiles(
@@ -574,9 +547,9 @@ export default class RepoService extends GitHubService {
   ): Promise<GitHubCommitData> {
     const { siteName } = sessionData
     if (
-      this.isRepoGgsWhitelisted(
-        siteName,
-        this.getGgsWhitelistedRepos(sessionData.growthbook)
+      sessionData.growthbook?.getFeatureValue(
+        FEATURE_FLAGS.IS_GGS_ENABLED,
+        false
       )
     ) {
       logger.info(
@@ -630,9 +603,9 @@ export default class RepoService extends GitHubService {
   ): Promise<void> {
     const { siteName } = sessionData
     if (
-      this.isRepoGgsWhitelisted(
-        siteName,
-        this.getGgsWhitelistedRepos(sessionData.growthbook)
+      sessionData.growthbook?.getFeatureValue(
+        FEATURE_FLAGS.IS_GGS_ENABLED,
+        false
       )
     ) {
       logger.info(

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -88,6 +88,9 @@ describe("RepoService", () => {
           repos: ["fake-repo", mockSiteName],
         },
       },
+      is_ggs_whitelisted: {
+        defaultValue: true,
+      },
     })
   })
 
@@ -110,13 +113,18 @@ describe("RepoService", () => {
       expect(actual2).toBe(true)
     })
 
-    it("should indicate non-whitelisted repos as non-whitelisted correctly", () => {
+    it("should indicate blacklisted repos as not being allowed", () => {
+      // NOTE: Mock a blacklisted repo
+      const gbSpy = jest.spyOn(mockGrowthBook, "getFeatureValue")
+      gbSpy.mockReturnValueOnce(false)
+
       const actual = RepoService.isRepoGgsWhitelisted(
         "not-whitelisted",
         RepoService.getGgsWhitelistedRepos(
           mockUserWithSiteSessionDataAndGrowthBook.growthbook
         )
       )
+
       expect(actual).toBe(false)
     })
   })

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -75,22 +75,24 @@ const RepoService = new _RepoService({
 })
 
 describe("RepoService", () => {
+  const gbSpy = jest.spyOn(mockGrowthBook, "getFeatureValue")
+
   // Prevent inter-test pollution of mocks
   afterEach(() => {
     jest.clearAllMocks()
   })
 
-  // load whitelisted sites into growthbook
+  // load ggs enabled sites into growthbook
   beforeAll(() => {
     mockGrowthBook.setFeatures({
-      is_ggs_whitelisted: {
+      is_ggs_enabled: {
         defaultValue: true,
       },
     })
   })
 
   describe("create", () => {
-    it("should create using the local Git file system using utf-8 for non-media files if the repo is whitelisted", async () => {
+    it("should create using the local Git file system using utf-8 for non-media files if the repo is ggs enabled", async () => {
       const returnedSha = "test-sha"
       const mockContent = "content"
       const mockFileName = "test.md"
@@ -101,6 +103,7 @@ describe("RepoService", () => {
       const expected = {
         sha: returnedSha,
       }
+      gbSpy.mockReturnValueOnce(true)
       MockGitFileCommitService.create.mockResolvedValueOnce(createOutput)
       const isMedia = false
       const actual = await RepoService.create(
@@ -125,7 +128,7 @@ describe("RepoService", () => {
       )
     })
 
-    it("should create using the local Git file system using base64 for media files if the repo is whitelisted", async () => {
+    it("should create using the local Git file system using base64 for media files if the repo is ggs enabled", async () => {
       const returnedSha = "test-sha"
       const mockContent = "content"
       const mockFileName = "test.md"
@@ -136,6 +139,7 @@ describe("RepoService", () => {
       const expected = {
         sha: returnedSha,
       }
+      gbSpy.mockReturnValueOnce(true)
       MockGitFileCommitService.create.mockResolvedValueOnce(createOutput)
 
       const actual = await RepoService.create(
@@ -160,7 +164,7 @@ describe("RepoService", () => {
       )
     })
 
-    it("should create files on GitHub directly if the repo is not whitelisted", async () => {
+    it("should create files on GitHub directly if the repo is not ggs enabled", async () => {
       const mockContent = "content"
       const mockFileName = "test.md"
       const mockDirectoryName = ""
@@ -195,11 +199,12 @@ describe("RepoService", () => {
   })
 
   describe("read", () => {
-    it("should read from the local Git file system if the repo is whitelisted", async () => {
+    it("should read from the local Git file system if the repo is ggs enabled", async () => {
       const expected: GitFile = {
         content: "test content",
         sha: "test-sha",
       }
+      gbSpy.mockReturnValueOnce(true)
       MockGitFileSystemService.read.mockResolvedValueOnce(okAsync(expected))
 
       const actual = await RepoService.read(
@@ -213,7 +218,7 @@ describe("RepoService", () => {
       expect(actual).toEqual(expected)
     })
 
-    it("should read from GitHub directly if the repo is not whitelisted", async () => {
+    it("should read from GitHub directly if the repo is ggs enabled", async () => {
       const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
         githubId: mockGithubId,
         accessToken: mockAccessToken,
@@ -225,6 +230,7 @@ describe("RepoService", () => {
         content: "test content",
         sha: "test-sha",
       }
+      gbSpy.mockReturnValueOnce(true)
       const gitHubServiceRead = jest.spyOn(GitHubService.prototype, "read")
       gitHubServiceRead.mockResolvedValueOnce(expected)
 
@@ -238,7 +244,7 @@ describe("RepoService", () => {
   })
 
   describe("readMediaFile", () => {
-    it("should read image from the local Git file system for whitelisted repos", async () => {
+    it("should read image from the local Git file system for ggs enabled repos", async () => {
       const expected: MediaFileOutput = {
         name: "test content",
         sha: "test-sha",
@@ -246,6 +252,7 @@ describe("RepoService", () => {
         mediaPath: "images/test-img.jpeg",
         type: "image" as ItemType,
       }
+      gbSpy.mockReturnValueOnce(true)
       MockGitFileSystemService.readMediaFile.mockResolvedValueOnce(
         okAsync(expected)
       )
@@ -261,7 +268,7 @@ describe("RepoService", () => {
       expect(actual).toEqual(expected)
     })
 
-    it("should read image from GitHub for whitelisted repos", async () => {
+    it("should read image from GitHub for ggs enabled repos", async () => {
       const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
         githubId: mockGithubId,
         accessToken: mockAccessToken,
@@ -313,7 +320,7 @@ describe("RepoService", () => {
   })
 
   describe("readDirectory", () => {
-    it("should read from the local Git file system if the repo is whitelisted", async () => {
+    it("should read from the local Git file system if the repo is ggs enabled", async () => {
       const expected: GitDirectoryItem[] = [
         {
           name: "fake-file.md",
@@ -337,6 +344,7 @@ describe("RepoService", () => {
           size: 0,
         },
       ]
+      gbSpy.mockReturnValueOnce(true)
       MockGitFileSystemService.listDirectoryContents.mockResolvedValueOnce(
         okAsync(expected)
       )
@@ -351,7 +359,7 @@ describe("RepoService", () => {
       expect(actual).toEqual(expected)
     })
 
-    it("should read from GitHub directly if the repo is not whitelisted", async () => {
+    it("should read from GitHub directly if the repo is not ggs enabled", async () => {
       const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
         githubId: mockGithubId,
         accessToken: mockAccessToken,
@@ -398,7 +406,7 @@ describe("RepoService", () => {
 
   //! TODO: fix this test, commented out for now as code changes did not change this method
   // describe("readMediaDirectory", () => {
-  //   it("should return an array of files and directories from disk if repo is whitelisted", async () => {
+  //   it("should return an array of files and directories from disk if repo is ggs enabled", async () => {
   //     const image: MediaFileOutput = {
   //       name: "image-name",
   //       sha: "test-sha",
@@ -442,7 +450,7 @@ describe("RepoService", () => {
   //     expect(actual).toEqual(expected)
   //   })
 
-  //   it("should return an array of files and directories from GitHub if repo is not whitelisted", async () => {
+  //   it("should return an array of files and directories from GitHub if repo is not ggs enabled", async () => {
   //     const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
   //       githubId: mockGithubId,
   //       accessToken: mockAccessToken,
@@ -515,7 +523,7 @@ describe("RepoService", () => {
   // })
 
   describe("update", () => {
-    it("should update the local Git file system if the repo is whitelisted", async () => {
+    it("should update the local Git file system if the repo is ggs enabled", async () => {
       const expected: GitCommitResult = { newSha: "fake-commit-sha" }
       MockGitFileCommitService.update.mockResolvedValueOnce(expected)
 
@@ -532,7 +540,7 @@ describe("RepoService", () => {
       expect(actual).toEqual(expected)
     })
 
-    it("should update GitHub directly if the repo is not whitelisted", async () => {
+    it("should update GitHub directly if the repo is not ggs enabled", async () => {
       const expectedSha = "fake-commit-sha"
       const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
         githubId: mockGithubId,
@@ -557,10 +565,11 @@ describe("RepoService", () => {
   })
 
   describe("delete", () => {
-    it("should delete a file from Git file system when repo is whitelisted", async () => {
+    it("should delete a file from Git file system when repo is ggs enabled", async () => {
       MockGitFileCommitService.delete.mockResolvedValueOnce(
         okAsync("some-fake-sha")
       )
+      gbSpy.mockReturnValueOnce(true)
 
       await RepoService.delete(mockUserWithSiteSessionDataAndGrowthBook, {
         sha: "fake-original-sha",
@@ -579,7 +588,7 @@ describe("RepoService", () => {
       )
     })
 
-    it("should delete a file from GitHub when repo is not whitelisted", async () => {
+    it("should delete a file from GitHub when repo is not ggs enabled", async () => {
       const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
         githubId: mockGithubId,
         accessToken: mockAccessToken,
@@ -604,9 +613,10 @@ describe("RepoService", () => {
   })
 
   describe("renameSinglePath", () => {
-    it("should rename using the local Git file system if the repo is whitelisted", async () => {
+    it("should rename using the local Git file system if the repo is ggs enabled", async () => {
       const expected: GitCommitResult = { newSha: "fake-commit-sha" }
       MockGitFileCommitService.renameSinglePath.mockResolvedValueOnce(expected)
+      gbSpy.mockReturnValueOnce(true)
 
       const actual = await RepoService.renameSinglePath(
         mockUserWithSiteSessionDataAndGrowthBook,
@@ -619,7 +629,7 @@ describe("RepoService", () => {
       expect(actual).toEqual(expected)
     })
 
-    it("should rename file using GitHub directly if the repo is not whitelisted", async () => {
+    it("should rename file using GitHub directly if the repo is not ggs enabled", async () => {
       const expectedSha = "fake-commit-sha"
       const fakeCommitMessage = "fake-commit-message"
       const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
@@ -647,9 +657,10 @@ describe("RepoService", () => {
   })
 
   describe("moveFiles", () => {
-    it("should move files using the Git local file system if the repo is whitelisted", async () => {
+    it("should move files using the Git local file system if the repo is ggs enabled", async () => {
       const expected = { newSha: "fake-commit-sha" }
       MockGitFileCommitService.moveFiles.mockResolvedValueOnce(expected)
+      gbSpy.mockReturnValueOnce(true)
       // MockCommitServiceGitFile.push.mockReturnValueOnce(undefined)
 
       const actual = await RepoService.moveFiles(
@@ -664,7 +675,7 @@ describe("RepoService", () => {
       expect(actual).toEqual(expected)
     })
 
-    it("should move files using GitHub directly if the repo is not whitelisted", async () => {
+    it("should move files using GitHub directly if the repo is not ggs enabled", async () => {
       const expected = { newSha: "fake-commit-sha" }
       const fakeCommitMessage = "fake-commit-message"
       const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
@@ -691,7 +702,7 @@ describe("RepoService", () => {
   })
 
   describe("getLatestCommitOfBranch", () => {
-    it("should read the latest commit data from the local Git file system if the repo is whitelisted", async () => {
+    it("should read the latest commit data from the local Git file system if the repo is ggs enabled", async () => {
       const expected: GitHubCommitData = {
         author: {
           name: "test author",
@@ -701,6 +712,7 @@ describe("RepoService", () => {
         sha: "test-sha",
         message: "test message",
       }
+      gbSpy.mockReturnValueOnce(true)
       MockGitFileSystemService.getLatestCommitOfBranch.mockResolvedValueOnce(
         okAsync(expected)
       )
@@ -712,7 +724,7 @@ describe("RepoService", () => {
       expect(actual).toEqual(expected)
     })
 
-    it("should read latest commit data from GitHub if the repo is not whitelisted", async () => {
+    it("should read latest commit data from GitHub if the repo is not ggs enabled", async () => {
       const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
         githubId: mockGithubId,
         accessToken: mockAccessToken,
@@ -742,10 +754,11 @@ describe("RepoService", () => {
   })
 
   describe("updateRepoState", () => {
-    it("should update the repo state on the local Git file system if the repo is whitelisted", async () => {
+    it("should update the repo state on the local Git file system if the repo is ggs enabled", async () => {
       MockGitFileSystemService.updateRepoState.mockResolvedValueOnce(
         okAsync(undefined)
       )
+      gbSpy.mockReturnValueOnce(true)
 
       await RepoService.updateRepoState(
         mockUserWithSiteSessionDataAndGrowthBook,
@@ -758,7 +771,7 @@ describe("RepoService", () => {
       expect(MockGitFileSystemService.updateRepoState).toBeCalledTimes(1)
     })
 
-    it("should update the repo state on GitHub if the repo is not whitelisted", async () => {
+    it("should update the repo state on GitHub if the repo is not ggs enabled", async () => {
       const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
         githubId: mockGithubId,
         accessToken: mockAccessToken,

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -83,49 +83,9 @@ describe("RepoService", () => {
   // load whitelisted sites into growthbook
   beforeAll(() => {
     mockGrowthBook.setFeatures({
-      ggs_whitelisted_repos: {
-        defaultValue: {
-          repos: ["fake-repo", mockSiteName],
-        },
-      },
       is_ggs_whitelisted: {
         defaultValue: true,
       },
-    })
-  })
-
-  describe("isRepoWhitelisted", () => {
-    it("should indicate whitelisted repos as whitelisted correctly", () => {
-      const actual1 = RepoService.isRepoGgsWhitelisted(
-        "fake-repo",
-        RepoService.getGgsWhitelistedRepos(
-          mockUserWithSiteSessionDataAndGrowthBook.growthbook
-        )
-      )
-      expect(actual1).toBe(true)
-
-      const actual2 = RepoService.isRepoGgsWhitelisted(
-        mockSiteName,
-        RepoService.getGgsWhitelistedRepos(
-          mockUserWithSiteSessionDataAndGrowthBook.growthbook
-        )
-      )
-      expect(actual2).toBe(true)
-    })
-
-    it("should indicate blacklisted repos as not being allowed", () => {
-      // NOTE: Mock a blacklisted repo
-      const gbSpy = jest.spyOn(mockGrowthBook, "getFeatureValue")
-      gbSpy.mockReturnValueOnce(false)
-
-      const actual = RepoService.isRepoGgsWhitelisted(
-        "not-whitelisted",
-        RepoService.getGgsWhitelistedRepos(
-          mockUserWithSiteSessionDataAndGrowthBook.growthbook
-        )
-      )
-
-      expect(actual).toBe(false)
     })
   })
 

--- a/src/types/featureFlags.ts
+++ b/src/types/featureFlags.ts
@@ -4,7 +4,7 @@
 export interface FeatureFlags {
   ggs_whitelisted_repos: { repos: string[] }
   is_build_times_reduction_enabled: boolean
-  is_ggs_whitelisted: boolean
+  is_ggs_enabled: boolean
 }
 
 // List of attributes we set in GrowthBook Instance in auth middleware

--- a/src/types/featureFlags.ts
+++ b/src/types/featureFlags.ts
@@ -4,6 +4,7 @@
 export interface FeatureFlags {
   ggs_whitelisted_repos: { repos: string[] }
   is_build_times_reduction_enabled: boolean
+  is_ggs_whitelisted: boolean
 }
 
 // List of attributes we set in GrowthBook Instance in auth middleware

--- a/src/types/featureFlags.ts
+++ b/src/types/featureFlags.ts
@@ -2,7 +2,6 @@
 // Add BE feature flags here to mirror that on GrowthBook
 // Note: key should mirror GrowthBook exactly as it is
 export interface FeatureFlags {
-  ggs_whitelisted_repos: { repos: string[] }
   is_build_times_reduction_enabled: boolean
   is_ggs_enabled: boolean
 }


### PR DESCRIPTION
## Problem
Right now, our GGS flag adopts a two tiered approach - first, we get the list of repos from growthbook then we validate based on that. 

This is a _whitelist_ approach, where we add sites as they shift to ggs. This is effortful and going forward, we want to make our flag a _blacklist_ approach, where we allow sites by default until we need to blacklist them. 

## Solution
Add new flag on growthbook that returns a boolean value checking if the user type is email and whether site is blacklisted. (it's true if user is email && site isn't blacklisted)

## Deploy notes
**these steps have to be done pre deploy**
- [ ] for new **email login** sites that are not on ggs, migrate them to ggs by cloning them onto efs (can use form atm) 

**these steps have to be done post deploy**
- [ ] remove the flag for ggs whitelisted repo
- [ ] enable the flag for `is_ggs_enabled` on **production**