### PR TITLE
fix: use cTimeMs instead of birthtime due to EFS

### DIFF
--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -858,7 +858,7 @@ export default class GitFileSystemService {
           mediaUrl: `${dataUrlPrefix},${file.content}`,
           mediaPath: `${directoryName}/${fileName}`,
           type: fileType,
-          addedTime: stats.birthtimeMs,
+          addedTime: stats.ctimeMs,
           size: stats.size,
         })
       })
@@ -929,7 +929,7 @@ export default class GitFileSystemService {
                 sha,
                 path,
                 size: type === "dir" ? 0 : stats.size,
-                addedTime: stats.birthtimeMs,
+                addedTime: stats.ctimeMs,
               }
 
               return okAsync(result)

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -91,7 +91,7 @@ describe("GitFileSystemService", () => {
         path: "fake-dir",
         size: 0,
         addedTime: fs.statSync(`${EFS_VOL_PATH_STAGING}/fake-repo/fake-dir`)
-          .birthtimeMs,
+          .ctimeMs,
       }
       const expectedAnotherFakeDir: GitDirectoryItem = {
         name: "another-fake-dir",
@@ -101,7 +101,7 @@ describe("GitFileSystemService", () => {
         size: 0,
         addedTime: fs.statSync(
           `${EFS_VOL_PATH_STAGING}/fake-repo/another-fake-dir`
-        ).birthtimeMs,
+        ).ctimeMs,
       }
       const expectedFakeEmptyDir: GitDirectoryItem = {
         name: "fake-empty-dir",
@@ -111,7 +111,7 @@ describe("GitFileSystemService", () => {
         size: 0,
         addedTime: fs.statSync(
           `${EFS_VOL_PATH_STAGING}/fake-repo/fake-empty-dir`
-        ).birthtimeMs,
+        ).ctimeMs,
       }
       const expectedAnotherFakeFile: GitDirectoryItem = {
         name: "another-fake-file",
@@ -121,7 +121,7 @@ describe("GitFileSystemService", () => {
         size: "Another fake content".length,
         addedTime: fs.statSync(
           `${EFS_VOL_PATH_STAGING}/fake-repo/another-fake-file`
-        ).birthtimeMs,
+        ).ctimeMs,
       }
 
       const result = await GitFileSystemService.listDirectoryContents(
@@ -162,7 +162,7 @@ describe("GitFileSystemService", () => {
         path: "fake-dir",
         size: 0,
         addedTime: fs.statSync(`${EFS_VOL_PATH_STAGING}/fake-repo/fake-dir`)
-          .birthtimeMs,
+          .ctimeMs,
       }
       const expectedAnotherFakeFile: GitDirectoryItem = {
         name: "another-fake-file",
@@ -172,7 +172,7 @@ describe("GitFileSystemService", () => {
         size: "Another fake content".length,
         addedTime: fs.statSync(
           `${EFS_VOL_PATH_STAGING}/fake-repo/another-fake-file`
-        ).birthtimeMs,
+        ).ctimeMs,
       }
 
       const result = await GitFileSystemService.listDirectoryContents(
@@ -1429,7 +1429,7 @@ describe("GitFileSystemService", () => {
         ).toString("base64")}`,
         mediaPath: "fake-dir/fake-media-file.png",
         type: "file",
-        addedTime: fileStats.birthtimeMs,
+        addedTime: fileStats.ctimeMs,
         size: fileStats.size,
       }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Birth time shows 0 on EFS for some weird reason.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ ] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details
    - [ ] added env var to 1PW + SSM script (`fetch_ssm_parameters.sh`)

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details