### PR TITLE
Feat/is 52 add monitor after successful site launch

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -73,3 +73,6 @@ export SGID_REDIRECT_URI=""
 
 # GrowthBook
 export GROWTHBOOK_CLIENT_KEY=""
+
+# Uptime robot
+export UPTIME_ROBOT_API_KEY=""

--- a/.platform/hooks/predeploy/06_fetch_ssm_parameters.sh
+++ b/.platform/hooks/predeploy/06_fetch_ssm_parameters.sh
@@ -81,6 +81,7 @@ ENV_VARS=(
     "SSM_PREFIX"
     "STEP_FUNCTIONS_ARN"
     "SYSTEM_GITHUB_TOKEN"
+    "UPTIME_ROBOT_API_KEY"
 )
 
 echo "Set AWS region"

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -428,6 +428,14 @@ const config = convict({
       default: "",
     },
   },
+  uptimeRobot: {
+    apiKey: {
+      doc: "Uptime Robot API key",
+      env: "UPTIME_ROBOT_API_KEY",
+      format: String,
+      default: "",
+    },
+  },
 })
 
 // Perform validation

--- a/src/routes/formsgSiteLaunch.ts
+++ b/src/routes/formsgSiteLaunch.ts
@@ -276,7 +276,7 @@ export class FormsgSiteLaunchRouter {
             interval: 30,
             timeout: 30,
             alert_contacts: alertContacts,
-            http_method: 1, // GET
+            http_method: 2, // GET
           }
         )
       } else {
@@ -293,7 +293,7 @@ export class FormsgSiteLaunchRouter {
             interval: 30,
             timeout: 30,
             alert_contacts: alertContacts,
-            http_method: 1, // GET
+            http_method: 2, // GET
           }
         )
       }

--- a/src/routes/formsgSiteLaunch.ts
+++ b/src/routes/formsgSiteLaunch.ts
@@ -224,6 +224,13 @@ export class FormsgSiteLaunchRouter {
     await mailer.sendMail(requesterEmail, subject, html)
   }
 
+  sendMonitorCreationFailure = async (repoName: string): Promise<void> => {
+    const email = ISOMER_SUPPORT_EMAIL
+    const subject = `[Isomer] Monitor creation FAILURE`
+    const html = `The Uptime Robot monitor for the following site was not created successfully: ${repoName}`
+    await mailer.sendMail(email, subject, html)
+  }
+
   private digDomainForQuadARecords = async (
     domain: string,
     digType: DigType
@@ -299,9 +306,15 @@ export class FormsgSiteLaunchRouter {
       }
     } catch (uptimerobotErr) {
       // Non-blocking error, since site launch is still successful
-      logger.info(
-        `Unable to create better uptime monitor for ${baseDomain}. Error: ${uptimerobotErr}`
-      )
+      const errMessage = `Unable to create better uptime monitor for ${baseDomain}. Error: ${uptimerobotErr}`
+      logger.error(errMessage)
+      try {
+        await this.sendMonitorCreationFailure(baseDomain)
+      } catch (monitorFailureEmailErr) {
+        logger.error(
+          `Failed to send error email for ${baseDomain}: ${monitorFailureEmailErr}`
+        )
+      }
     }
   }
 

--- a/src/routes/formsgSiteLaunch.ts
+++ b/src/routes/formsgSiteLaunch.ts
@@ -250,11 +250,13 @@ export class FormsgSiteLaunchRouter {
       })
 
   private async createMonitor(baseDomain: string) {
+    const uptimeRobotBaseUrl = "https://api.uptimerobot.com/v2"
     try {
+      const UPTIME_ROBOT_API_KEY = config.get("uptimeRobot.apiKey")
       const getResp = await axios.post<{ monitors: { id: string }[] }>(
-        "https://api.uptimerobot.com/v2/getMonitors?format=json",
+        `${uptimeRobotBaseUrl}/getMonitors?format=json`,
         {
-          api_key: config.get("uptimeRobot.apiKey"),
+          api_key: UPTIME_ROBOT_API_KEY,
           search: baseDomain,
         }
       )
@@ -263,8 +265,8 @@ export class FormsgSiteLaunchRouter {
       )
       const getAlertContactsResp = await axios.post<{
         alert_contacts: { id: string }[]
-      }>("https://api.uptimerobot.com/v2/getAlertContacts?format=json", {
-        api_key: config.get("uptimeRobot.apiKey"),
+      }>(`${uptimeRobotBaseUrl}/getAlertContacts?format=json`, {
+        api_key: UPTIME_ROBOT_API_KEY,
       })
       const alertContacts = getAlertContactsResp.data.alert_contacts
         .map(
@@ -274,9 +276,9 @@ export class FormsgSiteLaunchRouter {
       if (affectedMonitorIds.length === 0) {
         // Create new monitor
         await axios.post<{ monitors: { id: string }[] }>(
-          "https://api.uptimerobot.com/v2/newMonitor?format=json",
+          `${uptimeRobotBaseUrl}/newMonitor?format=json`,
           {
-            api_key: config.get("uptimeRobot.apiKey"),
+            api_key: UPTIME_ROBOT_API_KEY,
             friendly_name: baseDomain,
             url: `https://${baseDomain}`,
             type: 1, // HTTP(S)
@@ -290,9 +292,9 @@ export class FormsgSiteLaunchRouter {
         // Edit existing monitor
         // We only edit the first matching monitor, in the case where multiple monitors exist
         await axios.post<{ monitors: { id: string }[] }>(
-          "https://api.uptimerobot.com/v2/editMonitor?format=json",
+          `${uptimeRobotBaseUrl}/editMonitor?format=json`,
           {
-            api_key: config.get("uptimeRobot.apiKey"),
+            api_key: UPTIME_ROBOT_API_KEY,
             id: affectedMonitorIds[0],
             friendly_name: baseDomain,
             url: `https://${baseDomain}`,

--- a/src/routes/formsgSiteLaunch.ts
+++ b/src/routes/formsgSiteLaunch.ts
@@ -224,10 +224,10 @@ export class FormsgSiteLaunchRouter {
     await mailer.sendMail(requesterEmail, subject, html)
   }
 
-  sendMonitorCreationFailure = async (repoName: string): Promise<void> => {
+  sendMonitorCreationFailure = async (baseDomain: string): Promise<void> => {
     const email = ISOMER_SUPPORT_EMAIL
     const subject = `[Isomer] Monitor creation FAILURE`
-    const html = `The Uptime Robot monitor for the following site was not created successfully: ${repoName}`
+    const html = `The Uptime Robot monitor for the following site was not created successfully: ${baseDomain}`
     await mailer.sendMail(email, subject, html)
   }
 


### PR DESCRIPTION
## Problem

This PR adds automated creation of uptime robot monitors for sites which are successfully launched. After a site is successfully launched, we make a request to the Uptime Robot api to create a new monitor if it doesn't already exist, otherwise it modifies the existing monitor to ensure the monitor is setup correctly. 

Note that the monitor setup is non-blocking on failure, since the site launch would still have been successful - an email is sent to the isomer support email instead so that we are informed to manually setup the monitor.


## Tests
Monitor created/edited via site launch staging - https://uptimerobot.com/dashboard#795440992

<!-- What tests should be run to confirm functionality? -->

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

Env vars have been populated on SSM.
- `UPTIME_ROBOT_API_KEY` : API key for uptime robot
    - [x] added env var to 1PW + SSM script (`fetch_ssm_parameters.sh`)

**Post merge**:
To remove all test records after this PR has been reviewed:


- [ ] Remove records introduced on indirection repo: https://github.com/isomerpages/isomer-indirection/pull/36
- [ ] Remove uptime robot: https://uptimerobot.com/dashboard#795440992
- [ ] Remove domain association on amplify app: https://ap-southeast-1.console.aws.amazon.com/amplify/home?region=ap-southeast-1#/duyfy15grdtiq/settings/domains