### PR TITLE
ref(media): defer image loading

### DIFF
--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -42,7 +42,7 @@ const getPaginatedDirectoryContents = (
     (item) => item.type === "file" && item.name !== PLACEHOLDER_FILE_NAME
   )
   const paginatedFiles = _(files)
-    .sortBy((file) => file.name)
+    .sortBy(["name"])
     .drop(page * limit)
     .take(limit)
     .value()

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -332,7 +332,7 @@ export default class RepoService extends GitHubService {
     limit = 15
   ): Promise<{
     directories: MediaDirOutput[]
-    files: MediaFileOutput[]
+    files: Pick<MediaFileOutput, "name">[]
     total: number
   }> {
     const { siteName } = sessionData
@@ -372,14 +372,7 @@ export default class RepoService extends GitHubService {
         name,
         type,
       })),
-      files: await Promise.all(
-        files.map((file) =>
-          this.readMediaFile(sessionData, {
-            fileName: file.name,
-            directoryName,
-          })
-        )
-      ),
+      files,
       total,
     }
   }

--- a/src/types/gitfilesystem.ts
+++ b/src/types/gitfilesystem.ts
@@ -6,3 +6,11 @@ export type GitFile = {
 export type GitCommitResult = {
   newSha: string
 }
+
+export type GitDirectoryItem = {
+  name: string
+  type: "file" | "dir"
+  sha: string
+  path: string
+  size: number
+}

--- a/src/types/gitfilesystem.ts
+++ b/src/types/gitfilesystem.ts
@@ -3,14 +3,6 @@ export type GitFile = {
   sha: string
 }
 
-export type GitDirectoryItem = {
-  name: string
-  type: "file" | "dir"
-  sha: string
-  path: string
-  size: number
-}
-
 export type GitCommitResult = {
   newSha: string
 }


### PR DESCRIPTION
**NOTE: ** This PR requires the corresponding FE PR [here](https://github.com/isomerpages/isomercms-frontend/pull/1581)

## Problem
Right now, we return the image fully per call. This isn't optimal because we have to load the image fully even when we don't need it. As an example, consider the image move - we don't require the images (only titles), but we do a full load inclusive of the image data. 

## Solution
1. Defer fetching the image to the `readMediaFile` endpoint instead of returning wholesale from `listDirectoryContents`

**Tests coming in another PR**