### PR TITLE
fix(sl): warn ops regarding CAA records

### DIFF
--- a/src/routes/formsg/formsgSiteLaunch.ts
+++ b/src/routes/formsg/formsgSiteLaunch.ts
@@ -375,7 +375,7 @@ export class FormsgSiteLaunchRouter {
               )
               return isAmazonCAA
             })
-            if (caaRecords.length > 1 && !hasAmazonCAAWhitelisted) {
+            if (caaRecords.length > 0 && !hasAmazonCAAWhitelisted) {
               successResult.addCAARecord = true
             } else {
               successResult.addCAARecord = false

--- a/src/routes/formsg/formsgSiteLaunch.ts
+++ b/src/routes/formsg/formsgSiteLaunch.ts
@@ -22,6 +22,7 @@ import {
   getDNSRecordsEmailBody,
   getErrorEmailBody,
 } from "@root/services/utilServices/SendDNSRecordEmailClient"
+import TRUSTED_AMPLIFY_CAA_RECORDS from "@root/types/caaAmplify"
 import { DigResponse, DigType } from "@root/types/dig"
 import UsersService from "@services/identity/UsersService"
 import InfraService from "@services/infra/InfraService"
@@ -231,7 +232,7 @@ export class FormsgSiteLaunchRouter {
     await mailer.sendMail(email, subject, html)
   }
 
-  private digDomainForQuadARecords = async (
+  digDomainRecords = async (
     domain: string,
     digType: DigType
   ): Promise<DigResponse | null> =>
@@ -332,13 +333,18 @@ export class FormsgSiteLaunchRouter {
       for (const launchResult of launchResults) {
         if (launchResult.isOk()) {
           // check for AAAA records
-          const digResponse = await this.digDomainForQuadARecords(
+          const quadADigResponse = await this.digDomainRecords(
             launchResult.value.primaryDomainSource,
             "AAAA"
           )
+          const caaDigResponse = await this.digDomainRecords(
+            launchResult.value.primaryDomainSource,
+            "CAA"
+          )
+
           const successResult: DnsRecordsEmailProps = launchResult.value
-          if (digResponse && digResponse.answer) {
-            const quadARecords = digResponse.answer
+          if (quadADigResponse && quadADigResponse.answer) {
+            const quadARecords = quadADigResponse.answer
             successResult.quadARecords = quadARecords.map((record) => ({
               domain: record.domain,
               class: record.class,
@@ -348,6 +354,35 @@ export class FormsgSiteLaunchRouter {
           } else {
             logger.info(
               `Unable to get dig response for domain: ${launchResult.value.primaryDomainSource}. Skipping check for AAAA records`
+            )
+          }
+
+          if (!caaDigResponse) {
+            logger.info(
+              `Unable to get dig response for domain: ${launchResult.value.primaryDomainSource}. Skipping check for CAA records`
+            )
+          } else if (caaDigResponse.answer) {
+            const caaRecords = caaDigResponse.answer
+
+            /**
+             * NOTE: If there exists more than one CAA Record, we need to
+             * 1. check if they have whitelisted Amazon CAA
+             * 2. if not, send email to inform them to whitelist Amazon CAA
+             */
+            const hasAmazonCAAWhitelisted = caaRecords.some((record) => {
+              const isAmazonCAA = TRUSTED_AMPLIFY_CAA_RECORDS.some(
+                (trustedCAA) => trustedCAA === record.value
+              )
+              return isAmazonCAA
+            })
+            if (caaRecords.length > 1 && !hasAmazonCAAWhitelisted) {
+              successResult.addCAARecord = true
+            } else {
+              successResult.addCAARecord = false
+            }
+          } else {
+            logger.info(
+              `${launchResult.value.primaryDomainSource} Domain does not have any CAA records.`
             )
           }
           // Create better uptime monitor

--- a/src/types/caaAmplify.ts
+++ b/src/types/caaAmplify.ts
@@ -1,0 +1,11 @@
+/**
+ * This is taken from https://docs.aws.amazon.com/acm/latest/userguide/setup-caa.html
+ */
+const TRUSTED_AMPLIFY_CAA_RECORDS = [
+  "amazon.com",
+  "amazontrust.com",
+  "awstrust.com",
+  "amazonaws.com",
+]
+
+export default TRUSTED_AMPLIFY_CAA_RECORDS

--- a/src/types/dig.ts
+++ b/src/types/dig.ts
@@ -23,3 +23,4 @@ export type DigType =
   | "SOA"
   | "SRV"
   | "TXT"
+  | "CAA"


### PR DESCRIPTION
## Problem

Prevent [this](https://www.notion.so/opengov/On-Call-Runbook-ab4bffa2472d47ef9b657242632da7f9?pvs=4#c16acb00f4524e84b1ebd6509fdf82db) from occurring by warning the agency and ops beforehand regarding a possible site launch failure route. 

## Solution

Check for existence of CAA records, and if found, check if they 'trust' Amazon, else ask them to add DNS records that specifically allow for this. 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)


## Tests 
set export MOCK_AMPLIFY_DOMAIN_ASSOCIATION_CALLS="true" and add this in server.js
```
const formResponses = [
  {
    submissionId: "",
    requesterEmail: "kishore@open.gov.sg",
    repoName: "kishore-test",
    primaryDomain: "isomer.gov.sg",
    redirectionDomain: "www.isomer.gov.sg",
    agencyEmail: "kishore@open.gov.sg",
  },
  {
    submissionId: "",
    requesterEmail: "kishore@open.gov.sg",
    repoName: "kishore-test-dev-gh",
    primaryDomain: "guide.isomer.gov.sg",
    redirectionDomain: "www.guide.isomer.gov.sg",
    agencyEmail: "kishore@open.gov.sg",
  },
  {
    submissionId: "",
    requesterEmail: "kishore@open.gov.sg",
    repoName: "ogp-jiachen",
    primaryDomain: "nushigh.edu.sg",
    redirectionDomain: "www.nushigh.edu.sg",
    agencyEmail: "kishore@open.gov.sg",
  },
  {
    submissionId: "",
    requesterEmail: "kishore@open.gov.sg",
    repoName: "kishore-test-dev-emil",
    primaryDomain: "asean-ifce.com",
    redirectionDomain: "www.asean-ifce.com",
    agencyEmail: "kishore@open.gov.sg",
  },
]

formsgSiteLaunchRouter.handleSiteLaunchResults(formResponses, "test")

```


the email (in the logs) should be out like this: 
<img width="1081" alt="Screenshot 2023-12-22 at 9 47 51 AM" src="https://github.com/isomerpages/isomercms-backend/assets/42832651/06ef4cfa-1a9b-43d0-81a8-933d6af300bf">


