### PR TITLE
fix(pagination): images fix pagination

### DIFF
--- a/src/routes/v2/authenticatedSites/mediaCategories.js
+++ b/src/routes/v2/authenticatedSites/mediaCategories.js
@@ -48,7 +48,7 @@ class MediaCategoriesRouter {
     const { userWithSiteSessionData } = res.locals
 
     const { directoryName } = req.params
-    const { page, limit } = req.query
+    const { page, limit, search } = req.query
 
     const {
       files,
@@ -59,6 +59,7 @@ class MediaCategoriesRouter {
         directoryName,
         page,
         limit,
+        search,
       }
     )
     return res.status(200).json({ files, total })

--- a/src/services/directoryServices/MediaDirectoryService.js
+++ b/src/services/directoryServices/MediaDirectoryService.js
@@ -28,7 +28,10 @@ class MediaDirectoryService {
     return files
   }
 
-  async listMediaDirectoryContent(sessionData, { directoryName, page, limit }) {
+  async listMediaDirectoryContent(
+    sessionData,
+    { directoryName, page, limit, search }
+  ) {
     if (!isMediaPathValid({ path: directoryName }))
       throw new BadRequestError("Invalid media folder name")
 
@@ -36,7 +39,8 @@ class MediaDirectoryService {
       sessionData,
       directoryName,
       page,
-      limit
+      limit,
+      search
     )
   }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->


Our images modal in FE is broken when search is used due to pagination. 
Review this tgt with [fe](https://github.com/isomerpages/isomercms-frontend/pull/1668) 

Screenshots 

## Before 
![image (5)](https://github.com/isomerpages/isomercms-backend/assets/42832651/28439ce7-9dc1-4151-a0c6-2b3360899957)


## After 
![Screenshot 2023-11-10 at 1 44 30 PM](https://github.com/isomerpages/isomercms-backend/assets/42832651/9e515c9d-35b7-475a-9bae-0448a5838364)


## Tests 
[ ] Go into a repo with lots of images (at least > 15 since thats what we paginate by)
[ ] Search for any image that would be > 15th index when alphabeticaly ordered. (eg. seach for an image that start with z) 
[ ] ensure that you can see the image in the modal 