### PR TITLE
fix(media): filter first before getting git blob hash

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -88,3 +88,5 @@ export const EFS_VOL_PATH_STAGING_LITE = path.join(
 )
 export const STAGING_BRANCH = "staging"
 export const STAGING_LITE_BRANCH = "staging-lite"
+export const PLACEHOLDER_FILE_NAME = ".keep"
+export const GIT_SYSTEM_DIRECTORY = ".git"

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -912,13 +912,11 @@ export default class GitFileSystemService {
   listDirectoryContents(
     repoName: string,
     directoryPath: string,
-    branchName: string,
-    page = 0,
-    limit = 0,
-    search = ""
-  ): ResultAsync<DirectoryContents, GitFileSystemError | NotFoundError> {
+    branchName: string
+  ): ResultAsync<GitDirectoryItem[], GitFileSystemError | NotFoundError> {
     const efsVolPath = this.getEfsVolPathFromBranch(branchName)
     const isStaging = this.isStagingFromBranchName(branchName)
+
     return this.getFilePathStats(
       repoName,
       directoryPath,
@@ -974,6 +972,19 @@ export default class GitFileSystemService {
 
         return ResultAsync.combine(resultAsyncs)
       })
+  }
+
+  listPaginatedDirectoryContents(
+    repoName: string,
+    directoryPath: string,
+    branchName: string,
+    page = 0,
+    limit = 0,
+    search = ""
+  ): ResultAsync<DirectoryContents, GitFileSystemError | NotFoundError> {
+    const isStaging = this.isStagingFromBranchName(branchName)
+
+    return this.listDirectoryContents(repoName, directoryPath, branchName)
       .andThen((directoryContents) =>
         okAsync(
           getPaginatedDirectoryContents(directoryContents, page, limit, search)

--- a/src/services/db/GitHubService.ts
+++ b/src/services/db/GitHubService.ts
@@ -14,6 +14,7 @@ import { STAGING_BRANCH } from "@root/constants"
 import logger from "@root/logger/logger"
 import { GitCommitResult } from "@root/types/gitfilesystem"
 import { RawGitTreeEntry } from "@root/types/github"
+import { getPaginatedDirectoryContents } from "@root/utils/files"
 
 import * as ReviewApi from "./review"
 

--- a/src/services/db/GitHubService.ts
+++ b/src/services/db/GitHubService.ts
@@ -14,7 +14,6 @@ import { STAGING_BRANCH } from "@root/constants"
 import logger from "@root/logger/logger"
 import { GitCommitResult } from "@root/types/gitfilesystem"
 import { RawGitTreeEntry } from "@root/types/github"
-import { getPaginatedDirectoryContents } from "@root/utils/files"
 
 import * as ReviewApi from "./review"
 

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -10,12 +10,14 @@ import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import { FEATURE_FLAGS, STAGING_BRANCH } from "@root/constants"
 import { GitHubCommitData } from "@root/types/commitData"
 import type {
+  DirectoryContents,
   GitCommitResult,
   GitDirectoryItem,
   GitFile,
 } from "@root/types/gitfilesystem"
 import { RawGitTreeEntry } from "@root/types/github"
 import { MediaDirOutput, MediaFileOutput, MediaType } from "@root/types/media"
+import { getPaginatedDirectoryContents } from "@root/utils/files"
 import { getMediaFileInfo } from "@root/utils/media-utils"
 
 import GitFileCommitService from "./GitFileCommitService"
@@ -23,53 +25,7 @@ import GitFileSystemService from "./GitFileSystemService"
 import GitHubService from "./GitHubService"
 import * as ReviewApi from "./review"
 
-const PLACEHOLDER_FILE_NAME = ".keep"
 const BRANCH_REF = config.get("github.branchRef")
-
-const getPaginatedDirectoryContents = (
-  directoryContents: GitDirectoryItem[],
-  page: number,
-  limit = 15,
-  search = ""
-): {
-  directories: GitDirectoryItem[]
-  files: GitDirectoryItem[]
-  total: number
-} => {
-  const subdirectories = directoryContents.filter((item) => item.type === "dir")
-  const files = directoryContents.filter(
-    (item) => item.type === "file" && item.name !== PLACEHOLDER_FILE_NAME
-  )
-
-  let sortedFiles = _(files)
-    // Note: We are sorting by name here to maintain compatibility for
-    // GitHub-login users, since it is very expensive to get the addedTime for
-    // each file from the GitHub API. The files will be sorted by addedTime in
-    // milliseconds for GGS users, so they will never see the alphabetical
-    // sorting.
-    .orderBy(
-      [(file) => file.addedTime, (file) => file.name.toLowerCase()],
-      ["desc", "asc"]
-    )
-
-  if (search) {
-    sortedFiles = sortedFiles.filter((file) =>
-      file.name.toLowerCase().includes(search.toLowerCase())
-    )
-  }
-  const totalLength = sortedFiles.value().length
-
-  const paginatedFiles = sortedFiles
-    .drop(page * limit)
-    .take(limit)
-    .value()
-
-  return {
-    directories: subdirectories,
-    files: paginatedFiles,
-    total: totalLength,
-  }
-}
 
 // TODO: update the typings here to remove `any`.
 // We can type as `unknown` if required.
@@ -318,7 +274,7 @@ export default class RepoService extends GitHubService {
         throw result.error
       }
 
-      return result.value
+      return [...result.value.directories, ...result.value.files]
     }
 
     return super.readDirectory(sessionData, {
@@ -343,7 +299,7 @@ export default class RepoService extends GitHubService {
     const { siteName } = sessionData
     const defaultBranch = STAGING_BRANCH
     logger.debug(`Reading media directory: ${directoryName}`)
-    let dirContent: GitDirectoryItem[] = []
+    let dirContent: DirectoryContents
 
     if (
       sessionData.growthbook?.getFeatureValue(
@@ -354,7 +310,10 @@ export default class RepoService extends GitHubService {
       const result = await this.gitFileSystemService.listDirectoryContents(
         siteName,
         directoryName,
-        defaultBranch
+        defaultBranch,
+        page,
+        limit,
+        search
       )
 
       if (result.isErr()) {
@@ -363,17 +322,13 @@ export default class RepoService extends GitHubService {
 
       dirContent = result.value
     } else {
-      dirContent = await super.readDirectory(sessionData, {
+      const contents = await super.readDirectory(sessionData, {
         directoryName,
       })
+      dirContent = getPaginatedDirectoryContents(contents, page, limit, search)
     }
 
-    const { directories, files, total } = getPaginatedDirectoryContents(
-      dirContent,
-      page,
-      limit,
-      search
-    )
+    const { directories, files, total } = dirContent
 
     return {
       directories: directories.map(({ name, type }) => ({

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -274,7 +274,7 @@ export default class RepoService extends GitHubService {
         throw result.error
       }
 
-      return [...result.value.directories, ...result.value.files]
+      return result.value
     }
 
     return super.readDirectory(sessionData, {
@@ -307,7 +307,7 @@ export default class RepoService extends GitHubService {
         false
       )
     ) {
-      const result = await this.gitFileSystemService.listDirectoryContents(
+      const result = await this.gitFileSystemService.listPaginatedDirectoryContents(
         siteName,
         directoryName,
         defaultBranch,

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -75,13 +75,13 @@ describe("GitFileSystemService", () => {
         revparse: jest.fn().mockResolvedValueOnce("another-fake-dir-hash"),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockResolvedValueOnce("fake-dir-hash"),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockResolvedValueOnce("fake-empty-dir-hash"),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
       })
 
       const expectedFakeDir: GitDirectoryItem = {
@@ -129,9 +129,10 @@ describe("GitFileSystemService", () => {
         "",
         DEFAULT_BRANCH
       )
-      const actual = result
-        ._unsafeUnwrap()
-        .sort((a, b) => a.name.localeCompare(b.name))
+      const actual = [
+        ...result._unsafeUnwrap().directories,
+        ...result._unsafeUnwrap().files,
+      ].sort((a, b) => a.name.localeCompare(b.name))
 
       expect(actual).toMatchObject([
         expectedAnotherFakeDir,
@@ -146,20 +147,20 @@ describe("GitFileSystemService", () => {
         revparse: jest.fn().mockRejectedValueOnce(new GitError()),
       })
       MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        revparse: jest.fn().mockResolvedValueOnce("fake-dir-hash"),
-      })
-      MockSimpleGit.cwd.mockReturnValueOnce({
         revparse: jest.fn().mockRejectedValueOnce(new GitError()),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("fake-empty-dir-hash"),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
       })
 
       const expectedFakeDir: GitDirectoryItem = {
-        name: "fake-dir",
+        name: "fake-empty-dir",
         type: "dir",
-        sha: "fake-dir-hash",
-        path: "fake-dir",
+        sha: "fake-empty-dir-hash",
+        path: "fake-empty-dir",
         size: 0,
         addedTime: fs.statSync(`${EFS_VOL_PATH_STAGING}/fake-repo/fake-dir`)
           .ctimeMs,
@@ -181,9 +182,10 @@ describe("GitFileSystemService", () => {
         DEFAULT_BRANCH
       )
 
-      const actual = result
-        ._unsafeUnwrap()
-        .sort((a, b) => a.name.localeCompare(b.name))
+      const actual = [
+        ...result._unsafeUnwrap().directories,
+        ...result._unsafeUnwrap().files,
+      ].sort((a, b) => a.name.localeCompare(b.name))
 
       expect(actual).toMatchObject([expectedAnotherFakeFile, expectedFakeDir])
     })
@@ -202,23 +204,33 @@ describe("GitFileSystemService", () => {
         revparse: jest.fn().mockRejectedValueOnce(new GitError()),
       })
 
-      const actual = await GitFileSystemService.listDirectoryContents(
+      const result = await GitFileSystemService.listDirectoryContents(
         "fake-repo",
         "",
         DEFAULT_BRANCH
       )
 
-      expect(actual._unsafeUnwrap()).toHaveLength(0)
+      const actual = [
+        ...result._unsafeUnwrap().directories,
+        ...result._unsafeUnwrap().files,
+      ]
+
+      expect(actual).toHaveLength(0)
     })
 
     it("should return an empty result if the directory is empty", async () => {
-      const actual = await GitFileSystemService.listDirectoryContents(
+      const result = await GitFileSystemService.listDirectoryContents(
         "fake-repo",
         "fake-empty-dir",
         DEFAULT_BRANCH
       )
 
-      expect(actual._unsafeUnwrap()).toHaveLength(0)
+      const actual = [
+        ...result._unsafeUnwrap().directories,
+        ...result._unsafeUnwrap().files,
+      ]
+
+      expect(actual).toHaveLength(0)
     })
 
     it("should return a GitFileSystemError if the path is not a directory", async () => {

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -11,7 +11,7 @@ import {
   mockUserWithSiteSessionDataAndGrowthBook,
 } from "@fixtures/sessionData"
 import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
-import { ItemType, MediaFileOutput } from "@root/types"
+import { ItemType, MediaDirOutput, MediaFileOutput } from "@root/types"
 import { GitHubCommitData } from "@root/types/commitData"
 import {
   GitCommitResult,
@@ -38,6 +38,7 @@ const MockGitFileSystemService = {
   readMediaFile: jest.fn(),
   create: jest.fn(),
   listDirectoryContents: jest.fn(),
+  listPaginatedDirectoryContents: jest.fn(),
   push: jest.fn(),
   update: jest.fn(),
   delete: jest.fn(),
@@ -360,11 +361,7 @@ describe("RepoService", () => {
       ]
       gbSpy.mockReturnValueOnce(true)
       MockGitFileSystemService.listDirectoryContents.mockResolvedValueOnce(
-        okAsync({
-          directories: expected.filter((item) => item.type === "dir"),
-          files: expected.filter((item) => item.type === "file"),
-          total: expected.length,
-        })
+        okAsync(expected)
       )
 
       const actual = await RepoService.readDirectory(
@@ -425,123 +422,78 @@ describe("RepoService", () => {
     })
   })
 
-  //! TODO: fix this test, commented out for now as code changes did not change this method
-  // describe("readMediaDirectory", () => {
-  //   it("should return an array of files and directories from disk if repo is ggs enabled", async () => {
-  //     const image: MediaFileOutput = {
-  //       name: "image-name",
-  //       sha: "test-sha",
-  //       mediaUrl: "base64ofimage",
-  //       mediaPath: "images/image-name.jpg",
-  //       type: "file",
-  //     }
-  //     const dir: MediaDirOutput = {
-  //       name: "imageDir",
-  //       type: "dir",
-  //     }
-  //     const expected = [image, dir]
-  //     MockGitFileSystemService.listDirectoryContents.mockResolvedValueOnce(
-  //       okAsync([
-  //         {
-  //           name: "image-name",
-  //         },
-  //         {
-  //           name: "imageDir",
-  //           type: "dir",
-  //           sha: "test-sha",
-  //           path: "images/imageDir",
-  //         },
-  //         {
-  //           name: ".keep",
-  //           type: "file",
-  //           sha: "test-sha",
-  //           path: "images/.keep",
-  //         },
-  //       ])
-  //     )
-  //     MockGitFileSystemService.readMediaFile.mockResolvedValueOnce(
-  //       okAsync(expected)
-  //     )
+  describe("readMediaDirectory", () => {
+    it("should return an array of files and directories from disk if repo is ggs enabled", async () => {
+      const testDir: MediaDirOutput = {
+        name: "imageDir",
+        type: "dir",
+      }
+      const testFile: MediaFileOutput = {
+        name: "image-name",
+        sha: "test-sha",
+        mediaUrl: "base64ofimage",
+        mediaPath: "images/image-name.jpg",
+        type: "file",
+        addedTime: 0,
+        size: 0,
+      }
+      const expected = {
+        directories: [testDir],
+        files: [testFile],
+        total: 1,
+      }
+      MockGitFileSystemService.listPaginatedDirectoryContents.mockResolvedValueOnce(
+        okAsync(expected)
+      )
 
-  //     const actual = await RepoService.readMediaDirectory(
-  //       mockUserWithSiteSessionDataAndGrowthBook,
-  //       "images"
-  //     )
+      const actual = await RepoService.readMediaDirectory(
+        mockUserWithSiteSessionDataAndGrowthBook,
+        "images"
+      )
 
-  //     expect(actual).toEqual(expected)
-  //   })
+      expect(actual).toEqual(expected)
+    })
 
-  //   it("should return an array of files and directories from GitHub if repo is not ggs enabled", async () => {
-  //     const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
-  //       githubId: mockGithubId,
-  //       accessToken: mockAccessToken,
-  //       isomerUserId: mockIsomerUserId,
-  //       email: mockEmail,
-  //       siteName: "not-whitelisted",
-  //     })
+    it("should return an array of files and directories from GitHub if repo is not ggs enabled", async () => {
+      const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
+        githubId: mockGithubId,
+        accessToken: mockAccessToken,
+        isomerUserId: mockIsomerUserId,
+        email: mockEmail,
+        siteName: "not-whitelisted",
+      })
 
-  //     const directories: MediaDirOutput[] = [
-  //       {
-  //         name: "imageDir",
-  //         type: "dir",
-  //       },
-  //     ]
+      const testDirectory: MediaDirOutput = {
+        name: "imageDir",
+        type: "dir",
+      }
 
-  //     const files: Pick<MediaFileOutput, "name">[] = [
-  //       {
-  //         name: "image-name",
-  //       },
-  //     ]
-  //     const expected = { directories, files, total: 1 }
+      const testFile: MediaFileOutput = {
+        name: "image-name",
+        sha: "test-sha",
+        mediaUrl: "base64ofimage",
+        mediaPath: "images/image-name.jpg",
+        type: "file",
+        addedTime: 0,
+        size: 0,
+      }
 
-  //     // const image: MediaFileOutput = {
-  //     //   name: "image-name",
-  //     //   sha: "test-sha",
-  //     //   mediaUrl: "base64ofimage",
-  //     //   mediaPath: "images/image-name.jpg",
-  //     //   type: "file",
-  //     // }
-  //     // const dir: MediaDirOutput = {
-  //     //   name: "imageDir",
-  //     //   type: "dir",
-  //     // }
-  //     // const expected = [image, dir]
+      const expected = {
+        directories: [testDirectory],
+        files: [testFile],
+        total: 1,
+      }
 
-  //     const gitHubServiceGetRepoInfo = jest
-  //       .spyOn(GitHubService.prototype, "getRepoInfo")
-  //       .mockResolvedValueOnce({ private: false })
-  //     const gitHubServiceReadDirectory = jest
-  //       .spyOn(GitHubService.prototype, "readDirectory")
-  //       .mockResolvedValueOnce([
-  //         {
-  //           name: "image-name",
-  //         },
-  //         {
-  //           name: "imageDir",
-  //           type: "dir",
-  //           sha: "test-sha",
-  //           path: "images/imageDir",
-  //         },
-  //         {
-  //           name: ".keep",
-  //           type: "file",
-  //           sha: "test-sha",
-  //           path: "images/.keep",
-  //         },
-  //       ])
+      const gitHubServiceReadDirectory = jest
+        .spyOn(GitHubService.prototype, "readDirectory")
+        .mockResolvedValueOnce([testDirectory, testFile])
 
-  //     // const repoServiceReadMediaFile = jest
-  //     //   .spyOn(_RepoService.prototype, "readMediaFile")
-  //     //   .mockResolvedValueOnce(expected)
+      const actual = await RepoService.readMediaDirectory(sessionData, "images")
 
-  //     const actual = await RepoService.readMediaDirectory(sessionData, "images")
-
-  //     expect(actual).toEqual(expected)
-  //     expect(gitHubServiceGetRepoInfo).toBeCalledTimes(1)
-  //     expect(gitHubServiceReadDirectory).toBeCalledTimes(1)
-  //     // expect(repoServiceReadMediaFile).toBeCalledTimes(1)
-  //   })
-  // })
+      expect(actual).toEqual(expected)
+      expect(gitHubServiceReadDirectory).toBeCalledTimes(1)
+    })
+  })
 
   describe("update", () => {
     it("should update the local Git file system if the repo is ggs enabled", async () => {

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -334,6 +334,14 @@ describe("RepoService", () => {
     it("should read from the local Git file system if the repo is ggs enabled", async () => {
       const expected: GitDirectoryItem[] = [
         {
+          name: "fake-dir",
+          type: "dir",
+          sha: "test-sha3",
+          path: "fake-dir",
+          size: 0,
+          addedTime: 1,
+        },
+        {
           name: "fake-file.md",
           type: "file",
           sha: "test-sha1",
@@ -349,18 +357,14 @@ describe("RepoService", () => {
           size: 100,
           addedTime: 2,
         },
-        {
-          name: "fake-dir",
-          type: "dir",
-          sha: "test-sha3",
-          path: "fake-dir",
-          size: 0,
-          addedTime: 1,
-        },
       ]
       gbSpy.mockReturnValueOnce(true)
       MockGitFileSystemService.listDirectoryContents.mockResolvedValueOnce(
-        okAsync(expected)
+        okAsync({
+          directories: expected.filter((item) => item.type === "dir"),
+          files: expected.filter((item) => item.type === "file"),
+          total: expected.length,
+        })
       )
 
       const actual = await RepoService.readDirectory(

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -585,205 +585,195 @@ describe("RepoService", () => {
         directoryName: "pages",
       })
     })
+  })
 
-    describe("renameSinglePath", () => {
-      it("should rename using the local Git file system if the repo is ggs enabled", async () => {
-        const expected: GitCommitResult = { newSha: "fake-commit-sha" }
-        MockGitFileCommitService.renameSinglePath.mockResolvedValueOnce(
-          expected
-        )
-        gbSpy.mockReturnValueOnce(true)
+  describe("renameSinglePath", () => {
+    it("should rename using the local Git file system if the repo is ggs enabled", async () => {
+      const expected: GitCommitResult = { newSha: "fake-commit-sha" }
+      MockGitFileCommitService.renameSinglePath.mockResolvedValueOnce(expected)
+      gbSpy.mockReturnValueOnce(true)
 
-        const actual = await RepoService.renameSinglePath(
-          mockUserWithSiteSessionDataAndGrowthBook,
-          mockGithubSessionData,
-          "fake-old-path",
-          "fake-new-path",
-          "fake-commit-message"
-        )
+      const actual = await RepoService.renameSinglePath(
+        mockUserWithSiteSessionDataAndGrowthBook,
+        mockGithubSessionData,
+        "fake-old-path",
+        "fake-new-path",
+        "fake-commit-message"
+      )
 
-        expect(actual).toEqual(expected)
-      })
-
-      it("should rename file using GitHub directly if the repo is not ggs enabled", async () => {
-        const expectedSha = "fake-commit-sha"
-        const fakeCommitMessage = "fake-commit-message"
-        const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData(
-          {
-            githubId: mockGithubId,
-            accessToken: mockAccessToken,
-            isomerUserId: mockIsomerUserId,
-            email: mockEmail,
-            siteName: "not-whitelisted",
-          }
-        )
-
-        const gitHubServiceRenameSinglePath = jest.spyOn(
-          GitHubService.prototype,
-          "renameSinglePath"
-        )
-        gitHubServiceRenameSinglePath.mockResolvedValueOnce({
-          newSha: expectedSha,
-        })
-
-        const actual = await RepoService.renameSinglePath(
-          sessionData,
-          mockGithubSessionData,
-          "fake-path/old-fake-file.md",
-          "fake-path/new-fake-file.md",
-          fakeCommitMessage
-        )
-
-        expect(actual).toEqual({ newSha: expectedSha })
-      })
+      expect(actual).toEqual(expected)
     })
 
-    describe("moveFiles", () => {
-      it("should move files using the Git local file system if the repo is ggs enabled", async () => {
-        const expected = { newSha: "fake-commit-sha" }
-        MockGitFileCommitService.moveFiles.mockResolvedValueOnce(expected)
-        gbSpy.mockReturnValueOnce(true)
-        // MockCommitServiceGitFile.push.mockReturnValueOnce(undefined)
-
-        const actual = await RepoService.moveFiles(
-          mockUserWithSiteSessionDataAndGrowthBook,
-          mockGithubSessionData,
-          "fake-old-path",
-          "fake-new-path",
-          ["fake-file1", "fake-file2"],
-          "fake-commit-message"
-        )
-
-        expect(actual).toEqual(expected)
+    it("should rename file using GitHub directly if the repo is not ggs enabled", async () => {
+      const expectedSha = "fake-commit-sha"
+      const fakeCommitMessage = "fake-commit-message"
+      const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
+        githubId: mockGithubId,
+        accessToken: mockAccessToken,
+        isomerUserId: mockIsomerUserId,
+        email: mockEmail,
+        siteName: "not-whitelisted",
       })
 
-      it("should move files using GitHub directly if the repo is not ggs enabled", async () => {
-        const expected = { newSha: "fake-commit-sha" }
-        const fakeCommitMessage = "fake-commit-message"
-        const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData(
-          {
-            githubId: mockGithubId,
-            accessToken: mockAccessToken,
-            isomerUserId: mockIsomerUserId,
-            email: mockEmail,
-            siteName: "not-whitelisted",
-          }
-        )
-
-        const gitHubServiceMoveFiles = jest.spyOn(
-          GitHubService.prototype,
-          "moveFiles"
-        )
-        gitHubServiceMoveFiles.mockResolvedValueOnce(expected)
-
-        const actual = await RepoService.moveFiles(
-          sessionData,
-          mockGithubSessionData,
-          "fake-path",
-          "fake-new-path",
-          ["old-fake-file.md", "old-fake-file-two.md"],
-          fakeCommitMessage
-        )
-
-        expect(actual).toEqual(expected)
+      const gitHubServiceRenameSinglePath = jest.spyOn(
+        GitHubService.prototype,
+        "renameSinglePath"
+      )
+      gitHubServiceRenameSinglePath.mockResolvedValueOnce({
+        newSha: expectedSha,
       })
+
+      const actual = await RepoService.renameSinglePath(
+        sessionData,
+        mockGithubSessionData,
+        "fake-path/old-fake-file.md",
+        "fake-path/new-fake-file.md",
+        fakeCommitMessage
+      )
+
+      expect(actual).toEqual({ newSha: expectedSha })
+    })
+  })
+
+  describe("moveFiles", () => {
+    it("should move files using the Git local file system if the repo is ggs enabled", async () => {
+      const expected = { newSha: "fake-commit-sha" }
+      MockGitFileCommitService.moveFiles.mockResolvedValueOnce(expected)
+      gbSpy.mockReturnValueOnce(true)
+      // MockCommitServiceGitFile.push.mockReturnValueOnce(undefined)
+
+      const actual = await RepoService.moveFiles(
+        mockUserWithSiteSessionDataAndGrowthBook,
+        mockGithubSessionData,
+        "fake-old-path",
+        "fake-new-path",
+        ["fake-file1", "fake-file2"],
+        "fake-commit-message"
+      )
+
+      expect(actual).toEqual(expected)
     })
 
-    describe("getLatestCommitOfBranch", () => {
-      it("should read the latest commit data from the local Git file system if the repo is ggs enabled", async () => {
-        const expected: GitHubCommitData = {
-          author: {
-            name: "test author",
-            email: "test@email.com",
-            date: "2023-07-20T11:25:05+08:00",
-          },
-          sha: "test-sha",
-          message: "test message",
-        }
-        gbSpy.mockReturnValueOnce(true)
-        MockGitFileSystemService.getLatestCommitOfBranch.mockResolvedValueOnce(
-          okAsync(expected)
-        )
-
-        const actual = await RepoService.getLatestCommitOfBranch(
-          mockUserWithSiteSessionDataAndGrowthBook,
-          "master"
-        )
-        expect(actual).toEqual(expected)
+    it("should move files using GitHub directly if the repo is not ggs enabled", async () => {
+      const expected = { newSha: "fake-commit-sha" }
+      const fakeCommitMessage = "fake-commit-message"
+      const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
+        githubId: mockGithubId,
+        accessToken: mockAccessToken,
+        isomerUserId: mockIsomerUserId,
+        email: mockEmail,
+        siteName: "not-whitelisted",
       })
 
-      it("should read latest commit data from GitHub if the repo is not ggs enabled", async () => {
-        const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData(
-          {
-            githubId: mockGithubId,
-            accessToken: mockAccessToken,
-            isomerUserId: mockIsomerUserId,
-            email: mockEmail,
-            siteName: "not-whitelisted",
-          }
-        )
-        const expected: GitHubCommitData = {
-          author: {
-            name: "test author",
-            email: "test@email.com",
-            date: "2023-07-20T11:25:05+08:00",
-          },
-          message: "test message",
-        }
-        const gitHubServiceReadDirectory = jest.spyOn(
-          GitHubService.prototype,
-          "getLatestCommitOfBranch"
-        )
-        gitHubServiceReadDirectory.mockResolvedValueOnce(expected)
-        const actual = await RepoService.getLatestCommitOfBranch(
-          sessionData,
-          "master"
-        )
-        expect(actual).toEqual(expected)
-      })
+      const gitHubServiceMoveFiles = jest.spyOn(
+        GitHubService.prototype,
+        "moveFiles"
+      )
+      gitHubServiceMoveFiles.mockResolvedValueOnce(expected)
+
+      const actual = await RepoService.moveFiles(
+        sessionData,
+        mockGithubSessionData,
+        "fake-path",
+        "fake-new-path",
+        ["old-fake-file.md", "old-fake-file-two.md"],
+        fakeCommitMessage
+      )
+
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe("getLatestCommitOfBranch", () => {
+    it("should read the latest commit data from the local Git file system if the repo is ggs enabled", async () => {
+      const expected: GitHubCommitData = {
+        author: {
+          name: "test author",
+          email: "test@email.com",
+          date: "2023-07-20T11:25:05+08:00",
+        },
+        sha: "test-sha",
+        message: "test message",
+      }
+      gbSpy.mockReturnValueOnce(true)
+      MockGitFileSystemService.getLatestCommitOfBranch.mockResolvedValueOnce(
+        okAsync(expected)
+      )
+
+      const actual = await RepoService.getLatestCommitOfBranch(
+        mockUserWithSiteSessionDataAndGrowthBook,
+        "master"
+      )
+      expect(actual).toEqual(expected)
     })
 
-    describe("updateRepoState", () => {
-      it("should update the repo state on the local Git file system if the repo is ggs enabled", async () => {
-        MockGitFileSystemService.updateRepoState.mockResolvedValueOnce(
-          okAsync(undefined)
-        )
-        gbSpy.mockReturnValueOnce(true)
-
-        await RepoService.updateRepoState(
-          mockUserWithSiteSessionDataAndGrowthBook,
-          {
-            commitSha: "fake-sha",
-            branchName: "master",
-          }
-        )
-
-        expect(MockGitFileSystemService.updateRepoState).toBeCalledTimes(1)
+    it("should read latest commit data from GitHub if the repo is not ggs enabled", async () => {
+      const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
+        githubId: mockGithubId,
+        accessToken: mockAccessToken,
+        isomerUserId: mockIsomerUserId,
+        email: mockEmail,
+        siteName: "not-whitelisted",
       })
+      const expected: GitHubCommitData = {
+        author: {
+          name: "test author",
+          email: "test@email.com",
+          date: "2023-07-20T11:25:05+08:00",
+        },
+        message: "test message",
+      }
+      const gitHubServiceReadDirectory = jest.spyOn(
+        GitHubService.prototype,
+        "getLatestCommitOfBranch"
+      )
+      gitHubServiceReadDirectory.mockResolvedValueOnce(expected)
+      const actual = await RepoService.getLatestCommitOfBranch(
+        sessionData,
+        "master"
+      )
+      expect(actual).toEqual(expected)
+    })
+  })
 
-      it("should update the repo state on GitHub if the repo is not ggs enabled", async () => {
-        const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData(
-          {
-            githubId: mockGithubId,
-            accessToken: mockAccessToken,
-            isomerUserId: mockIsomerUserId,
-            email: mockEmail,
-            siteName: "not-whitelisted",
-          }
-        )
-        const gitHubServiceUpdateRepoState = jest.spyOn(
-          GitHubService.prototype,
-          "updateRepoState"
-        )
-        gitHubServiceUpdateRepoState.mockResolvedValueOnce(undefined)
+  describe("updateRepoState", () => {
+    it("should update the repo state on the local Git file system if the repo is ggs enabled", async () => {
+      MockGitFileSystemService.updateRepoState.mockResolvedValueOnce(
+        okAsync(undefined)
+      )
+      gbSpy.mockReturnValueOnce(true)
 
-        await RepoService.updateRepoState(sessionData, {
+      await RepoService.updateRepoState(
+        mockUserWithSiteSessionDataAndGrowthBook,
+        {
           commitSha: "fake-sha",
           branchName: "master",
-        })
+        }
+      )
 
-        expect(gitHubServiceUpdateRepoState).toBeCalledTimes(1)
+      expect(MockGitFileSystemService.updateRepoState).toBeCalledTimes(1)
+    })
+
+    it("should update the repo state on GitHub if the repo is not ggs enabled", async () => {
+      const sessionData: UserWithSiteSessionData = new UserWithSiteSessionData({
+        githubId: mockGithubId,
+        accessToken: mockAccessToken,
+        isomerUserId: mockIsomerUserId,
+        email: mockEmail,
+        siteName: "not-whitelisted",
       })
+      const gitHubServiceUpdateRepoState = jest.spyOn(
+        GitHubService.prototype,
+        "updateRepoState"
+      )
+      gitHubServiceUpdateRepoState.mockResolvedValueOnce(undefined)
+
+      await RepoService.updateRepoState(sessionData, {
+        commitSha: "fake-sha",
+        branchName: "master",
+      })
+
+      expect(gitHubServiceUpdateRepoState).toBeCalledTimes(1)
     })
   })
 })

--- a/src/types/gitfilesystem.ts
+++ b/src/types/gitfilesystem.ts
@@ -10,8 +10,14 @@ export type GitCommitResult = {
 export type GitDirectoryItem = {
   name: string
   type: "file" | "dir"
-  sha: string
+  sha?: string
   path: string
   size: number
   addedTime: number
+}
+
+export type DirectoryContents = {
+  directories: GitDirectoryItem[]
+  files: GitDirectoryItem[]
+  total: number
 }

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,6 +1,12 @@
+import _ from "lodash"
 import { Result, err, ok } from "neverthrow"
 
+import { GIT_SYSTEM_DIRECTORY, PLACEHOLDER_FILE_NAME } from "@root/constants"
 import EmptyStringError from "@root/errors/EmptyStringError"
+import type {
+  DirectoryContents,
+  GitDirectoryItem,
+} from "@root/types/gitfilesystem"
 import { PathInfo } from "@root/types/util"
 
 export const getFileExt = (fileName: string): string =>
@@ -33,4 +39,50 @@ export const extractPathInfo = (
     path: ok(fullPath),
     __kind: "PathInfo",
   })
+}
+
+export const getPaginatedDirectoryContents = (
+  directoryContents: GitDirectoryItem[],
+  page: number,
+  limit = 15,
+  search = ""
+): DirectoryContents => {
+  const subdirectories = directoryContents.filter(
+    (item) => item.type === "dir" && item.name !== GIT_SYSTEM_DIRECTORY
+  )
+  const files = directoryContents.filter(
+    (item) => item.type === "file" && item.name !== PLACEHOLDER_FILE_NAME
+  )
+
+  let sortedFiles = _(files)
+    // Note: We are sorting by name here to maintain compatibility for
+    // GitHub-login users, since it is very expensive to get the addedTime for
+    // each file from the GitHub API. The files will be sorted by addedTime in
+    // milliseconds for GGS users, so they will never see the alphabetical
+    // sorting.
+    .orderBy(
+      [(file) => file.addedTime, (file) => file.name.toLowerCase()],
+      ["desc", "asc"]
+    )
+
+  if (search) {
+    sortedFiles = sortedFiles.filter((file) =>
+      file.name.toLowerCase().includes(search.toLowerCase())
+    )
+  }
+  const totalLength = sortedFiles.value().length
+
+  const paginatedFiles =
+    limit === 0
+      ? sortedFiles.value()
+      : sortedFiles
+          .drop(page * limit)
+          .take(limit)
+          .value()
+
+  return {
+    directories: subdirectories,
+    files: paginatedFiles,
+    total: totalLength,
+  }
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Sites with a lot of images cannot load their images on the CMS.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Improvements**:

- Perform a filter first before getting the Git blob hash, which was found to be quite expensive for a large number of files.

**Bug Fixes**:

- The addedTime attribute was accidentally reverted earlier, fixed that so that the added times are now correct on EFS.
- Skip checking the `.git` folder, so we should have less error messages in the logs.

## Tests

<!-- What tests should be run to confirm functionality? -->

Smoke test:
- [ ] Navigate to `moe-ast-moehc` with the repo on GGS (i.e. email-login)
- [ ] Attempt to load the images page
- [ ] The page should load fairly quickly

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*