### PR TITLE
fix: add conditional sha calc

### DIFF
--- a/src/routes/v2/authenticatedSites/media.ts
+++ b/src/routes/v2/authenticatedSites/media.ts
@@ -108,13 +108,11 @@ export class MediaRouter {
     { directoryName: string },
     { directories: MediaDirOutput[] },
     never,
-    { page: number },
+    never,
     { userWithSiteSessionData: UserWithSiteSessionData }
   > = async (req, res) => {
     const { userWithSiteSessionData } = res.locals
-
     const { directoryName } = req.params
-    const { page } = req.query
 
     const {
       directories,
@@ -122,8 +120,8 @@ export class MediaRouter {
       userWithSiteSessionData,
       {
         directoryName,
-        page,
-        limit: 0,
+        page: 0,
+        limit: 1,
         search: "",
       }
     )

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -967,20 +967,16 @@ export default class GitFileSystemService {
               )
               .andThen((shaAndStats) => {
                 const [sha, stats] = shaAndStats
-                return this.getFilePathStats(repoName, path, isStaging).andThen(
-                  (stats) => {
-                    const result: GitDirectoryItem = {
-                      name,
-                      type,
-                      sha,
-                      path,
-                      size: type === "dir" ? 0 : stats.size,
-                      addedTime: stats.ctimeMs,
-                    }
+                const result: GitDirectoryItem = {
+                  name,
+                  type,
+                  sha,
+                  path,
+                  size: type === "dir" ? 0 : stats.size,
+                  addedTime: stats.ctimeMs,
+                }
 
-                    return okAsync(result)
-                  }
-                )
+                return okAsync(result)
               })
           }
           return this.getFilePathStats(repoName, path, isStaging).andThen(
@@ -1022,7 +1018,6 @@ export default class GitFileSystemService {
           getPaginatedDirectoryContents(directoryContents, page, limit, search)
         )
       )
-      .andThen((dirContents) => okAsync(dirContents))
       .andThen((paginatedDirectoryContents) => {
         const directories = paginatedDirectoryContents.directories.map(
           (directory) =>

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -1109,7 +1109,6 @@ export default class GitFileSystemService {
       .andThen(() =>
         this.getGitBlobHash(repoName, filePath, isStaging).andThen((sha) => {
           if (sha !== oldSha) {
-            logger.debug(`Old sha: ${oldSha}, new: ${sha}`)
             return errAsync(
               new ConflictError(
                 "File has been changed recently, please try again"
@@ -1216,7 +1215,6 @@ export default class GitFileSystemService {
           return okAsync(true) // If it's a directory, skip the blob hash verification
         }
         return this.getGitBlobHash(repoName, path, isStaging).andThen((sha) => {
-          logger.debug(`Delete: Old sha: ${oldSha}, new: ${sha}`)
           if (sha !== oldSha) {
             return errAsync(
               new ConflictError(

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -912,7 +912,8 @@ export default class GitFileSystemService {
   listDirectoryContents(
     repoName: string,
     directoryPath: string,
-    branchName: string
+    branchName: string,
+    includeSha = true
   ): ResultAsync<GitDirectoryItem[], GitFileSystemError | NotFoundError> {
     const efsVolPath = this.getEfsVolPathFromBranch(branchName)
     const isStaging = this.isStagingFromBranchName(branchName)
@@ -955,6 +956,33 @@ export default class GitFileSystemService {
           const path = directoryPath === "" ? name : `${directoryPath}/${name}`
           const type = isDirectory ? "dir" : "file"
 
+          if (includeSha) {
+            return this.getGitBlobHash(repoName, path, isStaging)
+              .orElse(() => okAsync(""))
+              .andThen((sha) =>
+                ResultAsync.combine([
+                  okAsync(sha),
+                  this.getFilePathStats(repoName, path, isStaging),
+                ])
+              )
+              .andThen((shaAndStats) => {
+                const [sha, stats] = shaAndStats
+                return this.getFilePathStats(repoName, path, isStaging).andThen(
+                  (stats) => {
+                    const result: GitDirectoryItem = {
+                      name,
+                      type,
+                      sha,
+                      path,
+                      size: type === "dir" ? 0 : stats.size,
+                      addedTime: stats.ctimeMs,
+                    }
+
+                    return okAsync(result)
+                  }
+                )
+              })
+          }
           return this.getFilePathStats(repoName, path, isStaging).andThen(
             (stats) => {
               const result: GitDirectoryItem = {
@@ -964,7 +992,6 @@ export default class GitFileSystemService {
                 size: type === "dir" ? 0 : stats.size,
                 addedTime: stats.ctimeMs,
               }
-
               return okAsync(result)
             }
           )
@@ -984,12 +1011,18 @@ export default class GitFileSystemService {
   ): ResultAsync<DirectoryContents, GitFileSystemError | NotFoundError> {
     const isStaging = this.isStagingFromBranchName(branchName)
 
-    return this.listDirectoryContents(repoName, directoryPath, branchName)
+    return this.listDirectoryContents(
+      repoName,
+      directoryPath,
+      branchName,
+      false
+    )
       .andThen((directoryContents) =>
         okAsync(
           getPaginatedDirectoryContents(directoryContents, page, limit, search)
         )
       )
+      .andThen((dirContents) => okAsync(dirContents))
       .andThen((paginatedDirectoryContents) => {
         const directories = paginatedDirectoryContents.directories.map(
           (directory) =>
@@ -1076,6 +1109,7 @@ export default class GitFileSystemService {
       .andThen(() =>
         this.getGitBlobHash(repoName, filePath, isStaging).andThen((sha) => {
           if (sha !== oldSha) {
+            logger.debug(`Old sha: ${oldSha}, new: ${sha}`)
             return errAsync(
               new ConflictError(
                 "File has been changed recently, please try again"
@@ -1182,6 +1216,7 @@ export default class GitFileSystemService {
           return okAsync(true) // If it's a directory, skip the blob hash verification
         }
         return this.getGitBlobHash(repoName, path, isStaging).andThen((sha) => {
+          logger.debug(`Delete: Old sha: ${oldSha}, new: ${sha}`)
           if (sha !== oldSha) {
             return errAsync(
               new ConflictError(

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -71,11 +71,26 @@ describe("GitFileSystemService", () => {
 
   describe("listDirectoryContents", () => {
     it("should return the contents of a directory successfully", async () => {
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("another-fake-dir-hash"),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("another-fake-file-hash"),
+      })
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("fake-dir-hash"),
+      })
+
+      MockSimpleGit.cwd.mockReturnValueOnce({
+        revparse: jest.fn().mockResolvedValueOnce("fake-empty-dir-hash"),
+      })
+
       const expectedFakeDir: GitDirectoryItem = {
         name: "fake-dir",
         type: "dir",
         path: "fake-dir",
         size: 0,
+        sha: "fake-dir-hash",
         addedTime: fs.statSync(`${EFS_VOL_PATH_STAGING}/fake-repo/fake-dir`)
           .ctimeMs,
       }
@@ -84,6 +99,7 @@ describe("GitFileSystemService", () => {
         type: "dir",
         path: "another-fake-dir",
         size: 0,
+        sha: "another-fake-dir-hash",
         addedTime: fs.statSync(
           `${EFS_VOL_PATH_STAGING}/fake-repo/another-fake-dir`
         ).ctimeMs,
@@ -93,6 +109,7 @@ describe("GitFileSystemService", () => {
         type: "dir",
         path: "fake-empty-dir",
         size: 0,
+        sha: "fake-empty-dir-hash",
         addedTime: fs.statSync(
           `${EFS_VOL_PATH_STAGING}/fake-repo/fake-empty-dir`
         ).ctimeMs,
@@ -102,6 +119,7 @@ describe("GitFileSystemService", () => {
         type: "file",
         path: "another-fake-file",
         size: "Another fake content".length,
+        sha: "another-fake-file-hash",
         addedTime: fs.statSync(
           `${EFS_VOL_PATH_STAGING}/fake-repo/another-fake-file`
         ).ctimeMs,
@@ -115,7 +133,7 @@ describe("GitFileSystemService", () => {
       const actual = result
         ._unsafeUnwrap()
         .sort((a, b) => a.name.localeCompare(b.name))
-
+      console.log(actual)
       expect(actual).toMatchObject([
         expectedAnotherFakeDir,
         expectedAnotherFakeFile,


### PR DESCRIPTION
fix for renaming subfolders

## context

We made a change to fast load images as huge repos with a lot of images had very slow load times.

We used to do: get all files -> calculate hash -> filter/paginate
Now, we get all files -> filter/paginate -> calculate hash

For the get all files to be fast, we removed the sha calculation in the first step of get all files. However, this affected other ops which use list directory contents

Specifically, when we try to rename a subfolder, we need to delete the current directory and re-create a new one
When deleting the current directory, it uses list directory method, but the sha is not present. So when it does a verification of oldSha === newSha, it fails as oldSha is undefined. This causes BE to think that the file was recently changed, so it blocks the delete operation.

Hence, the rename op fails, and we do a rollback. We return 409 saying someone edited the file.

## tests

- Ensure ci/test passes
- On staging, test renaming sub-folders on email login
- Sites with > 15 images should be paginated and switching across pages should be smooth
- Verify same for GitHub login