### PR TITLE
fix(reposService): simple git path cwd

### DIFF
--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -245,7 +245,7 @@ export default class ReposService {
       .checkoutLocalBranch("staging")
 
     // Add all the changes
-    await this.simpleGit.cwd(stgDir).add(".")
+    await this.simpleGit.cwd({ path: stgDir, root: false }).add(".")
 
     // Commit
     await this.simpleGit


### PR DESCRIPTION
forgot to add in one more to #1004 

no more .cwd(path) signatures found