### PR TITLE
fix(ci): reverts ci changes to allow staging updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,8 @@ jobs:
           import os
           ref = os.environ['GITHUB_REF']
           prod = os.environ['PRODUCTION_BRANCH']
-          if ref == prod:
+          staging = os.environ['STAGING_BRANCH']
+          if ref == prod or ref == staging:
             print('::set-output name=proceed::true')
           else:
             print('::set-output name=proceed::false')

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -7,7 +7,8 @@ concurrency:
 on:
   push:
     branches:
-      - staging
+      # TODO: Update this to allow `staging` once ecs deploys work
+      # - staging
       - feat/ecs
 
 jobs:


### PR DESCRIPTION
## Problem
we previously deployed to ecs on push to the `staging` branch. this PR swaps it back as efs has issues mounting onto a separate vpc. 

## Solution
swap out `ci.yml` changes