### PR TITLE
chore(auth): upgrade auth redirect endpoint to use v2

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,6 +1,6 @@
-export CLIENT_ID="" 
-export CLIENT_SECRET="" 
-export REDIRECT_URI="http://localhost:8081/v1/auth"
+export CLIENT_ID=""
+export CLIENT_SECRET=""
+export REDIRECT_URI="http://localhost:8081/v2/auth"
 export NODE_ENV="dev"
 export COOKIE_DOMAIN="localhost"
 export AUTH_TOKEN_EXPIRY_DURATION_IN_MILLISECONDS=800000000


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Auth redirect endpoint still uses the v1 endpoint and should be updated to v2.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Improvements**:

- The auth redirect endpoint has been upgraded to v2.

## Tests

<!-- What tests should be run to confirm functionality? -->

Login via GitHub, it should work as normal.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

⚠️ **The GitHub OAuth apps need to be updated AT THE SAME TIME, otherwise new logins will fail (existing logins are unaffected)** ⚠️ 

**CHANGED environment variables**:

- `REDIRECT_URI` : Any instances of `v1` in the string should be replaced with `v2`. Values in 1PW have already been updated, and the "Authorization callback URL" settings need to be updated:
    - [x] Local dev OAuth app has been updated
    - [ ] Staging OAuth app has been updated
    - [ ] Prod OAuth app has been updated