### PR TITLE
feat(media): add size information when getting media data

### DIFF
--- a/src/fixtures/media.ts
+++ b/src/fixtures/media.ts
@@ -11,6 +11,7 @@ export const MEDIA_DIR: MediaFile = {
   type: "dir",
   sha: MEDIA_FILE_SHA,
   path: `${MEDIA_DIRECTORY_NAME}/directory`,
+  size: 0,
 }
 
 const BASE_MEDIA_FILE: MediaFile = {
@@ -18,6 +19,7 @@ const BASE_MEDIA_FILE: MediaFile = {
   type: "file",
   sha: MEDIA_FILE_SHA,
   path: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
+  size: 1234,
 }
 
 export const NESTED_MEDIA_FILE: MediaFile = {

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -852,11 +852,12 @@ export default class GitFileSystemService {
 
         return okAsync({
           name: fileName,
-          sha: "",
+          sha: file.sha,
           mediaUrl: `${dataUrlPrefix},${file.content}`,
           mediaPath: `${directoryName}/${fileName}`,
           type: fileType,
           addedTime: stats.birthtimeMs,
+          size: stats.size,
         })
       })
   }

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -1407,13 +1407,14 @@ describe("GitFileSystemService", () => {
 
       const expected: MediaFileOutput = {
         name: "fake-media-file.png",
-        sha: "",
+        sha: "fake-hash",
         mediaUrl: `data:image/png;base64,${Buffer.from(
           "fake media content"
         ).toString("base64")}`,
         mediaPath: "fake-dir/fake-media-file.png",
         type: "file",
         addedTime: fileStats.birthtimeMs,
+        size: fileStats.size,
       }
 
       const actual = await GitFileSystemService.readMediaFile(

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -252,6 +252,7 @@ describe("RepoService", () => {
         mediaPath: "images/test-img.jpeg",
         type: "image" as ItemType,
         addedTime: 0,
+        size: 0,
       }
       gbSpy.mockReturnValueOnce(true)
       MockGitFileSystemService.readMediaFile.mockResolvedValueOnce(
@@ -285,6 +286,7 @@ describe("RepoService", () => {
         mediaPath: "images/test-img.jpeg",
         type: "image" as ItemType,
         addedTime: 0,
+        size: 0,
       }
 
       const gitHubServiceReadDirectory = jest.spyOn(

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -6,6 +6,7 @@ export interface MediaFile {
   type: ItemType
   sha: string
   path: string
+  size: number
 }
 
 export interface MediaFileInput {
@@ -24,6 +25,7 @@ export interface MediaFileOutput {
   mediaPath: string
   type: ItemType
   addedTime: number
+  size: number
 }
 
 export interface MediaDirOutput {

--- a/src/utils/__tests__/media-utils.spec.ts
+++ b/src/utils/__tests__/media-utils.spec.ts
@@ -44,6 +44,7 @@ describe("Media utils test", () => {
       mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
       type: "file",
       addedTime: 0,
+      size: 1234,
     }
     expect(await getMediaFileInfo(IMAGE_FILE_PUBLIC_INPUT)).toStrictEqual(
       expectedResp
@@ -60,6 +61,7 @@ describe("Media utils test", () => {
       mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_SUBDIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
       type: "file",
       addedTime: 0,
+      size: 1234,
     }
     expect(
       await getMediaFileInfo(NESTED_IMAGE_FILE_PUBLIC_INPUT)
@@ -76,6 +78,7 @@ describe("Media utils test", () => {
       mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}.svg`,
       type: "file",
       addedTime: 0,
+      size: 1234,
     }
     expect(await getMediaFileInfo(SVG_FILE_PUBLIC_INPUT)).toStrictEqual(
       expectedResp
@@ -92,6 +95,7 @@ describe("Media utils test", () => {
       mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
       type: "file",
       addedTime: 0,
+      size: 1234,
     }
     expect(await getMediaFileInfo(PDF_FILE_PUBLIC_INPUT)).toStrictEqual(
       expectedResp
@@ -105,6 +109,7 @@ describe("Media utils test", () => {
       mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
       type: "file",
       addedTime: 0,
+      size: 1234,
     }
     const resp = await getMediaFileInfo(IMAGE_FILE_PRIVATE_INPUT)
     expect(resp).toStrictEqual(expect.objectContaining(expectedPartialResp))
@@ -126,6 +131,7 @@ describe("Media utils test", () => {
       mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}.svg`,
       type: "file",
       addedTime: 0,
+      size: 1234,
     }
     const resp = await getMediaFileInfo(SVG_FILE_PRIVATE_INPUT)
     expect(resp).toStrictEqual(expect.objectContaining(expectedPartialResp))
@@ -150,6 +156,7 @@ describe("Media utils test", () => {
       mediaPath: `${MEDIA_DIRECTORY_NAME}/${MEDIA_FILE_NAME}`,
       type: "file",
       addedTime: 0,
+      size: 1234,
     }
     expect(await getMediaFileInfo(PDF_FILE_PRIVATE_INPUT)).toStrictEqual(
       expectedResp

--- a/src/utils/media-utils.ts
+++ b/src/utils/media-utils.ts
@@ -39,6 +39,7 @@ export const getMediaFileInfo = async ({
     mediaPath: `${directoryName}/${file.name}`,
     type: file.type,
     addedTime,
+    size: file.size,
   }
   if (mediaType === "images" && isPrivate) {
     try {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Part of 720.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- The frontend needs to report the size information when deleting media, lets now send it together as part of the query to get the media data information.

**Bug Fixes**:

- The file sha was accidentally removed, now added back.

## Tests

<!-- What tests should be run to confirm functionality? -->

Unit tests.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*