### PR TITLE
fix(siteCreate): add redirect rules

### DIFF
--- a/src/services/identity/DeploymentClient.ts
+++ b/src/services/identity/DeploymentClient.ts
@@ -13,6 +13,9 @@ import {
   ListJobsCommand,
   ListJobsCommandOutput,
   JobSummary,
+  StartJobCommand,
+  StartJobCommandOutput,
+  StartJobCommandInput,
 } from "@aws-sdk/client-amplify"
 import { ResultAsync, errAsync, fromPromise, okAsync } from "neverthrow"
 
@@ -77,11 +80,23 @@ class DeploymentClient {
       this.amplifyClient.send(new ListJobsCommand({ appId, branchName }))
     ) as ResultAsync<ListJobsCommandOutput, AmplifyError>
 
-  generateCreateAppInput = (
-    repoName: string,
-    repoUrl: string,
+  sendStartJobCommand = (options: StartJobCommandInput) =>
+    wrap(this.amplifyClient.send(new StartJobCommand(options))) as ResultAsync<
+      StartJobCommandOutput,
+      AmplifyError
+    >
+
+  generateCreateAppInput = ({
+    appName,
+    repoName,
+    repoUrl,
+    isStagingLite,
+  }: {
+    appName: string
+    repoUrl: string
+    repoName: string
     isStagingLite: boolean
-  ): CreateAppCommandInput => {
+  }): CreateAppCommandInput => {
     const stgLiteRedirectRules = [
       {
         source: "/files/<*>",
@@ -103,7 +118,7 @@ class DeploymentClient {
       : defaultRedirectRules
 
     return {
-      name: repoName,
+      name: appName,
       accessToken: SYSTEM_GITHUB_TOKEN,
       repository: repoUrl,
       buildSpec: AMPLIFY_BUILD_SPEC,

--- a/src/services/identity/DeploymentsService.ts
+++ b/src/services/identity/DeploymentsService.ts
@@ -69,7 +69,7 @@ class DeploymentsService {
 
     return this.create({
       stagingUrl: Brand.fromString(
-        `https://staging.${amplifyStagingLiteResult.value.defaultDomain}`
+        `https://staging-lite.${amplifyStagingLiteResult.value.defaultDomain}`
       ),
       productionUrl: Brand.fromString(
         `https://master.${amplifyStagingResult.value.defaultDomain}`
@@ -105,7 +105,8 @@ class DeploymentsService {
 
     const createAppOptions = this.deploymentClient.generateCreateAppInput(
       appName,
-      repoUrl
+      repoUrl,
+      createStagingLite
     )
     // 1. Create Amplify app
     return this.deploymentClient


### PR DESCRIPTION
## Problem

Stg lite never configure properly, the url not correct + the redirect rules were not present + for reasons I do not know why there were blips when some of the sites had their jobs queued + it did not start even after a while. As such am pinging Amplify to release the jobs. Not sure if this completely fixes it, not sure why we have this issue now, so intent here is to add the release job + monitor for tickets. 



## Tests

running this in server.js 
```

deploymentsService.createAmplifyAppOnAws(
  "kishore-test-dev-gh",
  "kishore-test-again-delete-me",
  false
)

deploymentsService.createAmplifyAppOnAws(
  "kishore-test-dev-gh",
  "kishore-test-again-delete-me-staging-lite",
  true
)

```

note that there will be two apps being created in amplify. Staging lite will have the redirect rules for images + files, while the main app will have just the main 404 redirect. 

Stg lite
![Screenshot 2023-11-16 at 9 37 51 AM](https://github.com/isomerpages/isomercms-backend/assets/42832651/fcf65f75-ff5b-4ec1-b39e-f1e58784ad37)
![Screenshot 2023-11-16 at 9 37 45 AM](https://github.com/isomerpages/isomercms-backend/assets/42832651/775a2b48-042a-499a-9ced-e41a2b8f57f3)

Stg
![Screenshot 2023-11-16 at 9 37 31 AM](https://github.com/isomerpages/isomercms-backend/assets/42832651/1801aca8-225d-4e47-b343-1f3506b2fe5c)
![Screenshot 2023-11-16 at 9 37 26 AM](https://github.com/isomerpages/isomercms-backend/assets/42832651/8dc3767f-7d1c-4d14-ae19-f9ceac68ebdd)

when visiting stg lite, we should see the images as such : https://staging-lite.da33yn9c7fu8b.amplifyapp.com/images/favicon-isomer.ico
