### PR TITLE
feat(media): include added time for every file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "module-alias": "^2.2.2",
         "moment-timezone": "^0.5.35",
         "morgan": "~1.10.0",
-        "neverthrow": "^4.3.1",
+        "neverthrow": "^6.1.0",
         "nocache": "^3.0.4",
         "node-dig-dns": "^0.3.3",
         "otplib": "^12.0.1",
@@ -13035,9 +13035,9 @@
       "dev": true
     },
     "node_modules/neverthrow": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-4.4.2.tgz",
-      "integrity": "sha512-QVY0ylzBF71pUdLshRrqtweMgqKnE3R37/T82Z5bhO/z8P9z96PC/5pEl2FmiZSy0p+3lsjKerh6jmTWM5fv2g=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-6.1.0.tgz",
+      "integrity": "sha512-xNbNjp/6M5vUV+mststgneJN9eJeJCDSYSBTaf3vxgvcKooP+8L0ATFpM8DGfmH7UWKJeoa24Qi33tBP9Ya3zA=="
     },
     "node_modules/nocache": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "module-alias": "^2.2.2",
     "moment-timezone": "^0.5.35",
     "morgan": "~1.10.0",
-    "neverthrow": "^4.3.1",
+    "neverthrow": "^6.1.0",
     "nocache": "^3.0.4",
     "node-dig-dns": "^0.3.3",
     "otplib": "^12.0.1",

--- a/src/fixtures/media.ts
+++ b/src/fixtures/media.ts
@@ -34,6 +34,7 @@ export const SVG_FILE = {
 const BASE_INPUT = {
   siteName: MEDIA_SITE_NAME,
   directoryName: MEDIA_DIRECTORY_NAME,
+  addedTime: 0,
 }
 
 export const DIR_INPUT = {

--- a/src/routes/formsg/formsgGGsRepair.ts
+++ b/src/routes/formsg/formsgGGsRepair.ts
@@ -6,13 +6,7 @@ import {
   DecryptedFile,
 } from "@opengovsg/formsg-sdk/dist/types"
 import express, { RequestHandler } from "express"
-import {
-  ResultAsync,
-  combineWithAllErrors,
-  errAsync,
-  fromPromise,
-  okAsync,
-} from "neverthrow"
+import { ResultAsync, errAsync, fromPromise, okAsync } from "neverthrow"
 
 import { config } from "@config/config"
 
@@ -172,7 +166,7 @@ export class FormsgGGsRepairRouter {
     })
 
     let errors: GitFileSystemError[] = []
-    combineWithAllErrors(repairs)
+    ResultAsync.combineWithAllErrors(repairs)
       .orElse((error) => {
         errors = error
         // send one final email about success and failures

--- a/src/services/db/GitHubService.ts
+++ b/src/services/db/GitHubService.ts
@@ -504,6 +504,30 @@ export default class GitHubService {
     }
   }
 
+  async getLatestCommitOfPath(
+    sessionData: UserWithSiteSessionData,
+    path: string
+  ) {
+    const { accessToken, siteName } = sessionData
+    const endpoint = `${siteName}/commits`
+    const headers = {
+      Authorization: `token ${accessToken}`,
+    }
+
+    const { data: latestCommit } = await this.axiosInstance.get(endpoint, {
+      headers,
+      params: {
+        path,
+      },
+    })
+
+    if (latestCommit.length === 0)
+      throw new NotFoundError(`Path ${path} does not exist`)
+
+    const { commit: latestCommitMeta } = latestCommit[0]
+    return latestCommitMeta
+  }
+
   async getTree(
     sessionData: UserWithSiteSessionData,
     githubSessionData: GithubSessionData,

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -261,9 +261,13 @@ export default class RepoService extends GitHubService {
     }
 
     // fetch from Github
+    const filePath = `${directoryName}/${fileName}`
     const directoryData = await super.readDirectory(sessionData, {
       directoryName,
     })
+    const {
+      author: { date: addedTime },
+    } = await super.getLatestCommitOfPath(sessionData, filePath)
 
     const mediaType = directoryName.split("/")[0] as MediaType
     const targetFile = directoryData.find(
@@ -276,6 +280,7 @@ export default class RepoService extends GitHubService {
       siteName,
       directoryName,
       mediaType,
+      addedTime,
       isPrivate,
     })
   }

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -1,4 +1,4 @@
-import { Stats } from "fs"
+import fs, { Stats } from "fs"
 
 import mockFs from "mock-fs"
 import { okAsync } from "neverthrow"
@@ -23,6 +23,8 @@ import {
   MOCK_GITHUB_COMMIT_MESSAGE_ALPHA_ONE,
 } from "@fixtures/github"
 import { MOCK_USER_ID_ONE } from "@fixtures/users"
+import { MediaTypeError } from "@root/errors/MediaTypeError"
+import { MediaFileOutput } from "@root/types"
 import { GitHubCommitData } from "@root/types/commitData"
 import { GitDirectoryItem, GitFile } from "@root/types/gitfilesystem"
 import _GitFileSystemService from "@services/db/GitFileSystemService"
@@ -43,6 +45,7 @@ const dirTree = {
   "fake-repo": {
     "fake-dir": {
       "fake-file": "fake content",
+      "fake-media-file.png": "fake media content",
     },
     "another-fake-dir": {
       "fake-file": "duplicate fake file",
@@ -1391,6 +1394,84 @@ describe("GitFileSystemService", () => {
 
       expect(result.isErr()).toBeTrue()
     })
+  })
+
+  describe("readMediaFile", () => {
+    it("should read the contents of a media file successfully", async () => {
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("fake-hash"),
+      })
+      const fileStats = fs.statSync(
+        `${EFS_VOL_PATH_STAGING}/fake-repo/fake-dir/fake-media-file.png`
+      )
+
+      const expected: MediaFileOutput = {
+        name: "fake-media-file.png",
+        sha: "",
+        mediaUrl: `data:image/png;base64,${Buffer.from(
+          "fake media content"
+        ).toString("base64")}`,
+        mediaPath: "fake-dir/fake-media-file.png",
+        type: "file",
+        addedTime: fileStats.birthtimeMs,
+      }
+
+      const actual = await GitFileSystemService.readMediaFile(
+        "fake-repo",
+        "fake-dir",
+        "fake-media-file.png"
+      )
+
+      expect(actual._unsafeUnwrap()).toEqual(expected)
+    })
+
+    it("should return a NotFoundError if the file does not exist", async () => {
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockRejectedValueOnce("fake-hash"),
+      })
+
+      const result = await GitFileSystemService.readMediaFile(
+        "fake-repo",
+        "fake-dir",
+        "non-existent-file.png"
+      )
+
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+    })
+
+    it("should return a GitFileSystemError if an error occurred when getting the Git blob hash", async () => {
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockRejectedValueOnce(new GitError()),
+      })
+
+      const result = await GitFileSystemService.readMediaFile(
+        "fake-repo",
+        "fake-dir",
+        "fake-media-file.png"
+      )
+
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
+    })
+  })
+
+  it("should return a MediaTypeError if the file has an invalid file extension", async () => {
+    const result = await GitFileSystemService.readMediaFile(
+      "fake-repo",
+      "fake-dir",
+      "fake-media-file.invalid"
+    )
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(MediaTypeError)
+  })
+
+  it("should return a MediaTypeError if the file has no file extension", async () => {
+    const result = await GitFileSystemService.readMediaFile(
+      "fake-repo",
+      "fake-dir",
+      "fake-file"
+    )
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(MediaTypeError)
   })
 
   describe("update", () => {

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -251,6 +251,7 @@ describe("RepoService", () => {
         mediaUrl: "sampleBase64Img",
         mediaPath: "images/test-img.jpeg",
         type: "image" as ItemType,
+        addedTime: 0,
       }
       gbSpy.mockReturnValueOnce(true)
       MockGitFileSystemService.readMediaFile.mockResolvedValueOnce(
@@ -268,7 +269,7 @@ describe("RepoService", () => {
       expect(actual).toEqual(expected)
     })
 
-    it("should read image from GitHub for ggs enabled repos", async () => {
+    it("should read image from GitHub for non-ggs enabled repos", async () => {
       const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
         githubId: mockGithubId,
         accessToken: mockAccessToken,
@@ -283,11 +284,16 @@ describe("RepoService", () => {
         mediaUrl: "http://some-cdn.com/image",
         mediaPath: "images/test-img.jpeg",
         type: "image" as ItemType,
+        addedTime: 0,
       }
 
       const gitHubServiceReadDirectory = jest.spyOn(
         GitHubService.prototype,
         "readDirectory"
+      )
+      const gitHubServiceGetLatestCommitOfPath = jest.spyOn(
+        GitHubService.prototype,
+        "getLatestCommitOfPath"
       )
       const gitHubServiceGetRepoInfo = jest.spyOn(
         GitHubService.prototype,
@@ -304,6 +310,11 @@ describe("RepoService", () => {
           name: "fake-dir",
         },
       ])
+      gitHubServiceGetLatestCommitOfPath.mockResolvedValueOnce({
+        author: {
+          date: 0,
+        },
+      })
       gitHubServiceGetRepoInfo.mockResolvedValueOnce({ private: false })
       const getMediaFileInfo = jest
         .spyOn(mediaUtils, "getMediaFileInfo")

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -1,14 +1,6 @@
 import { AxiosResponse } from "axios"
 import _ from "lodash"
-import {
-  err,
-  errAsync,
-  ok,
-  okAsync,
-  Result,
-  ResultAsync,
-  combine,
-} from "neverthrow"
+import { err, errAsync, ok, okAsync, Result, ResultAsync } from "neverthrow"
 import { Op, ModelStatic } from "sequelize"
 import { Sequelize } from "sequelize-typescript"
 
@@ -147,7 +139,7 @@ export default class ReviewRequestService {
         ).map((mappings) => ({ mappings, files }))
       )
       .andThen(({ mappings, files }) =>
-        combine(
+        ResultAsync.combine(
           this.compareDiffWithMappings(
             userWithSiteSessionData,
             stagingLink,
@@ -235,7 +227,7 @@ export default class ReviewRequestService {
     return this.pageService
       .parsePageName(pathInfo, sessionData)
       .andThen((pageName) =>
-        combine([
+        ResultAsync.combine([
           this.pageService.retrieveCmsPermalink(pageName, siteName),
           this.pageService.retrieveStagingPermalink(
             sessionData,

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -13,6 +13,7 @@ export interface MediaFileInput {
   siteName: string
   directoryName: string
   mediaType: MediaType
+  addedTime: number
   isPrivate?: boolean
 }
 
@@ -22,6 +23,7 @@ export interface MediaFileOutput {
   mediaUrl: string
   mediaPath: string
   type: ItemType
+  addedTime: number
 }
 
 export interface MediaDirOutput {

--- a/src/utils/__tests__/media-utils.spec.ts
+++ b/src/utils/__tests__/media-utils.spec.ts
@@ -43,6 +43,7 @@ describe("Media utils test", () => {
       sha: MEDIA_FILE_SHA,
       mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
       type: "file",
+      addedTime: 0,
     }
     expect(await getMediaFileInfo(IMAGE_FILE_PUBLIC_INPUT)).toStrictEqual(
       expectedResp
@@ -58,6 +59,7 @@ describe("Media utils test", () => {
       sha: MEDIA_FILE_SHA,
       mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_SUBDIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
       type: "file",
+      addedTime: 0,
     }
     expect(
       await getMediaFileInfo(NESTED_IMAGE_FILE_PUBLIC_INPUT)
@@ -73,6 +75,7 @@ describe("Media utils test", () => {
       sha: MEDIA_FILE_SHA,
       mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}.svg`,
       type: "file",
+      addedTime: 0,
     }
     expect(await getMediaFileInfo(SVG_FILE_PUBLIC_INPUT)).toStrictEqual(
       expectedResp
@@ -88,6 +91,7 @@ describe("Media utils test", () => {
       sha: MEDIA_FILE_SHA,
       mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
       type: "file",
+      addedTime: 0,
     }
     expect(await getMediaFileInfo(PDF_FILE_PUBLIC_INPUT)).toStrictEqual(
       expectedResp
@@ -100,6 +104,7 @@ describe("Media utils test", () => {
       sha: MEDIA_FILE_SHA,
       mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
       type: "file",
+      addedTime: 0,
     }
     const resp = await getMediaFileInfo(IMAGE_FILE_PRIVATE_INPUT)
     expect(resp).toStrictEqual(expect.objectContaining(expectedPartialResp))
@@ -120,6 +125,7 @@ describe("Media utils test", () => {
       sha: MEDIA_FILE_SHA,
       mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}.svg`,
       type: "file",
+      addedTime: 0,
     }
     const resp = await getMediaFileInfo(SVG_FILE_PRIVATE_INPUT)
     expect(resp).toStrictEqual(expect.objectContaining(expectedPartialResp))
@@ -143,6 +149,7 @@ describe("Media utils test", () => {
       sha: MEDIA_FILE_SHA,
       mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
       type: "file",
+      addedTime: 0,
     }
     expect(await getMediaFileInfo(PDF_FILE_PRIVATE_INPUT)).toStrictEqual(
       expectedResp

--- a/src/utils/media-utils.ts
+++ b/src/utils/media-utils.ts
@@ -30,6 +30,7 @@ export const getMediaFileInfo = async ({
   siteName,
   directoryName,
   mediaType,
+  addedTime,
   isPrivate,
 }: MediaFileInput): Promise<MediaFileOutput> => {
   const baseFileData = {
@@ -37,6 +38,7 @@ export const getMediaFileInfo = async ({
     sha: file.sha,
     mediaPath: `${directoryName}/${file.name}`,
     type: file.type,
+    addedTime,
   }
   if (mediaType === "images" && isPrivate) {
     try {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Part of 681 and 682.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- The response when getting each media file now includes the timestamp that it was added.
    - For GGS repos, the added time is correct in the sense that it is the "birthtime" of the file.
    - For non-GGS repos, because Git has no concept of file creation timestamps, we have to get this information from the Git commit history. However, one caveat is that it is possible for the user to have deleted the file and created another with the same name, so we cannot rely on getting the earliest commit of that path. Since we generally only create commits when they upload, we can make a "best guess" using the latest commit.

**Improvements**:

- The `neverthrow` library has been upgraded to take advantage of [better type inferences](https://github.com/supermacro/neverthrow/releases/tag/v5.1.0). The breaking changes has been fixed in the codebase.

## Tests

<!-- What tests should be run to confirm functionality? -->

- Unit tests.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**UPGRADED dependencies**:

- `neverthrow` : for type inferences when using `combine`.
