### PR TITLE
feat(quickie): only gitfile should have quickie

### DIFF
--- a/src/services/db/GitHubService.ts
+++ b/src/services/db/GitHubService.ts
@@ -767,7 +767,7 @@ export default class GitHubService {
 
   async updateRepoState(
     sessionData: UserWithSiteSessionData,
-    { commitSha }: { commitSha: any }
+    { commitSha }: { commitSha: string }
   ) {
     const { accessToken } = sessionData
     const { siteName } = sessionData

--- a/src/services/db/GithubCommitService.ts
+++ b/src/services/db/GithubCommitService.ts
@@ -149,15 +149,10 @@ export default class GitHubCommitService extends GitHubService {
         sha: null,
       }))
 
-    const newCommitSha = await this.updateTree(
-      sessionData,
-      githubSessionData,
-      {
-        gitTree: newGitTree,
-        message,
-      },
-      !!isStaging
-    )
+    const newCommitSha = await this.updateTree(sessionData, githubSessionData, {
+      gitTree: newGitTree,
+      message,
+    })
 
     const deletePromises = [
       this.updateRepoState(sessionData, {
@@ -280,8 +275,7 @@ export default class GitHubCommitService extends GitHubService {
       {
         gitTree: newGitTree,
         message,
-      },
-      !!isStaging
+      }
     )
     await super.updateRepoState(sessionData, {
       commitSha: newCommitSha,
@@ -362,8 +356,7 @@ export default class GitHubCommitService extends GitHubService {
       {
         gitTree: newGitTree,
         message,
-      },
-      !!isStaging
+      }
     )
 
     await super.updateRepoState(sessionData, {

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -20,7 +20,6 @@ import { getMediaFileInfo } from "@root/utils/media-utils"
 
 import GitFileCommitService from "./GitFileCommitService"
 import GitFileSystemService from "./GitFileSystemService"
-import GitHubCommitService from "./GithubCommitService"
 import GitHubService from "./GitHubService"
 import * as ReviewApi from "./review"
 
@@ -448,29 +447,10 @@ export default class RepoService extends GitHubService {
       return
     }
 
-    // GitHub flow
-    const gitTree = await this.getTree(sessionData, githubSessionData, {
-      isRecursive: true,
-    })
-
-    // Retrieve removed items and set their sha to null
-    const newGitTree = gitTree
-      .filter(
-        (item) =>
-          item.path.startsWith(`${directoryName}/`) && item.type !== "tree"
-      )
-      .map((item) => ({
-        ...item,
-        sha: null,
-      }))
-
-    const newCommitSha = await this.updateTree(sessionData, githubSessionData, {
-      gitTree: newGitTree,
+    super.deleteDirectory(sessionData, {
+      directoryName,
       message,
-    })
-
-    await this.updateRepoState(sessionData, {
-      commitSha: newCommitSha,
+      githubSessionData,
     })
   }
 


### PR DESCRIPTION
## Problem

Moving forward, since we have migrated most sites out of gh, we will only offer quickie for sites that are in ggs. 
As such, this pr removes the dependency of a no longer supported flow so as to allow for a simpler mental model. 
Additionally, there were weird abstractions bet GithubService + GithubCommitService -> removed the responsibilities to be isolated.

Test cases will be added in the leaf node of these prs, cicd will also be fixed upstream.