### PR TITLE
fix(betterUptime): make better uptime on success

### DIFF
--- a/src/routes/formsg/formsgSiteLaunch.ts
+++ b/src/routes/formsg/formsgSiteLaunch.ts
@@ -308,7 +308,6 @@ export class FormsgSiteLaunchRouter {
             )
           }
           // Create better uptime monitor
-          await this.createMonitor(launchResult.value.primaryDomainSource)
           successResults.push(successResult)
         }
       }

--- a/src/routes/formsg/formsgSiteLaunch.ts
+++ b/src/routes/formsg/formsgSiteLaunch.ts
@@ -225,13 +225,6 @@ export class FormsgSiteLaunchRouter {
     await mailer.sendMail(requesterEmail, subject, html)
   }
 
-  sendMonitorCreationFailure = async (baseDomain: string): Promise<void> => {
-    const email = ISOMER_SUPPORT_EMAIL
-    const subject = `[Isomer] Monitor creation FAILURE`
-    const html = `The Uptime Robot monitor for the following site was not created successfully: ${baseDomain}`
-    await mailer.sendMail(email, subject, html)
-  }
-
   digDomainRecords = async (
     domain: string,
     digType: DigType
@@ -249,77 +242,6 @@ export class FormsgSiteLaunchRouter {
         )
         return null
       })
-
-  private async createMonitor(baseDomain: string) {
-    const uptimeRobotBaseUrl = "https://api.uptimerobot.com/v2"
-    try {
-      const UPTIME_ROBOT_API_KEY = config.get("uptimeRobot.apiKey")
-      const getResp = await axios.post<{ monitors: { id: string }[] }>(
-        `${uptimeRobotBaseUrl}/getMonitors?format=json`,
-        {
-          api_key: UPTIME_ROBOT_API_KEY,
-          search: baseDomain,
-        }
-      )
-      const affectedMonitorIds = getResp.data.monitors.map(
-        (monitor) => monitor.id
-      )
-      const getAlertContactsResp = await axios.post<{
-        alert_contacts: { id: string }[]
-      }>(`${uptimeRobotBaseUrl}/getAlertContacts?format=json`, {
-        api_key: UPTIME_ROBOT_API_KEY,
-      })
-      const alertContacts = getAlertContactsResp.data.alert_contacts
-        .map(
-          (contact) => `${contact.id}_0_0` // numbers at the end represent threshold + recurrence, always 0 for free plan
-        )
-        .join("-")
-      if (affectedMonitorIds.length === 0) {
-        // Create new monitor
-        await axios.post<{ monitors: { id: string }[] }>(
-          `${uptimeRobotBaseUrl}/newMonitor?format=json`,
-          {
-            api_key: UPTIME_ROBOT_API_KEY,
-            friendly_name: baseDomain,
-            url: `https://${baseDomain}`,
-            type: 1, // HTTP(S)
-            interval: 30,
-            timeout: 30,
-            alert_contacts: alertContacts,
-            http_method: 2, // GET
-          }
-        )
-      } else {
-        // Edit existing monitor
-        // We only edit the first matching monitor, in the case where multiple monitors exist
-        await axios.post<{ monitors: { id: string }[] }>(
-          `${uptimeRobotBaseUrl}/editMonitor?format=json`,
-          {
-            api_key: UPTIME_ROBOT_API_KEY,
-            id: affectedMonitorIds[0],
-            friendly_name: baseDomain,
-            url: `https://${baseDomain}`,
-            type: 1, // HTTP(S)
-            interval: 30,
-            timeout: 30,
-            alert_contacts: alertContacts,
-            http_method: 2, // GET
-          }
-        )
-      }
-    } catch (uptimerobotErr) {
-      // Non-blocking error, since site launch is still successful
-      const errMessage = `Unable to create better uptime monitor for ${baseDomain}. Error: ${uptimerobotErr}`
-      logger.error(errMessage)
-      try {
-        await this.sendMonitorCreationFailure(baseDomain)
-      } catch (monitorFailureEmailErr) {
-        logger.error(
-          `Failed to send error email for ${baseDomain}: ${monitorFailureEmailErr}`
-        )
-      }
-    }
-  }
 
   private async handleSiteLaunchResults(
     formResponses: FormResponsesProps[],

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -606,6 +606,9 @@ export default class InfraService {
               siteStatus: SiteStatus.Launched,
               jobStatus: JobStatus.Ready,
             }
+
+            // Create better uptime monitor iff site launch is a success
+            await this.createMonitor(message.primaryDomainSource)
           } else {
             updateSiteLaunchParams = {
               id: site.value.id,
@@ -614,10 +617,7 @@ export default class InfraService {
             }
           }
 
-          // Create better uptime monitor
-          await this.createMonitor(message.primaryDomainSource)
           await this.sitesService.update(updateSiteLaunchParams)
-
           await this.sendEmailUpdate(message, isSuccess)
         })
       )


### PR DESCRIPTION
## Problem
Currently our better uptime is done on create, but it should be on success instead. 


Closes [insert issue #]

## Solution

shifting the creation of this to post success, not during the launch process. 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

Tests

- [ ] create site alunch in staging, notice that better uptime monitor was [created](https://opengovproducts.slack.com/archives/C04RDJ504DC/p1704255875013479) 