### PR TITLE
Fix/quickie/dbUpdate

### DIFF
--- a/src/fixtures/repoInfo.ts
+++ b/src/fixtures/repoInfo.ts
@@ -11,6 +11,9 @@ export const MOCK_STAGING_URL_CONFIGYML: NonNullable<
 export const MOCK_STAGING_URL_DB: NonNullable<
   ConfigYmlData["staging"]
 > = Brand.fromString("https://repo-staging-db.netlify.app")
+export const MOCK_STAGING_LITE_URL_DB: NonNullable<
+  ConfigYmlData["staging"]
+> = Brand.fromString("https://repo-staging-lite-db.netlify.app")
 
 export const MOCK_PRODUCTION_URL_GITHUB: NonNullable<
   ConfigYmlData["prod"]

--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -6,6 +6,7 @@ import { NotificationOnEditHandler } from "@middleware/notificationOnEditHandler
 import UserSessionData from "@classes/UserSessionData"
 
 import {
+  Deployment,
   Notification,
   Repo,
   Reviewer,
@@ -41,6 +42,7 @@ import { UnlinkedPageService } from "@root/services/fileServices/MdPageServices/
 import { CollectionYmlService } from "@root/services/fileServices/YmlFileServices/CollectionYmlService"
 import { ConfigService } from "@root/services/fileServices/YmlFileServices/ConfigService"
 import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/FooterYmlService"
+import DeploymentsService from "@root/services/identity/DeploymentsService"
 import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import RepoService from "@services/db/RepoService"
@@ -121,6 +123,9 @@ const reviewRequestService = new ReviewRequestService(
   configService,
   sequelize
 )
+const deploymentsService = new DeploymentsService({
+  deploymentsRepository: Deployment,
+})
 // Using a mock SitesCacheService as the actual service has setInterval
 // which causes tests to not exit.
 const MockSitesCacheService = {
@@ -136,6 +141,7 @@ const sitesService = new SitesService({
   reviewRequestService,
   sitesCacheService: (MockSitesCacheService as unknown) as SitesCacheService,
   previewService: (MockPreviewService as unknown) as PreviewService,
+  deploymentsService,
 })
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,

--- a/src/integration/Notifications.spec.ts
+++ b/src/integration/Notifications.spec.ts
@@ -3,6 +3,7 @@ import simpleGit from "simple-git"
 import request from "supertest"
 
 import {
+  Deployment,
   Notification,
   Repo,
   Reviewer,
@@ -48,6 +49,7 @@ import { ConfigService } from "@root/services/fileServices/YmlFileServices/Confi
 import { ConfigYmlService } from "@root/services/fileServices/YmlFileServices/ConfigYmlService"
 import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/FooterYmlService"
 import CollaboratorsService from "@root/services/identity/CollaboratorsService"
+import DeploymentsService from "@root/services/identity/DeploymentsService"
 import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import SitesService from "@root/services/identity/SitesService"
@@ -126,6 +128,10 @@ const reviewRequestService = new ReviewRequestService(
   configService,
   sequelize
 )
+
+const deploymentsService = new DeploymentsService({
+  deploymentsRepository: Deployment,
+})
 // Using a mock SitesCacheService as the actual service has setInterval
 // which causes tests to not exit.
 const MockSitesCacheService = {
@@ -141,6 +147,7 @@ const sitesService = new SitesService({
   reviewRequestService,
   sitesCacheService: (MockSitesCacheService as unknown) as SitesCacheService,
   previewService: (MockPreviewService as unknown) as PreviewService,
+  deploymentsService,
 })
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,

--- a/src/integration/Privatisation.spec.ts
+++ b/src/integration/Privatisation.spec.ts
@@ -157,6 +157,10 @@ const reviewRequestService = new ReviewRequestService(
   configService,
   sequelize
 )
+
+const deploymentsService = new DeploymentsService({
+  deploymentsRepository: Deployment,
+})
 // Using a mock SitesCacheService as the actual service has setInterval
 // which causes tests to not exit.
 const MockSitesCacheService = {
@@ -172,15 +176,13 @@ const sitesService = new SitesService({
   reviewRequestService,
   sitesCacheService: (MockSitesCacheService as unknown) as SitesCacheService,
   previewService: (MockPreviewService as unknown) as PreviewService,
+  deploymentsService,
 })
 const navYmlService = new NavYmlService({
   gitHubService,
 })
 const homepagePageService = new HomepagePageService({
   gitHubService,
-})
-const deploymentsService = new DeploymentsService({
-  deploymentsRepository: Deployment,
 })
 
 const identityAuthService = getIdentityAuthService(gitHubService)

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -88,6 +88,7 @@ import { UnlinkedPageService } from "@root/services/fileServices/MdPageServices/
 import { CollectionYmlService } from "@root/services/fileServices/YmlFileServices/CollectionYmlService"
 import { ConfigService } from "@root/services/fileServices/YmlFileServices/ConfigService"
 import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/FooterYmlService"
+import DeploymentsService from "@root/services/identity/DeploymentsService"
 import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import { ReviewRequestDto } from "@root/types/dto/review"
@@ -161,6 +162,9 @@ const reviewRequestService = new ReviewRequestService(
   configService,
   sequelize
 )
+const deploymentsService = new DeploymentsService({
+  deploymentsRepository: Deployment,
+})
 // Using a mock SitesCacheService as the actual service has setInterval
 // which causes tests to not exit.
 const MockSitesCacheService = {
@@ -176,6 +180,7 @@ const sitesService = new SitesService({
   reviewRequestService,
   sitesCacheService: (MockSitesCacheService as unknown) as SitesCacheService,
   previewService: (MockPreviewService as unknown) as PreviewService,
+  deploymentsService,
 })
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,

--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -125,6 +125,10 @@ const reviewRequestService = new ReviewRequestService(
   configService,
   sequelize
 )
+
+const deploymentsService = new DeploymentsService({
+  deploymentsRepository: Deployment,
+})
 // Using a mock SitesCacheService as the actual service has setInterval
 // which causes tests to not exit.
 const MockSitesCacheService = {
@@ -141,6 +145,7 @@ const sitesService = new SitesService({
   reviewRequestService,
   sitesCacheService: (MockSitesCacheService as unknown) as SitesCacheService,
   previewService: (MockPreviewService as unknown) as PreviewService,
+  deploymentsService,
 })
 const collaboratorsService = new CollaboratorsService({
   siteRepository: Site,
@@ -161,9 +166,6 @@ const authorizationMiddleware = getAuthorizationMiddleware({
 const reposService = new ReposService({
   repository: Repo,
   simpleGit: simpleGit(),
-})
-const deploymentsService = new DeploymentsService({
-  deploymentsRepository: Deployment,
 })
 const launchClient = new LaunchClient()
 const launchesService = new LaunchesService({

--- a/src/server.js
+++ b/src/server.js
@@ -233,6 +233,9 @@ const reviewRequestService = new ReviewRequestService(
 const cacheRefreshInterval = 1000 * 60 * 5 // 5 minutes
 const sitesCacheService = new SitesCacheService(cacheRefreshInterval)
 const previewService = new PreviewService()
+const deploymentsService = new DeploymentsService({
+  deploymentsRepository: Deployment,
+})
 const sitesService = new SitesService({
   siteRepository: Site,
   gitHubService,
@@ -242,14 +245,13 @@ const sitesService = new SitesService({
   reviewRequestService,
   sitesCacheService,
   previewService,
+  deploymentsService,
 })
 const reposService = new ReposService({
   repository: Repo,
   simpleGit: simpleGitInstance,
 })
-const deploymentsService = new DeploymentsService({
-  deploymentsRepository: Deployment,
-})
+
 const launchClient = new LaunchClient()
 const launchesService = new LaunchesService({
   launchesRepository: Launch,

--- a/src/services/identity/DeploymentsService.ts
+++ b/src/services/identity/DeploymentsService.ts
@@ -250,6 +250,7 @@ class DeploymentsService {
     })
     if (!deploymentInfo)
       return errAsync(new NotFoundError("Site has not been deployed!"))
+    logger.info(`Updating staging url for ${siteId} to ${stagingUrl}`)
     await this.deploymentsRepository.update(
       {
         stagingUrl,

--- a/src/services/identity/DeploymentsService.ts
+++ b/src/services/identity/DeploymentsService.ts
@@ -241,6 +241,23 @@ class DeploymentsService {
 
     return updateResp
   }
+
+  updateStagingUrl = async (siteId: number, stagingUrl: string) => {
+    const deploymentInfo = await this.deploymentsRepository.findOne({
+      where: {
+        siteId,
+      },
+    })
+    if (!deploymentInfo)
+      return errAsync(new NotFoundError("Site has not been deployed!"))
+    await this.deploymentsRepository.update(
+      {
+        stagingUrl,
+      },
+      { where: { siteId } }
+    )
+    return okAsync(deploymentInfo)
+  }
 }
 
 export default DeploymentsService

--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -383,6 +383,7 @@ export const createRecords = (zoneId: string): Record[] => {
     // note: for some reason, combining below commands led to race conditions
     // so we have to do it separately
     // Create staging lite branch in other repo path
+
     await this.simpleGit
       .cwd({ path: stgLiteDir, root: false })
       .clone(repoUrl, stgLiteDir)
@@ -390,8 +391,18 @@ export const createRecords = (zoneId: string): Record[] => {
     await this.simpleGit
       .cwd({ path: stgLiteDir, root: false })
       .checkout("staging")
-      .rm(["-r", "images"])
-      .rm(["-r", "files"])
+
+    if (fs.existsSync(path.join(`${stgLiteDir}`, `images`))) {
+      await this.simpleGit
+        .cwd({ path: stgLiteDir, root: false })
+        .rm(["-r", "images"])
+    }
+
+    if (fs.existsSync(path.join(`${stgLiteDir}`, `files`))) {
+      await this.simpleGit
+        .cwd({ path: stgLiteDir, root: false })
+        .rm(["-r", "files"])
+    }
 
     // Clear git
     fs.rmSync(`${stgLiteDir}/.git`, { recursive: true, force: true })

--- a/src/services/identity/SitesService.ts
+++ b/src/services/identity/SitesService.ts
@@ -31,6 +31,8 @@ import IsomerAdminsService from "@services/identity/IsomerAdminsService"
 import UsersService from "@services/identity/UsersService"
 import ReviewRequestService from "@services/review/ReviewRequestService"
 
+import DeploymentsService from "./DeploymentsService"
+
 interface SitesServiceProps {
   siteRepository: ModelStatic<Site>
   gitHubService: RepoService
@@ -40,6 +42,7 @@ interface SitesServiceProps {
   reviewRequestService: ReviewRequestService
   sitesCacheService: SitesCacheService
   previewService: PreviewService
+  deploymentsService: DeploymentsService
 }
 
 class SitesService {
@@ -61,6 +64,8 @@ class SitesService {
 
   private readonly previewService: SitesServiceProps["previewService"]
 
+  private readonly deploymentsService: SitesServiceProps["deploymentsService"]
+
   constructor({
     siteRepository,
     gitHubService,
@@ -70,6 +75,7 @@ class SitesService {
     reviewRequestService,
     sitesCacheService,
     previewService,
+    deploymentsService,
   }: SitesServiceProps) {
     this.siteRepository = siteRepository
     this.gitHubService = gitHubService
@@ -79,6 +85,7 @@ class SitesService {
     this.reviewRequestService = reviewRequestService
     this.sitesCacheService = sitesCacheService
     this.previewService = previewService
+    this.deploymentsService = deploymentsService
   }
 
   isGitHubCommitData(commit: unknown): commit is GitHubCommitData {
@@ -260,20 +267,8 @@ class SitesService {
       .orElse(() => okAsync(this.extractAuthorEmail(commit)))
   }
 
-  updateDbWithStagingUrl(site: Site, stagingUrl: StagingPermalink) {
-    // Non-blocking control flow
-    this.siteRepository.update(
-      {
-        deployment: {
-          stagingUrl,
-        },
-      },
-      {
-        where: {
-          id: site.id,
-        },
-      }
-    )
+  async updateDbWithStagingUrl(site: Site, stagingUrl: StagingPermalink) {
+    this.deploymentsService.updateStagingUrl(site.id, stagingUrl)
   }
 
   // Tries to get the site urls in the following order:

--- a/src/services/identity/__tests__/SitesService.spec.ts
+++ b/src/services/identity/__tests__/SitesService.spec.ts
@@ -28,6 +28,7 @@ import {
   MOCK_STAGING_URL_DB,
   MOCK_STAGING_URL_GITHUB,
   MOCK_PRODUCTION_URL_GITHUB,
+  MOCK_STAGING_LITE_URL_DB,
 } from "@fixtures/repoInfo"
 import {
   mockUserWithSiteSessionData,
@@ -47,12 +48,15 @@ import { GitHubCommitData } from "@root/types/commitData"
 import { ConfigYmlData } from "@root/types/configYml"
 import type { RepositoryData, SiteUrls } from "@root/types/repoInfo"
 import { SiteInfo } from "@root/types/siteInfo"
+import { isReduceBuildTimesWhitelistedRepo } from "@root/utils/growthbook-utils"
 import RepoService from "@services/db/RepoService"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
 import IsomerAdminsService from "@services/identity/IsomerAdminsService"
 import { SitesCacheService } from "@services/identity/SitesCacheService"
 import _SitesService from "@services/identity/SitesService"
 import UsersService from "@services/identity/UsersService"
+
+import DeploymentsService from "../DeploymentsService"
 
 const MockRepository = {
   findOne: jest.fn(),
@@ -85,6 +89,10 @@ const MockSitesCacheService = {
   getLastUpdated: jest.fn(),
 }
 
+const MockDeploymentsService = {
+  updateStagingUrl: jest.fn(),
+}
+
 const MockPreviewService = {}
 const SitesService = new _SitesService({
   siteRepository: (MockRepository as unknown) as ModelStatic<Site>,
@@ -95,6 +103,7 @@ const SitesService = new _SitesService({
   reviewRequestService: (MockReviewRequestService as unknown) as ReviewRequestService,
   sitesCacheService: (MockSitesCacheService as unknown) as SitesCacheService,
   previewService: (MockPreviewService as unknown) as PreviewService,
+  deploymentsService: (MockDeploymentsService as unknown) as DeploymentsService,
 })
 
 const SpySitesService = {
@@ -106,6 +115,18 @@ const mockSite = ({
   name: "i m a site",
   users: [],
 } as unknown) as Site
+
+const mockDeploymentWithStagingUrl = {
+  stagingUrl: "https://123.staging.amplifyapp.com",
+  hostingId: "123",
+  stagingLiteHostingId: "321",
+}
+
+const mockDeploymentWithStagingLiteUrl = {
+  stagingUrl: "https://321.staging-lite.amplifyapp.com",
+  hostingId: "123",
+  stagingListHostingId: "321",
+}
 
 describe("SitesService", () => {
   // Prevent inter-test pollution of mocks


### PR DESCRIPTION
## Problem

Somehow the staging sites, while rendering correctly to the end user, did not mutate the DB as expected . 

Closes [insert issue #]

## Solution

Not too sure why the previous code didnt work, directly importing the deployments service to mutate this instead.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)


## Tests

- [ ] in staging, log into kishore-test and view the staging url, since it is whitelisted it should be the staging-lite url 
- [ ] log into growthbook, go into the `is_show_staging_build_status_enabled` for staging and remove `kishore-test`
- [ ] refresh the cms 
- [ ] assert that the db value for `stagingUrl` have changed back to the `staging.amplifyapp.com`, the staging link should now be just the `staging.amplifyapp.com` (note that its NOT the staging-lite link anymore) 
- [ ] log into growthbook, go into the `is_show_staging_build_status_enabled` for staging and add `kishore-test` back in 
- [ ] refresh cms 
- [ ] assert that the db value for `stagingUrl` have changed back o `staging-lite.amplifyapp.com`
- [ ] the staging link should revert back to the `staging-lite.amplifyapp.com` (note that its NOT the staging link anymore) 

