### PR TITLE
fix(githubCOmmitService): add sane defaults

### DIFF
--- a/src/services/db/GithubCommitService.ts
+++ b/src/services/db/GithubCommitService.ts
@@ -120,7 +120,7 @@ export default class GitHubCommitService extends GitHubService {
       directoryName,
       message,
       githubSessionData,
-      isStaging,
+      isStaging = true,
     }: {
       directoryName: string
       message: string
@@ -223,7 +223,7 @@ export default class GitHubCommitService extends GitHubService {
     oldPath: string,
     newPath: string,
     message?: string,
-    isStaging?: boolean
+    isStaging = true
   ): Promise<GitCommitResult> {
     const gitTree = await super.getTree(
       sessionData,
@@ -313,7 +313,7 @@ export default class GitHubCommitService extends GitHubService {
     newPath: string,
     targetFiles: string[],
     message?: string,
-    isStaging?: boolean
+    isStaging = true
   ): Promise<GitCommitResult> {
     const gitTree = await super.getTree(
       sessionData,


### PR DESCRIPTION
## Problem

Quickie has been facing some behaviour recently. I am not sure if this fixes it, but logically this tweak feels like better code as sane defaults > not having them -> undefined which is falsely and then subsequently makes `isStaging` === false

Closes [insert issue #]


## Tests

- [ ] e2e should be fine  

