### PR TITLE
IS-835 Removed all instances of any from GitHubService.ts

### DIFF
--- a/src/services/db/GitHubService.ts
+++ b/src/services/db/GitHubService.ts
@@ -207,7 +207,10 @@ export default class GitHubService {
 
   async read(
     sessionData: UserWithSiteSessionData,
-    { fileName, directoryName }: { fileName: any; directoryName: any }
+    {
+      fileName,
+      directoryName,
+    }: { fileName: string; directoryName: string | undefined }
   ) {
     const { accessToken } = sessionData
     const { siteName } = sessionData
@@ -514,7 +517,7 @@ export default class GitHubService {
   async getTree(
     sessionData: UserWithSiteSessionData,
     githubSessionData: GithubSessionData,
-    { isRecursive }: any
+    { isRecursive }: { isRecursive: boolean }
   ): Promise<RawGitTreeEntry[]> {
     const { accessToken } = sessionData
     const { siteName } = sessionData
@@ -541,7 +544,7 @@ export default class GitHubService {
   async updateTree(
     sessionData: UserWithSiteSessionData,
     githubSessionData: GithubSessionData,
-    { gitTree, message }: { gitTree: any; message: any }
+    { gitTree, message }: { gitTree: unknown; message: unknown }
   ) {
     const { accessToken, siteName, isomerUserId: userId } = sessionData
     const { treeSha, currentCommitSha } = githubSessionData.getGithubState()
@@ -634,9 +637,9 @@ export default class GitHubService {
     const gitTree = await this.getTree(sessionData, githubSessionData, {
       isRecursive: true,
     })
-    const newGitTree: any[] = []
+    const newGitTree: RawGitTreeEntry[] = []
 
-    gitTree.forEach((item: any) => {
+    gitTree.forEach((item: RawGitTreeEntry) => {
       if (item.path.startsWith(`${newPath}/`) && item.type !== "tree") {
         const fileName = item.path
           .split(`${newPath}/`)
@@ -689,12 +692,12 @@ export default class GitHubService {
     const gitTree = await this.getTree(sessionData, githubSessionData, {
       isRecursive: true,
     })
-    const newGitTree: any[] = []
+    const newGitTree: RawGitTreeEntry[] = []
     const isMovingDirectory =
-      gitTree.find((item: any) => item.path === oldPath)?.type === "tree" ||
-      false
+      gitTree.find((item: RawGitTreeEntry) => item.path === oldPath)?.type ===
+        "tree" || false
 
-    gitTree.forEach((item: any) => {
+    gitTree.forEach((item: RawGitTreeEntry) => {
       if (isMovingDirectory) {
         if (item.path === newPath && item.type === "tree") {
           throw new ConflictError("Target directory already exists")
@@ -743,7 +746,7 @@ export default class GitHubService {
 
   async updateRepoState(
     sessionData: UserWithSiteSessionData,
-    { commitSha, branchName }: { commitSha: any; branchName?: string }
+    { commitSha, branchName }: { commitSha: string; branchName?: string }
   ) {
     const { accessToken } = sessionData
     const { siteName } = sessionData
@@ -786,7 +789,7 @@ export default class GitHubService {
   }
 
   async changeRepoPrivacy(
-    sessionData: { siteName: any; isomerUserId: any },
+    sessionData: { siteName: string; isomerUserId: string },
     shouldMakePrivate: boolean
   ) {
     const { siteName, isomerUserId } = sessionData

--- a/src/services/db/GitHubService.ts
+++ b/src/services/db/GitHubService.ts
@@ -544,7 +544,7 @@ export default class GitHubService {
   async updateTree(
     sessionData: UserWithSiteSessionData,
     githubSessionData: GithubSessionData,
-    { gitTree, message }: { gitTree: unknown; message: unknown }
+    { gitTree, message }: { gitTree: RawGitTreeEntry[]; message?: string }
   ) {
     const { accessToken, siteName, isomerUserId: userId } = sessionData
     const { treeSha, currentCommitSha } = githubSessionData.getGithubState()

--- a/src/services/db/__tests__/GitHubService.spec.ts
+++ b/src/services/db/__tests__/GitHubService.spec.ts
@@ -862,7 +862,6 @@ describe("Github Service", () => {
     it("should update a repo tree correctly", async () => {
       const firstSha = "first-sha"
       const secondSha = "second-sha"
-      const gitTree = "git-tree"
       const message = "message"
       const finalExpectedMessage = JSON.stringify({
         message,

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -97,7 +97,7 @@ export type RawGitTreeEntry = {
   path: string
   mode: string
   type: "tree" | "file"
-  sha: string
+  sha: string | null
   url: string
   size?: number // only exists if it is a file
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [IS-835](https://isomeropengov.atlassian.net/browse/IS-835?atlOrigin=eyJpIjoiNGJiMzk4NTM4NmRlNGYxYmEzODU5MjY5MzY1YWQwOGYiLCJwIjoiaiJ9)

There are 13 instances of `any` in the file `GitHubService.ts`. The usage of `any` should be avoid if possible to maintain the type safety of Typescript. 

## Solution

<!-- How did you solve the problem? -->
Defined explicit types for all instances of `any` in `GitHubService.ts` 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Improvements**:

- Ensure type safety by replacing all instances of `any` with explicit types in `GitHubService.ts` file 

## Tests

<!-- What tests should be run to confirm functionality? -->
Clone the branch and run backend locally to confirm there is no error from type checking



[IS-835]: https://isomeropengov.atlassian.net/browse/IS-835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ