### PR TITLE
ref(media): paginate media endpoint

### DIFF
--- a/src/routes/v2/authenticatedSites/__tests__/MediaCategories.spec.js
+++ b/src/routes/v2/authenticatedSites/__tests__/MediaCategories.spec.js
@@ -29,7 +29,7 @@ describe("Media Categories Router", () => {
   // We can use read route handler here because we don't need to lock the repo
   subrouter.get(
     "/:siteName/media/:directoryName",
-    attachReadRouteHandlerWrapper(router.listMediaDirectoryFiles)
+    attachReadRouteHandlerWrapper(router.listMediaDirectoryContent)
   )
   subrouter.post(
     "/:siteName/media",

--- a/src/routes/v2/authenticatedSites/mediaCategories.js
+++ b/src/routes/v2/authenticatedSites/mediaCategories.js
@@ -27,10 +27,12 @@ class MediaCategoriesRouter {
     const { userWithSiteSessionData } = res.locals
 
     const { directoryName } = req.params
+    const { page } = req.query
     const listResp = await this.mediaDirectoryService.listFiles(
       userWithSiteSessionData,
       {
         directoryName,
+        page,
       }
     )
     return res.status(200).json(listResp)

--- a/src/routes/v2/authenticatedSites/mediaCategories.js
+++ b/src/routes/v2/authenticatedSites/mediaCategories.js
@@ -29,7 +29,10 @@ class MediaCategoriesRouter {
 
     const { directoryName } = req.params
     const { page, limit } = req.query
-    const listResp = await this.mediaDirectoryService.listMediaDirectoryContent(
+    const {
+      directories,
+      files,
+    } = await this.mediaDirectoryService.listMediaDirectoryContent(
       userWithSiteSessionData,
       {
         directoryName,
@@ -37,7 +40,7 @@ class MediaCategoriesRouter {
         limit,
       }
     )
-    return res.status(200).json(listResp)
+    return res.status(200).json([...directories, ...files])
   }
 
   // List files within a resource category.

--- a/src/routes/v2/authenticatedSites/mediaCategories.js
+++ b/src/routes/v2/authenticatedSites/mediaCategories.js
@@ -22,20 +22,60 @@ class MediaCategoriesRouter {
     autoBind(this)
   }
 
-  // List files in a resource category
+  // List content in a resource category.
+  // This includes both files and subdirectories within the resource category.
+  async listMediaDirectoryContent(req, res) {
+    const { userWithSiteSessionData } = res.locals
+
+    const { directoryName } = req.params
+    const { page, limit } = req.query
+    const listResp = await this.mediaDirectoryService.listMediaDirectoryContent(
+      userWithSiteSessionData,
+      {
+        directoryName,
+        page,
+        limit,
+      }
+    )
+    return res.status(200).json(listResp)
+  }
+
+  // List files within a resource category.
   async listMediaDirectoryFiles(req, res) {
     const { userWithSiteSessionData } = res.locals
 
     const { directoryName } = req.params
     const { page } = req.query
-    const listResp = await this.mediaDirectoryService.listFiles(
+
+    const {
+      files,
+      total,
+    } = await this.mediaDirectoryService.listMediaDirectoryContent(
       userWithSiteSessionData,
       {
         directoryName,
         page,
       }
     )
-    return res.status(200).json(listResp)
+    return res.status(200).json({ files, total })
+  }
+
+  async listMediaDirectorySubdirectories(req, res) {
+    const { userWithSiteSessionData } = res.locals
+
+    const { directoryName } = req.params
+    const { page } = req.query
+
+    const {
+      directories,
+    } = await this.mediaDirectoryService.listMediaDirectoryContent(
+      userWithSiteSessionData,
+      {
+        directoryName,
+        page,
+      }
+    )
+    return res.status(200).json({ directories })
   }
 
   // Create new media directory
@@ -124,7 +164,15 @@ class MediaCategoriesRouter {
 
     router.get(
       "/:directoryName",
+      attachReadRouteHandlerWrapper(this.listMediaDirectoryContent)
+    )
+    router.get(
+      "/:directoryName/files",
       attachReadRouteHandlerWrapper(this.listMediaDirectoryFiles)
+    )
+    router.get(
+      "/:directoryName/subdirectories",
+      attachReadRouteHandlerWrapper(this.listMediaDirectorySubdirectories)
     )
     router.post(
       "/",

--- a/src/routes/v2/authenticatedSites/mediaCategories.js
+++ b/src/routes/v2/authenticatedSites/mediaCategories.js
@@ -45,7 +45,7 @@ class MediaCategoriesRouter {
     const { userWithSiteSessionData } = res.locals
 
     const { directoryName } = req.params
-    const { page } = req.query
+    const { page, limit } = req.query
 
     const {
       files,
@@ -55,6 +55,7 @@ class MediaCategoriesRouter {
       {
         directoryName,
         page,
+        limit,
       }
     )
     return res.status(200).json({ files, total })

--- a/src/routes/v2/authenticatedSites/mediaCategories.js
+++ b/src/routes/v2/authenticatedSites/mediaCategories.js
@@ -24,7 +24,7 @@ class MediaCategoriesRouter {
 
   // List content in a resource category.
   // This includes both files and subdirectories within the resource category.
-  async listMediaDirectoryContent(req, res) {
+  async listMediaDirectoryContents(req, res) {
     const { userWithSiteSessionData } = res.locals
 
     const { directoryName } = req.params
@@ -164,7 +164,7 @@ class MediaCategoriesRouter {
 
     router.get(
       "/:directoryName",
-      attachReadRouteHandlerWrapper(this.listMediaDirectoryContent)
+      attachReadRouteHandlerWrapper(this.listMediaDirectoryContents)
     )
     router.get(
       "/:directoryName/files",

--- a/src/services/db/GitHubService.js
+++ b/src/services/db/GitHubService.js
@@ -12,7 +12,7 @@ const {
 const { NotFoundError } = require("@errors/NotFoundError")
 const { UnprocessableError } = require("@errors/UnprocessableError")
 
-const logger = require("@root/logger/logger")
+const logger = require("@root/logger/logger").default
 
 const ReviewApi = require("./review")
 

--- a/src/services/db/GitHubService.js
+++ b/src/services/db/GitHubService.js
@@ -181,36 +181,6 @@ class GitHubService {
     return { content, sha }
   }
 
-  async readMedia(sessionData, { fileSha }) {
-    /**
-     * Files that are bigger than 1 MB needs to be retrieved
-     * via Github Blob API. The content can only be retrieved through
-     * the `sha` of the file.
-     */
-    const { accessToken } = sessionData
-    const { siteName } = sessionData
-    const params = {
-      ref: BRANCH_REF,
-    }
-
-    const blobEndpoint = this.getBlobPath({ siteName, fileSha })
-
-    const resp = await this.axiosInstance.get(blobEndpoint, {
-      validateStatus,
-      params,
-      headers: {
-        Authorization: `token ${accessToken}`,
-      },
-    })
-
-    if (resp.status === 404)
-      throw new NotFoundError("Media file does not exist")
-
-    const { content, sha } = resp.data
-
-    return { content, sha }
-  }
-
   async readDirectory(sessionData, { directoryName }) {
     const { accessToken } = sessionData
     const { siteName } = sessionData

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -27,6 +27,25 @@ import * as ReviewApi from "./review"
 const PLACEHOLDER_FILE_NAME = ".keep"
 const BRANCH_REF = config.get("github.branchRef")
 
+const getPaginatedDirectoryContents = (
+  directoryContents: GitDirectoryItem[],
+  lastSeen: number,
+  limit: number
+): { directories: GitDirectoryItem[]; files: GitDirectoryItem[] } => {
+  const subdirectories = directoryContents.filter((item) => item.type === "dir")
+  const files = directoryContents
+    .filter(
+      (item) => item.type === "file" && item.name !== PLACEHOLDER_FILE_NAME
+    )
+    .toSorted((a, b) => a.name.localeCompare(b.name))
+    // NOTE: Take only first n
+    .slice(lastSeen, lastSeen + limit)
+
+  return { directories: subdirectories, files }
+}
+
+// TODO: update the typings here to remove `any`.
+// We can type as `unknown` if required.
 export default class RepoService extends GitHubService {
   private readonly gitFileSystemService: GitFileSystemService
 
@@ -177,7 +196,7 @@ export default class RepoService extends GitHubService {
       this.gitFileSystemService.push(sessionData.siteName, BRANCH_REF)
       return { sha: result.value.newSha }
     }
-    return await super.create(sessionData, {
+    return super.create(sessionData, {
       content,
       fileName,
       directoryName,
@@ -188,7 +207,7 @@ export default class RepoService extends GitHubService {
   async read(
     sessionData: UserWithSiteSessionData,
     { fileName, directoryName }: { fileName: string; directoryName?: string }
-  ): Promise<GitFile> {
+  ): Promise<Pick<GitFile, "sha" | "content"> | GitFile> {
     if (
       this.isRepoWhitelisted(
         sessionData.siteName,
@@ -209,7 +228,7 @@ export default class RepoService extends GitHubService {
       return result.value
     }
 
-    return await super.read(sessionData, {
+    return super.read(sessionData, {
       fileName,
       directoryName,
     })
@@ -256,7 +275,7 @@ export default class RepoService extends GitHubService {
     )
     const { private: isPrivate } = await super.getRepoInfo(sessionData)
 
-    return await getMediaFileInfo({
+    return getMediaFileInfo({
       file: targetFile,
       siteName,
       directoryName,
@@ -267,7 +286,7 @@ export default class RepoService extends GitHubService {
 
   // TODO: This is no longer used, remove it
   async readMedia(sessionData: any, { fileSha }: any): Promise<any> {
-    return await super.readMedia(sessionData, { fileSha })
+    return super.readMedia(sessionData, { fileSha })
   }
 
   async readDirectory(
@@ -293,23 +312,24 @@ export default class RepoService extends GitHubService {
       return result.value
     }
 
-    return await super.readDirectory(sessionData, {
+    return super.readDirectory(sessionData, {
       directoryName,
     })
   }
 
   async readMediaDirectory(
     sessionData: UserWithSiteSessionData,
-    directoryName: string
+    directoryName: string,
+    // NOTE: The last seen index denotes the previous seen images.
+    // We will tiebreak in alphabetical order - we sort
+    // and then we return the first n.
+    lastSeen = 0,
+    limit = 15
   ): Promise<(MediaDirOutput | MediaFileOutput)[]> {
     const { siteName } = sessionData
     logger.debug(`Reading media directory: ${directoryName}`)
 
     let filteredResult: GitDirectoryItem[] = []
-    let isPrivate = false
-    const filterLogic = (file: any) =>
-      (file.type === "file" || file.type === "dir") &&
-      file.name !== PLACEHOLDER_FILE_NAME
 
     if (
       this.isRepoWhitelisted(
@@ -326,17 +346,25 @@ export default class RepoService extends GitHubService {
         throw result.error
       }
 
-      filteredResult = result.value.filter(filterLogic)
+      const { directories, files } = getPaginatedDirectoryContents(
+        result.value,
+        lastSeen,
+        limit
+      )
+      filteredResult = [...directories, ...files]
     } else {
-      const repoInfo = await super.getRepoInfo(sessionData)
-      isPrivate = repoInfo.private
-      const files = await super.readDirectory(sessionData, {
+      const directoryContents = (await super.readDirectory(sessionData, {
         directoryName,
-      })
-      filteredResult = files.filter(filterLogic)
+      })) as GitDirectoryItem[]
+      const { directories, files } = getPaginatedDirectoryContents(
+        directoryContents,
+        lastSeen,
+        limit
+      )
+      filteredResult = [...directories, ...files]
     }
 
-    return await Promise.all(
+    return Promise.all(
       filteredResult.map((curr) => {
         if (curr.type === "dir") {
           return {
@@ -391,7 +419,7 @@ export default class RepoService extends GitHubService {
       return { newSha: result.value }
     }
 
-    return await super.update(sessionData, {
+    return super.update(sessionData, {
       fileContent,
       sha,
       fileName,
@@ -457,7 +485,7 @@ export default class RepoService extends GitHubService {
       message,
     })
 
-    return await this.updateRepoState(sessionData, {
+    await this.updateRepoState(sessionData, {
       commitSha: newCommitSha,
     })
   }
@@ -504,7 +532,7 @@ export default class RepoService extends GitHubService {
     }
 
     // GitHub flow
-    return await super.delete(sessionData, {
+    await super.delete(sessionData, {
       sha,
       fileName,
       directoryName,
@@ -685,11 +713,11 @@ export default class RepoService extends GitHubService {
   }
 
   async getRepoInfo(sessionData: any): Promise<any> {
-    return await super.getRepoInfo(sessionData)
+    return super.getRepoInfo(sessionData)
   }
 
   async getRepoState(sessionData: any): Promise<any> {
-    return await super.getRepoState(sessionData)
+    return super.getRepoState(sessionData)
   }
 
   async getLatestCommitOfBranch(
@@ -715,7 +743,7 @@ export default class RepoService extends GitHubService {
       }
       return result.value
     }
-    return await super.getLatestCommitOfBranch(sessionData, branchName)
+    return super.getLatestCommitOfBranch(sessionData, branchName)
   }
 
   async getTree(
@@ -723,7 +751,7 @@ export default class RepoService extends GitHubService {
     githubSessionData: any,
     { isRecursive }: any
   ): Promise<RawGitTreeEntry[]> {
-    return await super.getTree(sessionData, githubSessionData, {
+    return super.getTree(sessionData, githubSessionData, {
       isRecursive,
     })
   }
@@ -733,7 +761,7 @@ export default class RepoService extends GitHubService {
     githubSessionData: any,
     { gitTree, message }: any
   ): Promise<any> {
-    return await super.updateTree(sessionData, githubSessionData, {
+    return super.updateTree(sessionData, githubSessionData, {
       gitTree,
       message,
     })
@@ -767,18 +795,18 @@ export default class RepoService extends GitHubService {
       return
     }
 
-    return await super.updateRepoState(sessionData, { commitSha, branchName })
+    await super.updateRepoState(sessionData, { commitSha, branchName })
   }
 
   async checkHasAccess(sessionData: any): Promise<any> {
-    return await super.checkHasAccess(sessionData)
+    return super.checkHasAccess(sessionData)
   }
 
   async changeRepoPrivacy(
     sessionData: any,
     shouldMakePrivate: any
   ): Promise<any> {
-    return await super.changeRepoPrivacy(sessionData, {
+    return super.changeRepoPrivacy(sessionData, {
       shouldMakePrivate,
     })
   }

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -29,8 +29,8 @@ const BRANCH_REF = config.get("github.branchRef")
 
 const getPaginatedDirectoryContents = (
   directoryContents: GitDirectoryItem[],
-  lastSeen: number,
-  limit: number
+  page: number,
+  limit = 15
 ): { directories: GitDirectoryItem[]; files: GitDirectoryItem[] } => {
   const subdirectories = directoryContents.filter((item) => item.type === "dir")
   const files = directoryContents
@@ -39,7 +39,7 @@ const getPaginatedDirectoryContents = (
     )
     .toSorted((a, b) => a.name.localeCompare(b.name))
     // NOTE: Take only first n
-    .slice(lastSeen, lastSeen + limit)
+    .slice(page * limit, (page + 1) * limit)
 
   return { directories: subdirectories, files }
 }
@@ -323,7 +323,7 @@ export default class RepoService extends GitHubService {
     // NOTE: The last seen index denotes the previous seen images.
     // We will tiebreak in alphabetical order - we sort
     // and then we return the first n.
-    lastSeen = 0,
+    page = 0,
     limit = 15
   ): Promise<(MediaDirOutput | MediaFileOutput)[]> {
     const { siteName } = sessionData
@@ -348,7 +348,7 @@ export default class RepoService extends GitHubService {
 
       const { directories, files } = getPaginatedDirectoryContents(
         result.value,
-        lastSeen,
+        page,
         limit
       )
       filteredResult = [...directories, ...files]
@@ -358,7 +358,7 @@ export default class RepoService extends GitHubService {
       })) as GitDirectoryItem[]
       const { directories, files } = getPaginatedDirectoryContents(
         directoryContents,
-        lastSeen,
+        page,
         limit
       )
       filteredResult = [...directories, ...files]

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -41,9 +41,11 @@ const getPaginatedDirectoryContents = (
   const files = directoryContents.filter(
     (item) => item.type === "file" && item.name !== PLACEHOLDER_FILE_NAME
   )
-  const paginatedFiles = _.sortBy(files, (file) => file.name)
-    // NOTE: Take only first n
-    .slice(page * limit, (page + 1) * limit)
+  const paginatedFiles = _(files)
+    .sortBy((file) => file.name)
+    .drop(page * limit)
+    .take(limit)
+    .value()
 
   return {
     directories: subdirectories,

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -1,5 +1,6 @@
 import { GrowthBook } from "@growthbook/growthbook"
 import { AxiosCacheInstance } from "axios-cache-interceptor"
+import _ from "lodash"
 
 import config from "@config/config"
 
@@ -40,8 +41,7 @@ const getPaginatedDirectoryContents = (
   const files = directoryContents.filter(
     (item) => item.type === "file" && item.name !== PLACEHOLDER_FILE_NAME
   )
-  const paginatedFiles = files
-    .toSorted((a, b) => a.name.localeCompare(b.name))
+  const paginatedFiles = _.sortBy(files, (file) => file.name)
     // NOTE: Take only first n
     .slice(page * limit, (page + 1) * limit)
 

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -37,15 +37,19 @@ const getPaginatedDirectoryContents = (
   total: number
 } => {
   const subdirectories = directoryContents.filter((item) => item.type === "dir")
-  const directoryFiles = directoryContents.filter(
+  const files = directoryContents.filter(
     (item) => item.type === "file" && item.name !== PLACEHOLDER_FILE_NAME
   )
-  const files = directoryFiles
+  const paginatedFiles = files
     .toSorted((a, b) => a.name.localeCompare(b.name))
     // NOTE: Take only first n
     .slice(page * limit, (page + 1) * limit)
 
-  return { directories: subdirectories, files, total: directoryFiles.length }
+  return {
+    directories: subdirectories,
+    files: paginatedFiles,
+    total: files.length,
+  }
 }
 
 // TODO: update the typings here to remove `any`.

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -215,7 +215,7 @@ export default class RepoService extends GitHubService {
   async read(
     sessionData: UserWithSiteSessionData,
     { fileName, directoryName }: { fileName: string; directoryName?: string }
-  ): Promise<Pick<GitFile, "sha" | "content"> | GitFile> {
+  ): Promise<GitFile> {
     if (
       this.isRepoWhitelisted(
         sessionData.siteName,

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -294,11 +294,6 @@ export default class RepoService extends GitHubService {
     })
   }
 
-  // TODO: This is no longer used, remove it
-  async readMedia(sessionData: any, { fileSha }: any): Promise<any> {
-    return super.readMedia(sessionData, { fileSha })
-  }
-
   async readDirectory(
     sessionData: UserWithSiteSessionData,
     { directoryName }: { directoryName: string }

--- a/src/services/db/__tests__/GitHubService.spec.ts
+++ b/src/services/db/__tests__/GitHubService.spec.ts
@@ -396,53 +396,6 @@ describe("Github Service", () => {
     })
   })
 
-  describe("ReadMedia", () => {
-    const endpoint = `${siteName}/git/blobs/${sha}`
-    const params = {
-      ref: BRANCH_REF,
-    }
-
-    it("should read a media file works correctly", async () => {
-      const resp = {
-        data: {
-          content,
-          sha,
-        },
-      }
-      mockAxiosInstance.get.mockResolvedValueOnce(resp)
-      await expect(
-        service.readMedia(sessionData, {
-          fileSha: sha,
-        })
-      ).resolves.toMatchObject({
-        content,
-        sha,
-      })
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith(endpoint, {
-        validateStatus,
-        params,
-        headers: authHeader.headers,
-      })
-    })
-
-    it("should throw the correct error if file cannot be found", async () => {
-      const resp = {
-        status: 404,
-      }
-      mockAxiosInstance.get.mockResolvedValueOnce(resp)
-      await expect(
-        service.readMedia(sessionData, {
-          fileSha: sha,
-        })
-      ).rejects.toThrowError(NotFoundError)
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith(endpoint, {
-        validateStatus,
-        params,
-        headers: authHeader.headers,
-      })
-    })
-  })
-
   describe("ReadDirectory", () => {
     const endpoint = `${siteName}/contents/${directoryName}`
     const params = {

--- a/src/services/directoryServices/MediaDirectoryService.js
+++ b/src/services/directoryServices/MediaDirectoryService.js
@@ -28,13 +28,14 @@ class MediaDirectoryService {
     return files
   }
 
-  async listFiles(sessionData, { directoryName }) {
+  async listFiles(sessionData, { directoryName, page }) {
     if (!isMediaPathValid({ path: directoryName }))
       throw new BadRequestError("Invalid media folder name")
 
-    return await this.gitHubService.readMediaDirectory(
+    return this.gitHubService.readMediaDirectory(
       sessionData,
-      directoryName
+      directoryName,
+      page
     )
   }
 

--- a/src/services/directoryServices/MediaDirectoryService.js
+++ b/src/services/directoryServices/MediaDirectoryService.js
@@ -35,7 +35,8 @@ class MediaDirectoryService {
     return this.gitHubService.readMediaDirectory(
       sessionData,
       directoryName,
-      page
+      // NOTE: Done here as frontend starts indexing from 1
+      page - 1
     )
   }
 

--- a/src/services/directoryServices/MediaDirectoryService.js
+++ b/src/services/directoryServices/MediaDirectoryService.js
@@ -35,8 +35,7 @@ class MediaDirectoryService {
     return this.gitHubService.readMediaDirectory(
       sessionData,
       directoryName,
-      // NOTE: Done here as frontend starts indexing from 1
-      page - 1,
+      page,
       limit
     )
   }

--- a/src/services/directoryServices/MediaDirectoryService.js
+++ b/src/services/directoryServices/MediaDirectoryService.js
@@ -28,7 +28,7 @@ class MediaDirectoryService {
     return files
   }
 
-  async listFiles(sessionData, { directoryName, page }) {
+  async listMediaDirectoryContent(sessionData, { directoryName, page, limit }) {
     if (!isMediaPathValid({ path: directoryName }))
       throw new BadRequestError("Invalid media folder name")
 
@@ -36,7 +36,8 @@ class MediaDirectoryService {
       sessionData,
       directoryName,
       // NOTE: Done here as frontend starts indexing from 1
-      page - 1
+      page - 1,
+      limit
     )
   }
 

--- a/src/services/directoryServices/__tests__/MediaDirectoryService.spec.js
+++ b/src/services/directoryServices/__tests__/MediaDirectoryService.spec.js
@@ -37,7 +37,6 @@ describe("Media Directory Service", () => {
 
   const mockGitHubService = {
     create: jest.fn(),
-    readMedia: jest.fn(),
     getRepoInfo: jest.fn(),
     readMediaDirectory: jest.fn(),
   }

--- a/src/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
@@ -25,7 +25,6 @@ describe("Media File Service", () => {
     update: jest.fn(),
     delete: jest.fn(),
     getRepoInfo: jest.fn(),
-    readMedia: jest.fn(),
     readMediaFile: jest.fn(),
     readDirectory: jest.fn(),
     renameSinglePath: jest.fn(),

--- a/src/types/gitfilesystem.ts
+++ b/src/types/gitfilesystem.ts
@@ -1,15 +1,21 @@
 export type GitFile = {
   content: string
   sha: string
+  name: string
+  type: "file"
+  path: string
+  size: number
 }
 
-export type GitDirectoryItem = {
+export type GitDirectory = {
   name: string
-  type: "file" | "dir"
+  type: "dir"
   sha: string
   path: string
   size: number
 }
+
+export type GitDirectoryItem = GitDirectory | GitFile
 
 export type GitCommitResult = {
   newSha: string

--- a/src/types/gitfilesystem.ts
+++ b/src/types/gitfilesystem.ts
@@ -1,21 +1,15 @@
 export type GitFile = {
   content: string
   sha: string
-  name: string
-  type: "file"
-  path: string
-  size: number
 }
 
-export type GitDirectory = {
+export type GitDirectoryItem = {
   name: string
-  type: "dir"
+  type: "file" | "dir"
   sha: string
   path: string
   size: number
 }
-
-export type GitDirectoryItem = GitDirectory | GitFile
 
 export type GitCommitResult = {
   newSha: string


### PR DESCRIPTION
## Problem
See [here](https://github.com/isomerpages/isomercms-frontend/pull/1578) for description

## Solution
- add `page` and `limit` to the media endpoint. we don't paginate directories (for now) due to reasons stated in the other PR. 
- also added 2 more endpoints for fetching files/directories separately. the reasons are given in the other PR. As github **does not** allow us ([no link header](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers)) to paginate the repository content [endpoint](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content), this pagination exists solely on our end, **not on github**. 
    - this means that we only save on 1 network call (from be -> fe) and we don't save on the network call from github -> be. this endpoint should have etags enabled so thankfully, only the first call out should be expensive.

## Note
tests coming in a follow up PR