### PR TITLE
hotfix(repair-form): set remote url correctly

### DIFF
--- a/src/routes/formsg/formsgGGsRepair.ts
+++ b/src/routes/formsg/formsgGGsRepair.ts
@@ -116,7 +116,7 @@ export class FormsgGGsRepairRouter {
     const clonedStagingRepos: string[] = []
     const syncedStagingAndStagingLiteRepos: string[] = []
     repoNames.forEach((repoName) => {
-      const repoUrl = `git@github.com:isomerpages/${repoName}`
+      const repoUrl = `git@github.com:isomerpages/${repoName}.git`
 
       repairs.push(
         this.doesRepoNeedClone(repoName)


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->
The remore was not set properly. Reason why this error was not caught eariler was beacuse git itself is tolerant to this error, but our BE logic is not as we check a strict string check. 
Closes [insert issue #]

## Solution

<!-- How did you solve the problem? -->
add .git at the end

