### PR TITLE
fix(pagination): total length

### DIFF
--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -58,6 +58,7 @@ const getPaginatedDirectoryContents = (
       file.name.toLowerCase().includes(search.toLowerCase())
     )
   }
+  const totalLength = sortedFiles.value().length
 
   const paginatedFiles = sortedFiles
     .drop(page * limit)
@@ -67,7 +68,7 @@ const getPaginatedDirectoryContents = (
   return {
     directories: subdirectories,
     files: paginatedFiles,
-    total: files.length,
+    total: totalLength,
   }
 }
 


### PR DESCRIPTION
## Problem

Fix ui bug when searching. Last time total length used to be the length of all the files, so this lead to the last few pages on search to be null.
![Screenshot 2023-11-14 at 4 11 55 PM](https://github.com/isomerpages/isomercms-backend/assets/42832651/fcd4c82f-bddc-445c-b625-bdf796642a18)

