### PR TITLE
fix(staging-lite): apps were created for wrong br

### DIFF
--- a/src/services/identity/DeploymentClient.ts
+++ b/src/services/identity/DeploymentClient.ts
@@ -93,7 +93,7 @@ class DeploymentClient {
 
   generateCreateBranchInput = (
     appId: string,
-    branchName: "master" | "staging"
+    branchName: "master" | "staging" | "staging-lite"
   ): CreateBranchCommandInput => ({
     appId,
     framework: "Jekyll",


### PR DESCRIPTION
## Problem

Stagign lite apps were created with master and stagign branches on site create, when it should have been just the staging-lite branch,


## Solution

change deployed branch

tested local function call directly, verified that 
1. staging lite creates just the lite branch
2. main app with 2 branhces are created 
