### PR TITLE
fix(rr): capture file extensions that are in uppercase

### DIFF
--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -252,7 +252,7 @@ export default class ReviewRequestService {
     path,
   }: PathInfo): Result<EditedMediaDto, PageParseError> => {
     const fileExt = getFileExt(name)
-    if (ALLOWED_FILE_EXTENSIONS.includes(fileExt)) {
+    if (ALLOWED_FILE_EXTENSIONS.includes(fileExt.toLowerCase())) {
       return ok({
         name,
         path: path.unwrapOr([""]),


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Our logs get a lot of false-positives that files are missing, but that is because our `ALLOWED_FILE_EXTENSIONS` does not take into account upper-case.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Allow ReviewRequestService to check for the upper-case versions as well, and handle them as a proper image.
    - NOTE: We are not allowing end-users to upload images with upper-case file extensions. This change is just to add support for backward compatibility.

## Tests

<!-- What tests should be run to confirm functionality? -->

1. Go to `sla-geoworks` site on CMS (ensure you have it cloned locally on your own GGS)
2. Check that the logs do not throw any errors regarding being unable to get the Git blob hash for uppercase file extensions.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*