### PR TITLE
fix: reposervice fix cwd

### DIFF
--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -111,7 +111,7 @@ export default class GitFileSystemService {
       ? `${EFS_VOL_PATH_STAGING}/${repoName}`
       : `${EFS_VOL_PATH_STAGING_LITE}/${repoName}`
     return ResultAsync.fromPromise(
-      this.git.cwd(`${repoPath}`).checkIsRepo(),
+      this.git.cwd({ path: `${repoPath}`, root: false }).checkIsRepo(),
       (error) => {
         logger.error(
           `Error when checking if ${repoName} is a Git repo: ${error}`
@@ -137,7 +137,9 @@ export default class GitFileSystemService {
       ? `${EFS_VOL_PATH_STAGING}/${repoName}`
       : `${EFS_VOL_PATH_STAGING_LITE}/${repoName}`
     return ResultAsync.fromPromise(
-      this.git.cwd(repoPath).remote(["get-url", "origin"]),
+      this.git
+        .cwd({ path: repoPath, root: false })
+        .remote(["get-url", "origin"]),
       (error) => {
         logger.error(`Error when checking origin remote URL: ${error}`)
 
@@ -204,7 +206,7 @@ export default class GitFileSystemService {
     const efsVolPath = this.getEfsVolPathFromBranch(branchName)
     return ResultAsync.fromPromise(
       this.git
-        .cwd(`${efsVolPath}/${repoName}`)
+        .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
         .revparse(["--abbrev-ref", "HEAD"]),
       (error) => {
         logger.error(`Error when getting current branch: ${error}`)
@@ -218,7 +220,9 @@ export default class GitFileSystemService {
     ).andThen((currentBranch) => {
       if (currentBranch !== branchName) {
         return ResultAsync.fromPromise(
-          this.git.cwd(`${efsVolPath}/${repoName}`).checkout(branchName),
+          this.git
+            .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
+            .checkout(branchName),
           (error) => {
             logger.error(`Error when checking out ${branchName}: ${error}`)
 
@@ -245,7 +249,9 @@ export default class GitFileSystemService {
       ? EFS_VOL_PATH_STAGING
       : EFS_VOL_PATH_STAGING_LITE
     return ResultAsync.fromPromise(
-      this.git.cwd(`${efsVolPath}/${repoName}`).revparse([`HEAD:${filePath}`]),
+      this.git
+        .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
+        .revparse([`HEAD:${filePath}`]),
       (error) => {
         logger.error(
           `Error when getting Git blob hash: ${error} when trying to access ${efsVolPath}/${repoName}`
@@ -302,7 +308,9 @@ export default class GitFileSystemService {
   ): ResultAsync<LogResult<DefaultLogFields>, GitFileSystemError> {
     const efsVolPath = this.getEfsVolPathFromBranch(branchName)
     return ResultAsync.fromPromise(
-      this.git.cwd(`${efsVolPath}/${repoName}`).log([branchName]),
+      this.git
+        .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
+        .log([branchName]),
       (error) => {
         logger.error(
           `Error when getting latest commit of "${branchName}" branch: ${error}, when trying to access ${efsVolPath}/${repoName} for ${branchName}`
@@ -331,7 +339,7 @@ export default class GitFileSystemService {
     const efsVolPath = this.getEfsVolPathFromBranch(branchName)
     return ResultAsync.fromPromise(
       this.git
-        .cwd(`${efsVolPath}/${repoName}`)
+        .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
         .reset(["--hard", commitSha])
         .clean(CleanOptions.FORCE + CleanOptions.RECURSIVE),
       (error) => {
@@ -378,7 +386,7 @@ export default class GitFileSystemService {
           const clonePromise = isStaging
             ? this.git
                 .clone(originUrl, `${efsVolPath}/${repoName}`)
-                .cwd(`${efsVolPath}/${repoName}`)
+                .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
                 .checkout(branch)
             : this.git
                 .clone(originUrl, `${efsVolPath}/${repoName}`, [
@@ -386,7 +394,7 @@ export default class GitFileSystemService {
                   branch,
                   "--single-branch",
                 ])
-                .cwd(`${efsVolPath}/${repoName}`)
+                .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
 
           return ResultAsync.fromPromise(clonePromise, (error) => {
             logger.error(`Error when cloning ${repoName}: ${error}`)
@@ -448,7 +456,9 @@ export default class GitFileSystemService {
 
       return this.ensureCorrectBranch(repoName, branchName).andThen(() =>
         ResultAsync.fromPromise(
-          this.git.cwd(`${efsVolPath}/${repoName}`).pull(),
+          this.git
+            .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
+            .pull(),
           (error) => {
             // Full error message 1: Your configuration specifies to merge
             // with the ref 'refs/heads/staging' from the remote, but no
@@ -514,9 +524,11 @@ export default class GitFileSystemService {
           ResultAsync.fromPromise(
             isForce
               ? this.git
-                  .cwd(`${efsVolPath}/${repoName}`)
+                  .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
                   .push([...gitOptions, "--force"])
-              : this.git.cwd(`${efsVolPath}/${repoName}`).push(gitOptions),
+              : this.git
+                  .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
+                  .push(gitOptions),
             (error) => {
               logger.error(`Error when pushing ${repoName}: ${error}`)
 
@@ -534,8 +546,12 @@ export default class GitFileSystemService {
           // Retry push once
           ResultAsync.fromPromise(
             isForce
-              ? this.git.cwd(`${efsVolPath}/${repoName}`).push(["--force"])
-              : this.git.cwd(`${efsVolPath}/${repoName}`).push(),
+              ? this.git
+                  .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
+                  .push(["--force"])
+              : this.git
+                  .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
+                  .push(),
             (error) => {
               logger.error(`Error when pushing ${repoName}: ${error}`)
 
@@ -600,7 +616,9 @@ export default class GitFileSystemService {
           }
 
           return ResultAsync.fromPromise(
-            this.git.cwd(`${efsVolPath}/${repoName}`).add(pathSpec),
+            this.git
+              .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
+              .add(pathSpec),
             (error) => {
               logger.error(
                 `Error when Git adding files to ${repoName}: ${error}`
@@ -620,7 +638,9 @@ export default class GitFileSystemService {
         })
         .andThen(() =>
           ResultAsync.fromPromise(
-            this.git.cwd(`${efsVolPath}/${repoName}`).commit(commitMessage),
+            this.git
+              .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
+              .commit(commitMessage),
             (error) => {
               logger.error(`Error when committing ${repoName}: ${error}`)
 
@@ -1163,7 +1183,9 @@ export default class GitFileSystemService {
       )
       .andThen(() =>
         ResultAsync.fromPromise(
-          this.git.cwd(`${efsVolPath}/${repoName}`).mv(oldPath, newPath),
+          this.git
+            .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
+            .mv(oldPath, newPath),
           (error) => {
             logger.error(`Error when moving ${oldPath} to ${newPath}: ${error}`)
 
@@ -1366,7 +1388,9 @@ export default class GitFileSystemService {
       return this.ensureCorrectBranch(repoName, branchName)
         .andThen(() =>
           ResultAsync.fromPromise(
-            this.git.cwd(`${efsVolPath}/${repoName}`).catFile(["-t", sha]),
+            this.git
+              .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
+              .catFile(["-t", sha]),
             (error) => {
               // An error is thrown if the SHA does not exist in the branch
               if (error instanceof GitError) {
@@ -1379,7 +1403,9 @@ export default class GitFileSystemService {
         )
         .andThen(() =>
           ResultAsync.fromPromise(
-            this.git.cwd(`${efsVolPath}/${repoName}`).reset(["--hard", sha]),
+            this.git
+              .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
+              .reset(["--hard", sha]),
             (error) => {
               logger.error(`Error when updating repo state: ${error}`)
 

--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -124,7 +124,7 @@ export default class ReposService {
 
     // 2. Commit changes in local repo
     await this.simpleGit
-      .cwd(dir)
+      .cwd({ path: dir, root: false })
       .checkout("staging") // ensure on staging branch
       .add(".")
       .addConfig("user.name", ISOMER_GITHUB_ORGANIZATION_NAME)
@@ -132,16 +132,23 @@ export default class ReposService {
       .commit("Set URLs")
 
     // 3. Push changes to staging branch
-    await this.simpleGit.cwd(dir).push("origin", "staging")
+    await this.simpleGit
+      .cwd({ path: dir, root: false })
+      .push("origin", "staging")
 
     // 4. Merge these changes into master branch
-    await this.simpleGit.cwd(dir).checkout("master").merge(["staging"])
+    await this.simpleGit
+      .cwd({ path: dir, root: false })
+      .checkout("master")
+      .merge(["staging"])
 
     // 5. Push changes to master branch
-    await this.simpleGit.cwd(dir).push("origin", "master")
+    await this.simpleGit
+      .cwd({ path: dir, root: false })
+      .push("origin", "master")
 
     // 6. Checkout back to staging branch
-    await this.simpleGit.cwd(dir).checkout("staging")
+    await this.simpleGit.cwd({ path: dir, root: false }).checkout("staging")
   }
 
   private setUrlsInLocalConfig(
@@ -225,7 +232,7 @@ export default class ReposService {
     // Clone base repo locally
     fs.mkdirSync(stgDir)
     await this.simpleGit
-      .cwd(stgDir)
+      .cwd({ path: stgDir, root: false })
       .clone(SITE_CREATION_BASE_REPO_URL, stgDir, ["-b", "staging"])
 
     // Clear git
@@ -233,7 +240,7 @@ export default class ReposService {
 
     // Prepare git repo
     await this.simpleGit
-      .cwd(stgDir)
+      .cwd({ path: stgDir, root: false })
       .init(["--initial-branch=staging"])
       .checkoutLocalBranch("staging")
 
@@ -242,14 +249,14 @@ export default class ReposService {
 
     // Commit
     await this.simpleGit
-      .cwd(stgDir)
+      .cwd({ path: stgDir, root: false })
       .addConfig("user.name", "isomeradmin")
       .addConfig("user.email", ISOMER_GITHUB_EMAIL)
       .commit("Initial commit")
 
     // Push to origin
     await this.simpleGit
-      .cwd(stgDir)
+      .cwd({ path: stgDir, root: false })
       .addRemote("origin", repoUrl)
       .checkout("staging")
       .push(["-u", "origin", "staging"]) // push to staging first to make it the default branch on GitHub
@@ -376,10 +383,12 @@ export const createRecords = (zoneId: string): Record[] => {
     // note: for some reason, combining below commands led to race conditions
     // so we have to do it separately
     // Create staging lite branch in other repo path
-    await this.simpleGit.cwd(stgLiteDir).clone(repoUrl, stgLiteDir)
-    await this.simpleGit.cwd(stgLiteDir).pull() // some repos are large, clone takes time
     await this.simpleGit
-      .cwd(stgLiteDir)
+      .cwd({ path: stgLiteDir, root: false })
+      .clone(repoUrl, stgLiteDir)
+    await this.simpleGit.cwd({ path: stgLiteDir, root: false }).pull() // some repos are large, clone takes time
+    await this.simpleGit
+      .cwd({ path: stgLiteDir, root: false })
       .checkout("staging")
       .rm(["-r", "images"])
       .rm(["-r", "files"])
@@ -389,7 +398,7 @@ export const createRecords = (zoneId: string): Record[] => {
 
     // Prepare git repo
     await this.simpleGit
-      .cwd(stgLiteDir)
+      .cwd({ path: stgLiteDir, root: false })
       .init()
       .checkoutLocalBranch("staging-lite")
       .add(".")


### PR DESCRIPTION
## Problem

By right we are supposed to use `root = false`, to quite the [doc](https://github.com/steveukx/git-js) 
```
.cwd({ path, root = false }) Sets the working directory for all future commands either in the current chain of commands (where root is omitted or set to false) or in the main instance (where root is true).
```

Ran this agains this against ~30 sites at one go, no errors like the ones we previously observed
![Screenshot 2023-11-01 at 5 29 23 PM](https://github.com/isomerpages/isomercms-backend/assets/42832651/7952b2db-b053-40cc-b0ba-b6248b6161e1)


### Tests 
- [ ] e2e tests for GGs 
- [ ] For a GGs site in staging, able to CRUD on pages + CRUD on images 