### PR TITLE
feat(mediafiles): add new mass creation endpoint

### DIFF
--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -195,6 +195,10 @@ const CreateMediaFileRequestSchema = Joi.object().keys({
   newFileName: Joi.string().required(),
 })
 
+const CreateMediaFilesRequestSchema = Joi.object().keys({
+  files: Joi.array().items(CreateMediaFileRequestSchema),
+})
+
 const UpdateMediaFileRequestSchema = Joi.object().keys({
   content: Joi.string(),
   sha: Joi.string().required(),
@@ -306,4 +310,5 @@ module.exports = {
   UpdateNavigationRequestSchema,
   UpdateSettingsRequestSchema,
   UpdateRepoPasswordRequestSchema,
+  CreateMediaFilesRequestSchema,
 }


### PR DESCRIPTION
## Problem
No mass creation endpoint - this is problematic because repeatedly calling the single media creation endpoint causes 429 errors (repo locked)

## Solution
duplicate most code from single endpoint