### PR TITLE
fix(media): introduce delete multiple files endpoint

### DIFF
--- a/src/routes/v2/authenticatedSites/__tests__/Media.spec.ts
+++ b/src/routes/v2/authenticatedSites/__tests__/Media.spec.ts
@@ -27,6 +27,7 @@ describe("Media Router", () => {
     read: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),
+    deleteMultipleFiles: jest.fn(),
     rename: jest.fn(),
   }
 
@@ -45,6 +46,10 @@ describe("Media Router", () => {
   subrouter.post(
     "/:siteName/media",
     attachReadRouteHandlerWrapper(router.createMediaDirectory)
+  )
+  subrouter.delete(
+    "/:siteName/media",
+    attachReadRouteHandlerWrapper(router.deleteMultipleMediaFiles)
   )
   subrouter.post(
     "/:siteName/media/:directoryName",
@@ -399,6 +404,36 @@ describe("Media Router", () => {
         .expect(200)
       expect(mockMediaFileService.delete).toHaveBeenCalledWith(
         MOCK_USER_WITH_SITE_SESSION_DATA_ONE,
+        expectedServiceInput
+      )
+    })
+  })
+
+  describe("deleteMultipleMediaFiles", () => {
+    it("rejects requests with invalid body", async () => {
+      await request(app).delete(`/${siteName}/media`).send({}).expect(400)
+    })
+
+    it("accepts valid multiple media files delete requests", async () => {
+      const expectedServiceInput = {
+        items: [
+          {
+            filePath: "test-file-one",
+            sha: "test-file-one-sha",
+          },
+          {
+            filePath: "test-file-two",
+            sha: "test-file=two-sha",
+          },
+        ],
+      }
+      await request(app)
+        .delete(`/${siteName}/media`)
+        .send(expectedServiceInput)
+        .expect(200)
+      expect(mockMediaFileService.deleteMultipleFiles).toHaveBeenCalledWith(
+        MOCK_USER_WITH_SITE_SESSION_DATA_ONE,
+        undefined,
         expectedServiceInput
       )
     })

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -620,8 +620,6 @@ export default class GitFileSystemService {
         )
       }
 
-      // Note: We only accept commits that change 1 file at once (pathSpec.length == 1)
-      // Or commits that move/rename files (pathSpec.length == 2)
       if (pathSpec.length < 1) {
         return errAsync(
           new GitFileSystemError(
@@ -1289,7 +1287,7 @@ export default class GitFileSystemService {
             )
           )
         }
-        oldStateSha = latestCommit.sha as string
+        oldStateSha = latestCommit.sha
         return okAsync(true)
       })
       .andThen(() =>

--- a/src/services/db/GitHubService.ts
+++ b/src/services/db/GitHubService.ts
@@ -419,6 +419,37 @@ export default class GitHubService {
     }
   }
 
+  async deleteMultipleFiles(
+    sessionData: UserWithSiteSessionData,
+    githubSessionData: GithubSessionData,
+    { items }: { items: Array<{ filePath: string; sha: string }> }
+  ): Promise<void> {
+    const gitTree = await this.getTree(sessionData, githubSessionData, {
+      isRecursive: true,
+    })
+    const newGitTree: any[] = []
+    const filePaths = items.map((item) => item.filePath)
+
+    gitTree.forEach((item: any) => {
+      if (filePaths.includes(item.path)) {
+        // Mark the file to be deleted
+        newGitTree.push({
+          ...item,
+          sha: null,
+        })
+      }
+    })
+
+    const newCommitSha = await this.updateTree(sessionData, githubSessionData, {
+      gitTree: newGitTree,
+      message: `Delete files: ${filePaths.join(", ")}`,
+    })
+
+    await this.updateRepoState(sessionData, {
+      commitSha: newCommitSha,
+    })
+  }
+
   async getRepoInfo(
     sessionData: UserWithSiteSessionData
   ): Promise<GitHubRepoInfo> {

--- a/src/services/db/GitHubService.ts
+++ b/src/services/db/GitHubService.ts
@@ -427,10 +427,10 @@ export default class GitHubService {
     const gitTree = await this.getTree(sessionData, githubSessionData, {
       isRecursive: true,
     })
-    const newGitTree: any[] = []
+    const newGitTree: RawGitTreeEntry[] = []
     const filePaths = items.map((item) => item.filePath)
 
-    gitTree.forEach((item: any) => {
+    gitTree.forEach((item: RawGitTreeEntry) => {
       if (filePaths.includes(item.path)) {
         // Mark the file to be deleted
         newGitTree.push({

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -259,6 +259,10 @@ export default class RepoService extends GitHubService {
     )
     const { private: isPrivate } = await super.getRepoInfo(sessionData)
 
+    if (targetFile === undefined) {
+      throw new NotFoundError(`File ${fileName} not found in ${directoryName}`)
+    }
+
     return getMediaFileInfo({
       file: targetFile,
       siteName,
@@ -456,6 +460,33 @@ export default class RepoService extends GitHubService {
       sha,
       fileName,
       directoryName,
+    })
+  }
+
+  async deleteMultipleFiles(
+    sessionData: UserWithSiteSessionData,
+    githubSessionData: GithubSessionData,
+    { items }: { items: Array<{ filePath: string; sha: string }> }
+  ): Promise<void> {
+    if (
+      sessionData.growthbook?.getFeatureValue(
+        FEATURE_FLAGS.IS_GGS_ENABLED,
+        false
+      )
+    ) {
+      await this.gitFileCommitService.deleteMultipleFiles(
+        sessionData,
+        githubSessionData,
+        {
+          items,
+        }
+      )
+      return
+    }
+
+    // GitHub flow
+    await super.deleteMultipleFiles(sessionData, githubSessionData, {
+      items,
     })
   }
 

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -257,11 +257,12 @@ export default class RepoService extends GitHubService {
     const targetFile = directoryData.find(
       (fileOrDir: { name: string }) => fileOrDir.name === fileName
     )
-    const { private: isPrivate } = await super.getRepoInfo(sessionData)
 
     if (targetFile === undefined) {
       throw new NotFoundError(`File ${fileName} not found in ${directoryName}`)
     }
+
+    const { private: isPrivate } = await super.getRepoInfo(sessionData)
 
     return getMediaFileInfo({
       file: targetFile,

--- a/src/services/db/__tests__/GitHubService.spec.ts
+++ b/src/services/db/__tests__/GitHubService.spec.ts
@@ -695,7 +695,7 @@ describe("Github Service", () => {
 
     const mockFiles = gitTree.map((item) => ({
       filePath: item.path,
-      sha: item.sha,
+      sha: item.sha || "",
     }))
 
     const params = {

--- a/src/services/fileServices/MdPageServices/MediaFileService.js
+++ b/src/services/fileServices/MdPageServices/MediaFileService.js
@@ -131,6 +131,24 @@ class MediaFileService {
       sha: newCommitSha,
     }
   }
+
+  async deleteMultipleFiles(sessionData, githubSessionData, { items }) {
+    items.forEach((item) => {
+      const directoryName = item.filePath.split("/").slice(0, -1).join("/")
+      const fileName = item.filePath.split("/").pop()
+
+      this.mediaNameChecks({
+        directoryName,
+        fileName,
+      })
+    })
+
+    return this.repoService.deleteMultipleFiles(
+      sessionData,
+      githubSessionData,
+      { items }
+    )
+  }
 }
 
 module.exports = { MediaFileService }

--- a/src/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
+++ b/src/services/fileServices/MdPageServices/__tests__/MediaFileService.spec.js
@@ -24,6 +24,7 @@ describe("Media File Service", () => {
     read: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),
+    deleteMultipleFiles: jest.fn(),
     getRepoInfo: jest.fn(),
     readMediaFile: jest.fn(),
     readDirectory: jest.fn(),
@@ -233,6 +234,42 @@ describe("Media File Service", () => {
         `${directoryName}/${oldFileName}`,
         `${directoryName}/${fileName}`,
         `Renamed ${oldFileName} to ${fileName}`
+      )
+    })
+  })
+
+  describe("DeleteMultipleFiles", () => {
+    it("rejects page names with special characters", async () => {
+      await expect(
+        service.deleteMultipleFiles(sessionData, mockGithubSessionData, {
+          items: [
+            { filePath: "file/file%%%name.pdf", sha },
+            { filePath: "valid.pdf", sha },
+          ],
+        })
+      ).rejects.toThrowError(BadRequestError)
+    })
+
+    it("Deleting multiple pages works correctly", async () => {
+      const mockFiles = [
+        { filePath: "images/valid.jpg", sha },
+        { filePath: "images/another/valid.jpg", sha },
+      ]
+
+      mockRepoService.deleteMultipleFiles.mockResolvedValueOnce(undefined)
+
+      await expect(
+        service.deleteMultipleFiles(sessionData, mockGithubSessionData, {
+          items: mockFiles,
+        })
+      ).resolves.not.toThrow()
+
+      expect(mockRepoService.deleteMultipleFiles).toHaveBeenCalledWith(
+        sessionData,
+        mockGithubSessionData,
+        {
+          items: mockFiles,
+        }
       )
     })
   })

--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -205,6 +205,17 @@ const DeleteMediaFileRequestSchema = Joi.object().keys({
   sha: Joi.string().required(),
 })
 
+const DeleteMultipleMediaFilesRequestSchema = Joi.object().keys({
+  items: Joi.array()
+    .items(
+      Joi.object().keys({
+        filePath: Joi.string().required(),
+        sha: Joi.string().required(),
+      })
+    )
+    .required(),
+})
+
 const UpdateNavigationRequestSchema = Joi.object().keys({
   content: Joi.object()
     .keys({
@@ -303,6 +314,7 @@ module.exports = {
   CreateMediaFileRequestSchema,
   UpdateMediaFileRequestSchema,
   DeleteMediaFileRequestSchema,
+  DeleteMultipleMediaFilesRequestSchema,
   UpdateNavigationRequestSchema,
   UpdateSettingsRequestSchema,
   UpdateRepoPasswordRequestSchema,


### PR DESCRIPTION
> [!NOTE]
> Large PR due to unit tests, feel free to browse by commits

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The current delete file endpoint often encounters the repo lock, prevent users from deleting multiple files at once.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Improvements**:

- A new endpoint has been introduced to allow for deleting of multiple files in a single repo lock transaction.

## Tests

<!-- What tests should be run to confirm functionality? -->

- Unit tests.
- Smoke tests (written on https://github.com/isomerpages/isomercms-frontend/pull/1753)

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*