### PR TITLE
feat(docker): shift app to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18-alpine AS base
 WORKDIR /opt/isomercms-backend
+COPY . .
 RUN npm ci
 EXPOSE "8081"
-COPY . /opt/isomercms-backend
 CMD ["npm", "run", "dev:server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:18-alpine AS base
 WORKDIR /opt/isomercms-backend
-COPY . .
 RUN npm ci
 EXPOSE "8081"
 COPY . /opt/isomercms-backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine AS base
+WORKDIR /opt/isomercms-backend
+COPY . .
+RUN npm ci
+EXPOSE "8081"
+COPY . /opt/isomercms-backend
+CMD ["npm", "run", "dev:server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:18-alpine AS base
 WORKDIR /opt/isomercms-backend
 COPY . .
+RUN apk update
+RUN apk add git
 RUN npm ci
 EXPOSE "8081"
 CMD ["npm", "run", "dev:server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     volumes:
       - ./:/opt/isomercms-backend
       - /opt/isomercms-backend/node_modules
+      - ${EFS_VOL_PATH}:${EFS_VOL_PATH}
 
   postgres:
     image: "postgres:13-alpine"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,20 @@
 version: "3"
 services:
+  web:
+    build: .
+    ports:
+      - "8081:8081"
+    depends_on:
+      - postgres
+    env_file:
+      - .env
+    environment:
+      # postgres://user:pass@hostname:port/database
+      - DB_URI=postgres://isomer:password@postgres:5432/isomercms_dev
+    volumes:
+      - ./:/opt/isomercms-backend
+      - /opt/isomercms-backend/node_modules
+
   postgres:
     image: "postgres:13-alpine"
     environment:
@@ -7,7 +22,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: isomercms_dev
     ports:
-      - "15432:5432"
+      - "5432:5432"
     volumes:
       - isomercms_data:/var/lib/postgresql/data
 
@@ -20,6 +35,5 @@ services:
     ports:
       # use a different port to avoid blocking dev environment when running tests
       - "54321:5432"
-
 volumes:
   isomercms_data:

--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "start": "node --unhandled-rejections=warn -r ts-node/register/transpile-only -r tsconfig-paths/register -r dotenv/config build/server.js dotenv_config_path=/efs/isomer/.isomer.env",
-    "dev:services": "docker compose up -d",
     "dev:server": "source .env && ts-node-dev --unhandled-rejections=warn --respawn src/server.js",
-    "dev": "npm run dev:services && npm run dev:server",
+    "dev": "docker compose up",
     "test": "source .env.test && jest --runInBand",
     "release": "npm version $npm_config_isomer_update && git push --tags",
     "lint": "npx eslint .",


### PR DESCRIPTION
## Problem
We want to shift our infra over to ecs instead of eb as ecs is faster to deploy + easier to work with. This PR dockerises our app as a first step. 

## Solution
1. add docker file
2. add docker compose

## Notes
- hot reload is enabled still by using volume mapping; we map the vol on disk to the docker volume so that on chnage of the files on disk, docker notices
- as our containers are part of the same network, the postgres url has to use the docker volume instead. (see comment for format in code)