### PR TITLE
ref(ts migration): replaced all instances of any in routeHandler.ts with explicit types

### DIFF
--- a/src/middleware/routeHandler.ts
+++ b/src/middleware/routeHandler.ts
@@ -32,10 +32,7 @@ const simpleGitInstance = simpleGit({
 })
 const gitFileSystemService = new GitFileSystemService(simpleGitInstance)
 
-const handleGitFileLock = async (
-  repoName: string,
-  next: (arg0: Error | null) => void
-) => {
+const handleGitFileLock = async (repoName: string, next: NextFunction) => {
   const result = await gitFileSystemService.hasGitFileLock(repoName, true)
   if (result.isErr()) {
     next(result.error)

--- a/src/middleware/routeHandler.ts
+++ b/src/middleware/routeHandler.ts
@@ -17,6 +17,7 @@ import {
   STAGING_LITE_BRANCH,
 } from "@constants/constants"
 
+import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import { FEATURE_FLAGS } from "@root/constants/featureFlags"
 import LockedError from "@root/errors/LockedError"
 import logger from "@root/logger/logger"
@@ -136,15 +137,13 @@ export const attachWriteRouteHandlerWrapper = <
 }
 
 export const attachRollbackRouteHandlerWrapper = <
-  P extends { siteName: string },
+  P extends { siteName: string; directoryName: string; fileName: string },
   ResBody,
   ReqBody,
   ReqQuery,
   Locals extends {
-    userSessionData: {
-      accessToken: string
-    }
-    githubSessionData: object
+    userWithSiteSessionData: UserWithSiteSessionData
+    githubSessionData: GithubSessionData
   }
 >(
   routeHandler: RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals>
@@ -153,10 +152,10 @@ export const attachRollbackRouteHandlerWrapper = <
   res: Response<ResBody, Locals>,
   next: NextFunction
 ) => {
-  const { userSessionData } = res.locals
+  const { userWithSiteSessionData } = res.locals
   const { siteName } = req.params
 
-  const { accessToken } = userSessionData
+  const { accessToken } = userWithSiteSessionData
   const { growthbook } = req
 
   if (!growthbook) {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [IS-834](https://isomeropengov.atlassian.net/browse/IS-834?atlOrigin=eyJpIjoiYzg1MGM2Mjk0ZGM1NGRkYzlmOTk3OTAxMWJjMWM4NTkiLCJwIjoiaiJ9)

There are many usages of `any` in the file `routeHandler.ts` which is not type safety in Typescript. 

## Solution

<!-- How did you solve the problem? -->
Replaced all usage of `any` with explicit types in `routeHandler.ts`

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Improvements**:

- Replaced all usage of `any` with explicit types in `routeHandler.ts`

## Tests

<!-- What tests should be run to confirm functionality? -->
Run the code locally to confirm no type checking error or waiting for the CI to pass 

[IS-834]: https://isomeropengov.atlassian.net/browse/IS-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ