### PR TITLE
fix(media): change media sorting to addedTime descending

### DIFF
--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -927,6 +927,7 @@ export default class GitFileSystemService {
                 sha,
                 path,
                 size: type === "dir" ? 0 : stats.size,
+                addedTime: stats.birthtimeMs,
               }
 
               return okAsync(result)

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -1,4 +1,3 @@
-import { GrowthBook } from "@growthbook/growthbook"
 import { AxiosCacheInstance } from "axios-cache-interceptor"
 import _ from "lodash"
 
@@ -10,7 +9,6 @@ import GithubSessionData from "@root/classes/GithubSessionData"
 import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import { FEATURE_FLAGS, STAGING_BRANCH } from "@root/constants"
 import { GitHubCommitData } from "@root/types/commitData"
-import { FeatureFlags } from "@root/types/featureFlags"
 import type {
   GitCommitResult,
   GitDirectoryItem,
@@ -43,7 +41,12 @@ const getPaginatedDirectoryContents = (
     (item) => item.type === "file" && item.name !== PLACEHOLDER_FILE_NAME
   )
   const paginatedFiles = _(files)
-    .sortBy(["name"])
+    // Note: We are sorting by name here to maintain compatibility for
+    // GitHub-login users, since it is very expensive to get the addedTime for
+    // each file from the GitHub API. The files will be sorted by addedTime in
+    // milliseconds for GGS users, so they will never see the alphabetical
+    // sorting.
+    .orderBy(["addedTime", "name"], ["desc", "asc"])
     .drop(page * limit)
     .take(limit)
     .value()
@@ -588,7 +591,7 @@ export default class RepoService extends GitHubService {
     { gitTree, message }: any,
     isStaging: boolean
   ): Promise<any> {
-    return await super.updateTree(
+    return super.updateTree(
       sessionData,
       githubSessionData,
       {
@@ -638,6 +641,6 @@ export default class RepoService extends GitHubService {
     sessionData: any,
     shouldMakePrivate: any
   ): Promise<any> {
-    return await super.changeRepoPrivacy(sessionData, shouldMakePrivate)
+    return super.changeRepoPrivacy(sessionData, shouldMakePrivate)
   }
 }

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -90,6 +90,8 @@ describe("GitFileSystemService", () => {
         sha: "fake-dir-hash",
         path: "fake-dir",
         size: 0,
+        addedTime: fs.statSync(`${EFS_VOL_PATH_STAGING}/fake-repo/fake-dir`)
+          .birthtimeMs,
       }
       const expectedAnotherFakeDir: GitDirectoryItem = {
         name: "another-fake-dir",
@@ -97,6 +99,9 @@ describe("GitFileSystemService", () => {
         sha: "another-fake-dir-hash",
         path: "another-fake-dir",
         size: 0,
+        addedTime: fs.statSync(
+          `${EFS_VOL_PATH_STAGING}/fake-repo/another-fake-dir`
+        ).birthtimeMs,
       }
       const expectedFakeEmptyDir: GitDirectoryItem = {
         name: "fake-empty-dir",
@@ -104,6 +109,9 @@ describe("GitFileSystemService", () => {
         sha: "fake-empty-dir-hash",
         path: "fake-empty-dir",
         size: 0,
+        addedTime: fs.statSync(
+          `${EFS_VOL_PATH_STAGING}/fake-repo/fake-empty-dir`
+        ).birthtimeMs,
       }
       const expectedAnotherFakeFile: GitDirectoryItem = {
         name: "another-fake-file",
@@ -111,6 +119,9 @@ describe("GitFileSystemService", () => {
         sha: "another-fake-file-hash",
         path: "another-fake-file",
         size: "Another fake content".length,
+        addedTime: fs.statSync(
+          `${EFS_VOL_PATH_STAGING}/fake-repo/another-fake-file`
+        ).birthtimeMs,
       }
 
       const result = await GitFileSystemService.listDirectoryContents(
@@ -150,6 +161,8 @@ describe("GitFileSystemService", () => {
         sha: "fake-dir-hash",
         path: "fake-dir",
         size: 0,
+        addedTime: fs.statSync(`${EFS_VOL_PATH_STAGING}/fake-repo/fake-dir`)
+          .birthtimeMs,
       }
       const expectedAnotherFakeFile: GitDirectoryItem = {
         name: "another-fake-file",
@@ -157,6 +170,9 @@ describe("GitFileSystemService", () => {
         sha: "another-fake-file-hash",
         path: "another-fake-file",
         size: "Another fake content".length,
+        addedTime: fs.statSync(
+          `${EFS_VOL_PATH_STAGING}/fake-repo/another-fake-file`
+        ).birthtimeMs,
       }
 
       const result = await GitFileSystemService.listDirectoryContents(

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -341,6 +341,7 @@ describe("RepoService", () => {
           sha: "test-sha1",
           path: "test/fake-file.md",
           size: 100,
+          addedTime: 3,
         },
         {
           name: "another-fake-file.md",
@@ -348,6 +349,7 @@ describe("RepoService", () => {
           sha: "test-sha2",
           path: "another-fake-file.md",
           size: 100,
+          addedTime: 2,
         },
         {
           name: "fake-dir",
@@ -355,6 +357,7 @@ describe("RepoService", () => {
           sha: "test-sha3",
           path: "fake-dir",
           size: 0,
+          addedTime: 1,
         },
       ]
       gbSpy.mockReturnValueOnce(true)
@@ -387,6 +390,7 @@ describe("RepoService", () => {
           sha: "test-sha1",
           path: "test/fake-file.md",
           size: 100,
+          addedTime: 3,
         },
         {
           name: "another-fake-file.md",
@@ -394,6 +398,7 @@ describe("RepoService", () => {
           sha: "test-sha2",
           path: "another-fake-file.md",
           size: 100,
+          addedTime: 2,
         },
         {
           name: "fake-dir",
@@ -401,6 +406,7 @@ describe("RepoService", () => {
           sha: "test-sha3",
           path: "fake-dir",
           size: 0,
+          addedTime: 1,
         },
       ]
       const gitHubServiceReadDirectory = jest.spyOn(

--- a/src/types/gitfilesystem.ts
+++ b/src/types/gitfilesystem.ts
@@ -13,4 +13,5 @@ export type GitDirectoryItem = {
   sha: string
   path: string
   size: number
+  addedTime: number
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The ordering of the media files should be by the addedTime in descending order.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Improvements**:

- The media files are now sorted by the addedTime in descending order for users on GGS (i.e. email-login users).
    - Unfortunately, it is very expensive to get the addedTime for each file from the GitHub API, as there is no concept of creation timestamp (since it is entirely based on commits). We currently do get this information when individual files are requested, but it would get very expensive if we do this for all files at once.
    - Hence, we are retaining the existing behaviour of sorting by the file name for GitHub-login users, but we will let email-login users have the sorting by addedTime.

## Tests

<!-- What tests should be run to confirm functionality? -->

Unit tests, smoke tests on the frontend.

- [ ] Navigate to any site and visit the images workspace as an email-login user
- [ ] Verify that the images are sorted by their added time in descending order
- [ ] Navigate to any site and visit the images workspace as a GitHub-login user
- [ ] Verify that the images are still sorted by their file names in ascending order

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*