### PR TITLE
feat: allow Isomer admins to edit on email-login and adjust permissions

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -22,6 +22,7 @@ export enum RedirectionTypes {
 export enum CollaboratorRoles {
   Admin = "ADMIN",
   Contributor = "CONTRIBUTOR",
+  IsomerAdmin = "ISOMERADMIN",
 }
 
 export enum ReviewRequestStatus {

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -25,6 +25,11 @@ export enum CollaboratorRoles {
   IsomerAdmin = "ISOMERADMIN",
 }
 
+export type CollaboratorRolesWithoutIsomerAdmin = Exclude<
+  CollaboratorRoles,
+  CollaboratorRoles.IsomerAdmin
+>
+
 export enum ReviewRequestStatus {
   Approved = "APPROVED",
   Open = "OPEN",

--- a/src/database/models/SiteMember.ts
+++ b/src/database/models/SiteMember.ts
@@ -38,7 +38,7 @@ export class SiteMember extends Model {
     allowNull: false,
     type: DataType.ENUM("ADMIN", "CONTRIBUTOR"),
   })
-  role!: CollaboratorRoles
+  role!: Exclude<CollaboratorRoles, CollaboratorRoles.IsomerAdmin>
 
   @CreatedAt
   createdAt!: Date

--- a/src/database/models/SiteMember.ts
+++ b/src/database/models/SiteMember.ts
@@ -10,7 +10,10 @@ import {
   UpdatedAt,
 } from "sequelize-typescript"
 
-import { CollaboratorRoles } from "@constants/index"
+import {
+  CollaboratorRoles,
+  CollaboratorRolesWithoutIsomerAdmin,
+} from "@constants/index"
 
 import { Notification } from "@database/models/Notification"
 import { Site } from "@database/models/Site"
@@ -38,7 +41,7 @@ export class SiteMember extends Model {
     allowNull: false,
     type: DataType.ENUM("ADMIN", "CONTRIBUTOR"),
   })
-  role!: Exclude<CollaboratorRoles, CollaboratorRoles.IsomerAdmin>
+  role!: CollaboratorRolesWithoutIsomerAdmin
 
   @CreatedAt
   createdAt!: Date

--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -140,6 +140,7 @@ const sitesService = new SitesService({
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,
   siteMemberRepository: SiteMember,
+  isomerAdminsService: (jest.fn() as unknown) as IsomerAdminsService,
   sitesService,
   usersService,
   whitelist: Whitelist,

--- a/src/integration/Notifications.spec.ts
+++ b/src/integration/Notifications.spec.ts
@@ -145,6 +145,7 @@ const sitesService = new SitesService({
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,
   siteMemberRepository: SiteMember,
+  isomerAdminsService,
   sitesService,
   usersService,
   whitelist: Whitelist,

--- a/src/integration/Privatisation.spec.ts
+++ b/src/integration/Privatisation.spec.ts
@@ -187,6 +187,7 @@ const identityAuthService = getIdentityAuthService(gitHubService)
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,
   siteMemberRepository: SiteMember,
+  isomerAdminsService,
   sitesService,
   usersService,
   whitelist: Whitelist,

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -180,6 +180,7 @@ const sitesService = new SitesService({
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,
   siteMemberRepository: SiteMember,
+  isomerAdminsService,
   sitesService,
   usersService,
   whitelist: Whitelist,

--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -145,6 +145,7 @@ const sitesService = new SitesService({
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,
   siteMemberRepository: SiteMember,
+  isomerAdminsService,
   sitesService,
   usersService,
   whitelist: Whitelist,

--- a/src/routes/v2/authenticated/__tests__/review.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/review.spec.ts
@@ -45,7 +45,6 @@ describe("Review Requests Router", () => {
 
   const mockIdentityUsersService = {
     findByEmail: jest.fn(),
-    getSiteMember: jest.fn(),
   }
 
   const mockSitesService = {
@@ -147,7 +146,9 @@ describe("Review Requests Router", () => {
     it("should return 200 with the list of changed files", async () => {
       // Arrange
       const mockFilesChanged = ["file1", "file2"]
-      mockIdentityUsersService.getSiteMember.mockResolvedValueOnce("user")
+      mockCollaboratorsService.getRole.mockResolvedValueOnce(
+        CollaboratorRoles.Admin
+      )
       mockReviewRequestService.compareDiff.mockReturnValueOnce(
         okAsync(mockFilesChanged)
       )
@@ -161,13 +162,13 @@ describe("Review Requests Router", () => {
       // Assert
       expect(response.status).toEqual(200)
       expect(response.body).toEqual({ items: mockFilesChanged })
-      expect(mockIdentityUsersService.getSiteMember).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
       expect(mockReviewRequestService.compareDiff).toHaveBeenCalledTimes(1)
     })
 
     it("should return 404 if user is not a site member", async () => {
       // Arrange
-      mockIdentityUsersService.getSiteMember.mockResolvedValueOnce(null)
+      mockCollaboratorsService.getRole.mockResolvedValueOnce(null)
       mockSitesService.getBySiteName.mockResolvedValueOnce(ok(true))
 
       // Act
@@ -175,7 +176,7 @@ describe("Review Requests Router", () => {
 
       // Assert
       expect(response.status).toEqual(404)
-      expect(mockIdentityUsersService.getSiteMember).toHaveBeenCalledTimes(1)
+      expect(mockCollaboratorsService.getRole).toHaveBeenCalledTimes(1)
       expect(mockReviewRequestService.compareDiff).not.toHaveBeenCalled()
     })
   })
@@ -358,7 +359,6 @@ describe("Review Requests Router", () => {
     it("should return 404 if the site does not exist", async () => {
       // Arrange
       mockGithubService.getRepoInfo.mockRejectedValueOnce(false)
-      mockIdentityUsersService.getSiteMember.mockResolvedValueOnce({})
       mockSitesService.getBySiteName.mockReturnValueOnce(
         err(new MissingSiteError("site"))
       )

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -311,6 +311,15 @@ export class ReviewsRouter {
     // Step 2: Check that user exists.
     // Having session data is proof that this user exists
     // as otherwise, they would be rejected by our middleware
+    // Reject if the user is on GitHub login and the site is already migrated
+    const isGitHubUser = !userWithSiteSessionData.isEmailUser()
+
+    if (isGitHubUser) {
+      return res.status(404).send({
+        message: "GitHub users should not be editing a migrated site!",
+      })
+    }
+
     // Check if they are a collaborator
     const role = await this.collaboratorsService.getRole(
       siteName,

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -114,12 +114,12 @@ export class ReviewsRouter {
     }
 
     // Check if they have access to site
-    const possibleSiteMember = await this.identityUsersService.getSiteMember(
-      userWithSiteSessionData.isomerUserId,
-      siteName
+    const role = await this.collaboratorsService.getRole(
+      siteName,
+      userWithSiteSessionData.isomerUserId
     )
 
-    if (!possibleSiteMember) {
+    if (!role) {
       return res.status(404).json({ message: "No site members found" })
     }
 

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -1,7 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import autoBind from "auto-bind"
 import express from "express"
-import { fromPromise } from "neverthrow"
 
 import type { AuthorizationMiddleware } from "@middleware/authorization"
 import { attachReadRouteHandlerWrapper } from "@middleware/routeHandler"

--- a/src/server.js
+++ b/src/server.js
@@ -266,6 +266,7 @@ const identityAuthService = getIdentityAuthService(gitHubService)
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,
   siteMemberRepository: SiteMember,
+  isomerAdminsService,
   sitesService,
   usersService,
   whitelist: Whitelist,

--- a/src/services/identity/CollaboratorsService.ts
+++ b/src/services/identity/CollaboratorsService.ts
@@ -16,12 +16,14 @@ import { BadRequestError } from "@root/errors/BadRequestError"
 import { ConflictError } from "@root/errors/ConflictError"
 import logger from "@root/logger/logger"
 
+import IsomerAdminsService from "./IsomerAdminsService"
 import SitesService from "./SitesService"
 import UsersService from "./UsersService"
 
 interface CollaboratorsServiceProps {
   siteRepository: ModelStatic<Site>
   siteMemberRepository: ModelStatic<SiteMember>
+  isomerAdminsService: IsomerAdminsService
   sitesService: SitesService
   usersService: UsersService
   whitelist: ModelStatic<Whitelist>
@@ -34,6 +36,8 @@ class CollaboratorsService {
 
   private readonly siteMemberRepository: CollaboratorsServiceProps["siteMemberRepository"]
 
+  private readonly isomerAdminsService: CollaboratorsServiceProps["isomerAdminsService"]
+
   private readonly sitesService: CollaboratorsServiceProps["sitesService"]
 
   private readonly usersService: CollaboratorsServiceProps["usersService"]
@@ -43,12 +47,14 @@ class CollaboratorsService {
   constructor({
     siteRepository,
     siteMemberRepository,
+    isomerAdminsService,
     sitesService,
     usersService,
     whitelist,
   }: CollaboratorsServiceProps) {
     this.siteRepository = siteRepository
     this.siteMemberRepository = siteMemberRepository
+    this.isomerAdminsService = isomerAdminsService
     this.sitesService = sitesService
     this.usersService = usersService
     this.whitelist = whitelist
@@ -245,7 +251,12 @@ class CollaboratorsService {
       ],
     })
 
-    return site?.site_members?.[0]?.SiteMember?.role ?? null
+    const isIsomerAdmin = await this.isomerAdminsService.isUserIsomerAdmin(
+      userId
+    )
+    const isomerAdminRole = isIsomerAdmin ? CollaboratorRoles.IsomerAdmin : null
+
+    return site?.site_members?.[0]?.SiteMember?.role ?? isomerAdminRole
   }
 
   getStatistics = async (siteName: string) => {

--- a/src/services/identity/IsomerAdminsService.ts
+++ b/src/services/identity/IsomerAdminsService.ts
@@ -15,6 +15,11 @@ class IsomerAdminsService {
     this.repository = repository
   }
 
+  async isUserIsomerAdmin(userId: string): Promise<boolean> {
+    const isomerAdmin = await this.getByUserId(userId)
+    return !!isomerAdmin
+  }
+
   async getByUserId(userId: string): Promise<IsomerAdmin | null> {
     const site = await this.repository.findOne({
       where: { userId },

--- a/src/services/identity/UsersService.ts
+++ b/src/services/identity/UsersService.ts
@@ -79,50 +79,6 @@ class UsersService {
     return this.repository.findOne({ where: { githubId } })
   }
 
-  async getSiteMember(userId: string, siteName: string): Promise<User | null> {
-    return this.repository.findOne({
-      where: { id: userId },
-      include: [
-        {
-          model: Site,
-          as: "site_members",
-          required: true,
-          include: [
-            {
-              model: Repo,
-              required: true,
-              where: {
-                name: siteName,
-              },
-            },
-          ],
-        },
-      ],
-    })
-  }
-
-  async getSiteAdmin(userId: string, siteName: string) {
-    return this.repository.findOne({
-      where: { id: userId, role: "ADMIN" },
-      include: [
-        {
-          model: SiteMember,
-          as: "site_members",
-          required: true,
-          include: [
-            {
-              model: Repo,
-              required: true,
-              where: {
-                name: siteName,
-              },
-            },
-          ],
-        },
-      ],
-    })
-  }
-
   async findSitesByUserId(
     isomerId: string
   ): Promise<

--- a/src/services/identity/__tests__/CollaboratorsService.spec.ts
+++ b/src/services/identity/__tests__/CollaboratorsService.spec.ts
@@ -286,7 +286,10 @@ describe("CollaboratorsService", () => {
       // Arrange
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Admin
-      ) as unknown) as () => Promise<CollaboratorRoles | null>
+      ) as unknown) as () => Promise<Exclude<
+        CollaboratorRoles,
+        CollaboratorRoles.IsomerAdmin
+      > | null>
       mockSitesService.getBySiteName.mockReturnValue(
         okAsync({ id: mockSiteId })
       )
@@ -319,7 +322,10 @@ describe("CollaboratorsService", () => {
       const MALFORMED_EMAIL = "test"
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Admin
-      ) as unknown) as () => Promise<CollaboratorRoles | null>
+      ) as unknown) as () => Promise<Exclude<
+        CollaboratorRoles,
+        CollaboratorRoles.IsomerAdmin
+      > | null>
       mockSitesService.getBySiteName.mockResolvedValue({ id: mockSiteId })
       mockUsersService.findOrCreateByEmail.mockResolvedValue({ id: mockUserId })
       mockSiteMemberRepo.findOne.mockResolvedValue(null)
@@ -347,7 +353,10 @@ describe("CollaboratorsService", () => {
       // Arrange
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => null
-      ) as unknown) as () => Promise<CollaboratorRoles | null>
+      ) as unknown) as () => Promise<Exclude<
+        CollaboratorRoles,
+        CollaboratorRoles.IsomerAdmin
+      > | null>
       mockSitesService.getBySiteName.mockResolvedValue({ id: mockSiteId })
       mockUsersService.findOrCreateByEmail.mockResolvedValue({ id: mockUserId })
       mockSiteMemberRepo.findOne.mockResolvedValue(null)
@@ -375,7 +384,10 @@ describe("CollaboratorsService", () => {
       // Arrange
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Admin
-      ) as unknown) as () => Promise<CollaboratorRoles | null>
+      ) as unknown) as () => Promise<Exclude<
+        CollaboratorRoles,
+        CollaboratorRoles.IsomerAdmin
+      > | null>
       mockSitesService.getBySiteName.mockResolvedValue(errAsync(null))
       mockUsersService.findOrCreateByEmail.mockResolvedValue({ id: mockUserId })
       mockSiteMemberRepo.findOne.mockResolvedValue(null)
@@ -403,7 +415,10 @@ describe("CollaboratorsService", () => {
       // Arrange
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Admin
-      ) as unknown) as () => Promise<CollaboratorRoles | null>
+      ) as unknown) as () => Promise<Exclude<
+        CollaboratorRoles,
+        CollaboratorRoles.IsomerAdmin
+      > | null>
       mockSitesService.getBySiteName.mockResolvedValue(
         okAsync({ id: mockSiteId })
       )
@@ -435,7 +450,10 @@ describe("CollaboratorsService", () => {
       // Arrange
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Contributor
-      ) as unknown) as () => Promise<CollaboratorRoles | null>
+      ) as unknown) as () => Promise<Exclude<
+        CollaboratorRoles,
+        CollaboratorRoles.IsomerAdmin
+      > | null>
       mockSitesService.getBySiteName.mockResolvedValue(
         okAsync({ id: mockSiteId })
       )

--- a/src/services/identity/__tests__/CollaboratorsService.spec.ts
+++ b/src/services/identity/__tests__/CollaboratorsService.spec.ts
@@ -15,6 +15,7 @@ import {
 } from "@fixtures/identity"
 import {
   CollaboratorRoles,
+  CollaboratorRolesWithoutIsomerAdmin,
   INACTIVE_USER_THRESHOLD_DAYS,
 } from "@root/constants"
 import { BadRequestError } from "@root/errors/BadRequestError"
@@ -315,10 +316,7 @@ describe("CollaboratorsService", () => {
       // Arrange
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Admin
-      ) as unknown) as () => Promise<Exclude<
-        CollaboratorRoles,
-        CollaboratorRoles.IsomerAdmin
-      > | null>
+      ) as unknown) as () => Promise<CollaboratorRolesWithoutIsomerAdmin | null>
       mockSitesService.getBySiteName.mockReturnValue(
         okAsync({ id: mockSiteId })
       )
@@ -351,10 +349,7 @@ describe("CollaboratorsService", () => {
       const MALFORMED_EMAIL = "test"
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Admin
-      ) as unknown) as () => Promise<Exclude<
-        CollaboratorRoles,
-        CollaboratorRoles.IsomerAdmin
-      > | null>
+      ) as unknown) as () => Promise<CollaboratorRolesWithoutIsomerAdmin | null>
       mockSitesService.getBySiteName.mockResolvedValue({ id: mockSiteId })
       mockUsersService.findOrCreateByEmail.mockResolvedValue({ id: mockUserId })
       mockSiteMemberRepo.findOne.mockResolvedValue(null)
@@ -382,10 +377,7 @@ describe("CollaboratorsService", () => {
       // Arrange
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => null
-      ) as unknown) as () => Promise<Exclude<
-        CollaboratorRoles,
-        CollaboratorRoles.IsomerAdmin
-      > | null>
+      ) as unknown) as () => Promise<CollaboratorRolesWithoutIsomerAdmin | null>
       mockSitesService.getBySiteName.mockResolvedValue({ id: mockSiteId })
       mockUsersService.findOrCreateByEmail.mockResolvedValue({ id: mockUserId })
       mockSiteMemberRepo.findOne.mockResolvedValue(null)
@@ -413,10 +405,7 @@ describe("CollaboratorsService", () => {
       // Arrange
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Admin
-      ) as unknown) as () => Promise<Exclude<
-        CollaboratorRoles,
-        CollaboratorRoles.IsomerAdmin
-      > | null>
+      ) as unknown) as () => Promise<CollaboratorRolesWithoutIsomerAdmin | null>
       mockSitesService.getBySiteName.mockResolvedValue(errAsync(null))
       mockUsersService.findOrCreateByEmail.mockResolvedValue({ id: mockUserId })
       mockSiteMemberRepo.findOne.mockResolvedValue(null)
@@ -444,10 +433,7 @@ describe("CollaboratorsService", () => {
       // Arrange
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Admin
-      ) as unknown) as () => Promise<Exclude<
-        CollaboratorRoles,
-        CollaboratorRoles.IsomerAdmin
-      > | null>
+      ) as unknown) as () => Promise<CollaboratorRolesWithoutIsomerAdmin | null>
       mockSitesService.getBySiteName.mockResolvedValue(
         okAsync({ id: mockSiteId })
       )
@@ -479,10 +465,7 @@ describe("CollaboratorsService", () => {
       // Arrange
       collaboratorsService.deriveAllowedRoleFromEmail = (jest.fn(
         () => CollaboratorRoles.Contributor
-      ) as unknown) as () => Promise<Exclude<
-        CollaboratorRoles,
-        CollaboratorRoles.IsomerAdmin
-      > | null>
+      ) as unknown) as () => Promise<CollaboratorRolesWithoutIsomerAdmin | null>
       mockSitesService.getBySiteName.mockResolvedValue(
         okAsync({ id: mockSiteId })
       )

--- a/src/services/middlewareServices/AuthenticationMiddlewareService.ts
+++ b/src/services/middlewareServices/AuthenticationMiddlewareService.ts
@@ -86,7 +86,7 @@ const getUserType = (userType: string): TestUserTypes => {
 }
 
 const generateE2eEmailUser = async (
-  role: CollaboratorRoles,
+  role: Exclude<CollaboratorRoles, CollaboratorRoles.IsomerAdmin>,
   site?: string,
   email?: string
 ): Promise<SessionDataProps> => {

--- a/src/services/middlewareServices/AuthenticationMiddlewareService.ts
+++ b/src/services/middlewareServices/AuthenticationMiddlewareService.ts
@@ -16,6 +16,7 @@ import {
   E2E_TEST_EMAIL,
   E2E_ISOMER_ID,
   CollaboratorRoles,
+  CollaboratorRolesWithoutIsomerAdmin,
 } from "@root/constants"
 import { Site, SiteMember, User } from "@root/database/models"
 import { BadRequestError } from "@root/errors/BadRequestError"
@@ -86,7 +87,7 @@ const getUserType = (userType: string): TestUserTypes => {
 }
 
 const generateE2eEmailUser = async (
-  role: Exclude<CollaboratorRoles, CollaboratorRoles.IsomerAdmin>,
+  role: CollaboratorRolesWithoutIsomerAdmin,
   site?: string,
   email?: string
 ): Promise<SessionDataProps> => {

--- a/src/services/middlewareServices/AuthorizationMiddlewareService.ts
+++ b/src/services/middlewareServices/AuthorizationMiddlewareService.ts
@@ -47,8 +47,10 @@ export default class AuthorizationMiddlewareService {
       userId
     )
     return collaboratorType === CollaboratorRoles.Admin
-      ? collaboratorRole === CollaboratorRoles.Admin
-      : collaboratorRole === CollaboratorRoles.Admin ||
+      ? collaboratorRole === CollaboratorRoles.IsomerAdmin ||
+          collaboratorRole === CollaboratorRoles.Admin
+      : collaboratorRole === CollaboratorRoles.IsomerAdmin ||
+          collaboratorRole === CollaboratorRoles.Admin ||
           collaboratorRole === CollaboratorRoles.Contributor
   }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes IS-654.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- A new collaborator role `ISOMERADMIN` has been added to identify users in the IsomerAdmins table. This additional role allows Isomer admins to have access to sites and act as if they are an admin of that particular site.

**Improvements**:

- The logic for the review request summary has been updated to reject GitHub login users if the site has already been migrated. This is to prevent GitHub users from editing their existing sites after we migrate them from GitHub to email login, and to encourage them to edit using their email-login account.

## Tests

<!-- What tests should be run to confirm functionality? -->

- Unit tests
- Smoke tests (on https://github.com/isomerpages/isomercms-frontend/pull/1604)

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*