### PR TITLE
fix(amplify): use rewrite instead of redirect for 404 error

### DIFF
--- a/src/services/identity/DeploymentClient.ts
+++ b/src/services/identity/DeploymentClient.ts
@@ -110,7 +110,7 @@ class DeploymentClient {
       },
     ]
     const defaultRedirectRules = [
-      { source: "/<*>", target: "/404.html", status: "404" },
+      { source: "/<*>", target: "/404.html", status: "404-200" },
     ]
 
     const redirectRules = isStagingLite


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We redirect when a page is not found instead of rewriting (to preserve the URL). This is semantically incorrect and causes SEO issues.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Set the custom rule to rewrite instead of redirect. The `404-200` comes from [their API reference](https://docs.aws.amazon.com/amplify/latest/APIReference/API_CustomRule.html).

## Tests

<!-- What tests should be run to confirm functionality? -->

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*