### PR TITLE
ref(ts migration): replaced all instances of any with explicit types in repoService.ts

### DIFF
--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -1,5 +1,7 @@
+import { User } from "aws-sdk/clients/budgets"
 import { AxiosCacheInstance } from "axios-cache-interceptor"
 import _ from "lodash"
+import { ResultAsync } from "neverthrow"
 
 import config from "@config/config"
 
@@ -8,6 +10,8 @@ import logger from "@logger/logger"
 import GithubSessionData from "@root/classes/GithubSessionData"
 import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import { FEATURE_FLAGS, STAGING_BRANCH } from "@root/constants"
+import GitHubApiError from "@root/errors/GitHubApiError"
+import { NotFoundError } from "@root/errors/NotFoundError"
 import { GitHubCommitData } from "@root/types/commitData"
 import type {
   DirectoryContents,
@@ -15,7 +19,7 @@ import type {
   GitDirectoryItem,
   GitFile,
 } from "@root/types/gitfilesystem"
-import { RawGitTreeEntry } from "@root/types/github"
+import { GitHubRepoInfo, RawGitTreeEntry, RepoState } from "@root/types/github"
 import { MediaDirOutput, MediaFileOutput, MediaType } from "@root/types/media"
 import { getPaginatedDirectoryContents } from "@root/utils/files"
 import { getMediaFileInfo } from "@root/utils/media-utils"
@@ -112,7 +116,15 @@ export default class RepoService extends GitHubService {
     return ReviewApi.createComment(siteName, pullRequestNumber, user, message)
   }
 
-  getFilePath({ siteName, fileName, directoryName }: any): any {
+  getFilePath({
+    siteName,
+    fileName,
+    directoryName,
+  }: {
+    siteName: string
+    fileName: string
+    directoryName?: string
+  }): string {
     return super.getFilePath({
       siteName,
       fileName,
@@ -120,11 +132,23 @@ export default class RepoService extends GitHubService {
     })
   }
 
-  getBlobPath({ siteName, fileSha }: any): any {
+  getBlobPath({
+    siteName,
+    fileSha,
+  }: {
+    siteName: string
+    fileSha: string
+  }): string {
     return super.getBlobPath({ siteName, fileSha })
   }
 
-  getFolderPath({ siteName, directoryName }: any) {
+  getFolderPath({
+    siteName,
+    directoryName,
+  }: {
+    siteName: string
+    directoryName: string
+  }) {
     return super.getFolderPath({ siteName, directoryName })
   }
 
@@ -506,11 +530,13 @@ export default class RepoService extends GitHubService {
     )
   }
 
-  async getRepoInfo(sessionData: any): Promise<any> {
+  async getRepoInfo(
+    sessionData: UserWithSiteSessionData
+  ): Promise<GitHubRepoInfo> {
     return super.getRepoInfo(sessionData)
   }
 
-  async getRepoState(sessionData: any): Promise<any> {
+  async getRepoState(sessionData: UserWithSiteSessionData): Promise<RepoState> {
     return super.getRepoState(sessionData)
   }
 
@@ -541,9 +567,9 @@ export default class RepoService extends GitHubService {
   }
 
   async getTree(
-    sessionData: any,
-    githubSessionData: any,
-    { isRecursive }: any
+    sessionData: UserWithSiteSessionData,
+    githubSessionData: GithubSessionData,
+    { isRecursive }: { isRecursive: boolean }
   ): Promise<RawGitTreeEntry[]> {
     return super.getTree(sessionData, githubSessionData, {
       isRecursive,
@@ -551,10 +577,10 @@ export default class RepoService extends GitHubService {
   }
 
   async updateTree(
-    sessionData: any,
-    githubSessionData: any,
-    { gitTree, message }: any
-  ): Promise<any> {
+    sessionData: UserWithSiteSessionData,
+    githubSessionData: GithubSessionData,
+    { gitTree, message }: { gitTree: RawGitTreeEntry[]; message?: string }
+  ): Promise<string> {
     return super.updateTree(sessionData, githubSessionData, {
       gitTree,
       message,
@@ -592,14 +618,14 @@ export default class RepoService extends GitHubService {
     await super.updateRepoState(sessionData, { commitSha })
   }
 
-  async checkHasAccess(sessionData: any): Promise<any> {
+  async checkHasAccess(sessionData: UserWithSiteSessionData): Promise<void> {
     return super.checkHasAccess(sessionData)
   }
 
   async changeRepoPrivacy(
-    sessionData: any,
-    shouldMakePrivate: any
-  ): Promise<any> {
+    sessionData: UserWithSiteSessionData,
+    shouldMakePrivate: boolean
+  ): Promise<ResultAsync<null, NotFoundError | GitHubApiError>> {
     return super.changeRepoPrivacy(sessionData, shouldMakePrivate)
   }
 }

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -1,4 +1,3 @@
-import { User } from "aws-sdk/clients/budgets"
 import { AxiosCacheInstance } from "axios-cache-interceptor"
 import _ from "lodash"
 import { ResultAsync } from "neverthrow"
@@ -124,7 +123,7 @@ export default class RepoService extends GitHubService {
     siteName: string
     fileName: string
     directoryName?: string
-  }): string {
+  }) {
     return super.getFilePath({
       siteName,
       fileName,
@@ -132,13 +131,7 @@ export default class RepoService extends GitHubService {
     })
   }
 
-  getBlobPath({
-    siteName,
-    fileSha,
-  }: {
-    siteName: string
-    fileSha: string
-  }): string {
+  getBlobPath({ siteName, fileSha }: { siteName: string; fileSha: string }) {
     return super.getBlobPath({ siteName, fileSha })
   }
 

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -615,10 +615,10 @@ export default class RepoService extends GitHubService {
     return super.checkHasAccess(sessionData)
   }
 
-  async changeRepoPrivacy(
+  changeRepoPrivacy(
     sessionData: UserWithSiteSessionData,
     shouldMakePrivate: boolean
-  ): Promise<ResultAsync<null, NotFoundError | GitHubApiError>> {
+  ): ResultAsync<null, NotFoundError | GitHubApiError> {
     return super.changeRepoPrivacy(sessionData, shouldMakePrivate)
   }
 }

--- a/src/services/db/__tests__/RepoService.spec.ts
+++ b/src/services/db/__tests__/RepoService.spec.ts
@@ -316,7 +316,10 @@ describe("RepoService", () => {
           date: 0,
         },
       })
-      gitHubServiceGetRepoInfo.mockResolvedValueOnce({ private: false })
+      gitHubServiceGetRepoInfo.mockResolvedValueOnce({
+        description: "",
+        private: false,
+      })
       const getMediaFileInfo = jest
         .spyOn(mediaUtils, "getMediaFileInfo")
         .mockResolvedValueOnce(expected)

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -103,9 +103,9 @@ export type RawGitTreeEntry = {
 }
 
 export type GitHubRepoInfo = {
-  title: string
-  description: string
-  type: string
+  title?: string
+  description?: string
+  type?: string
   private: boolean
 }
 

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -104,7 +104,7 @@ export type RawGitTreeEntry = {
 
 export type GitHubRepoInfo = {
   title?: string
-  description?: string
+  description: string
   type?: string
   private: boolean
 }

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -101,3 +101,15 @@ export type RawGitTreeEntry = {
   url: string
   size?: number // only exists if it is a file
 }
+
+export type GitHubRepoInfo = {
+  title: string
+  description: string
+  type: string
+  private: boolean
+}
+
+export type RepoState = {
+  treeSha: string
+  currentCommitSha: string
+}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [IS-836](https://isomeropengov.atlassian.net/browse/IS-836?atlOrigin=eyJpIjoiM2JkYjcxYjAwZjkwNDdkNWI3NmQ5ZGE2NmY1ZTdkN2IiLCJwIjoiaiJ9)

There are a lot of instances of type `any` in the file `repoService.ts`, and we need to replace them with explicit types to ensure type safety. 

## Solution

<!-- How did you solve the problem? -->
Replaced all instances of type `any` in `repoService.ts`

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Improvements**:

- Replaced all instances of type `any` in `repoService.ts`

## Tests

<!-- What tests should be run to confirm functionality? -->
CI test to confirm no error in type checking 


[IS-836]: https://isomeropengov.atlassian.net/browse/IS-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ