### PR TITLE
Feat/quickie/site-create-form

### DIFF
--- a/src/database/models/Deployment.ts
+++ b/src/database/models/Deployment.ts
@@ -57,6 +57,12 @@ export class Deployment extends Model {
   hostingId!: string
 
   @Column({
+    allowNull: false,
+    type: DataType.TEXT,
+  })
+  stagingLiteHostingId!: string
+
+  @Column({
     allowNull: true,
     type: DataType.TEXT,
   })

--- a/src/fixtures/sites.ts
+++ b/src/fixtures/sites.ts
@@ -85,6 +85,7 @@ export const MOCK_DEPLOYMENT_DBENTRY_ONE = {
   hostingId: "1",
   encryptionIv: null,
   encryptedPassword: null,
+  stagingLiteHostingId: "2",
 }
 
 export const MOCK_DEPLOYMENT_DBENTRY_TWO: Attributes<Deployment> = {
@@ -98,6 +99,7 @@ export const MOCK_DEPLOYMENT_DBENTRY_TWO: Attributes<Deployment> = {
   encryptionIv: "12345678901234561234567890123456",
   encryptedPassword:
     "1234567890123456789012345678901234567890123456789012345678901234",
+  stagingLiteHostingId: "2",
 }
 
 export const MOCK_SITEMEMBER_DBENTRY_ONE: Attributes<SiteMember> = {

--- a/src/routes/formsgSiteCreation.ts
+++ b/src/routes/formsgSiteCreation.ts
@@ -16,7 +16,6 @@ import UsersService from "@services/identity/UsersService"
 import InfraService from "@services/infra/InfraService"
 import { mailer } from "@services/utilServices/MailClient"
 
-const SITE_CLONE_FORM_KEY = config.get("formSg.siteCloneFormKey")
 const SITE_CREATE_FORM_KEY = config.get("formSg.siteCreateFormKey")
 const REQUESTER_EMAIL_FIELD = "Government E-mail"
 const SITE_NAME_FIELD = "Site Name"

--- a/src/services/identity/DeploymentsService.ts
+++ b/src/services/identity/DeploymentsService.ts
@@ -48,12 +48,16 @@ class DeploymentsService {
       amplifyStagingLiteResult,
     ] = await this.createAmplifyAppsOnAws(repoName)
     if (amplifyStagingResult.isErr()) {
-      logger.error(`Amplify set up error: ${amplifyStagingResult.error}`)
+      logger.error(
+        `Amplify set up error for main app: ${amplifyStagingResult.error}`
+      )
       throw amplifyStagingResult.error
     }
 
     if (amplifyStagingLiteResult.isErr()) {
-      logger.error(`Amplify set up error: ${amplifyStagingLiteResult.error}`)
+      logger.error(
+        `Amplify set up error for staging-lite app: ${amplifyStagingLiteResult.error}`
+      )
       throw amplifyStagingLiteResult.error
     }
 

--- a/src/services/identity/DeploymentsService.ts
+++ b/src/services/identity/DeploymentsService.ts
@@ -57,7 +57,8 @@ class DeploymentsService {
       throw amplifyStagingLiteResult.error
     }
 
-    const amplifyInfo = amplifyStagingLiteResult.value
+    const amplifyInfoStaging = amplifyStagingResult.value
+    const amplifyInfoStagingLite = amplifyStagingLiteResult.value
 
     return this.create({
       stagingUrl: Brand.fromString(
@@ -68,7 +69,8 @@ class DeploymentsService {
       ),
       site,
       siteId: site.id,
-      hostingId: amplifyInfo.id,
+      hostingId: amplifyInfoStaging.id,
+      stagingLiteHostingId: amplifyInfoStagingLite.id,
     })
   }
 

--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -274,7 +274,6 @@ export default class ReposService {
     fs.rmSync(`${stgLiteDir}/.git`, { recursive: true, force: true })
 
     // Prepare git repo
-
     await this.simpleGit
       .cwd(stgLiteDir)
       .init()

--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -268,7 +268,7 @@ export default class ReposService {
     // DO NOT use execSync -> it tends to be blocking and causes BE to hang.
     // From here, all the resulting commands are appended to avoid this ^
     exec(
-      `cd ${stgLiteDir} && rm -rf .git && cd ${stgLiteDir} init && git add . && git commit -m "initial commit for staging lite" && git remote add origin ${repoUrl} && git push origin staging-lite:staging-lite -f`
+      `cd ${stgLiteDir} && rm -rf .git && git init && git checkout -b staging-lite && git add . && git commit -m "initial commit for staging lite" && git remote add origin ${repoUrl} && git push origin staging-lite:staging-lite -f`
     )
   }
 


### PR DESCRIPTION
## Problem

Moving forward to support quickie, all sites need to have 2 branches, `staging` + `staging-lite` AND 2 amplify apps. This modifies the site create form to allow this to happen.
Closes [insert issue #]

- [X] Yes - this PR contains breaking changes
  - This does have implication with site privitisation. I have updated the [oncall runbook](https://www.notion.so/opengov/On-Call-Runbook-ab4bffa2472d47ef9b657242632da7f9?pvs=4#0ebf1ee6cf4c44a4a01352ce7fa79f20) on the additional step needed to make a site private AFTER this pr has been merged into main line. 
- [ ] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

