### PR TITLE
feat(logging): remove logging

### DIFF
--- a/src/database/config.js
+++ b/src/database/config.js
@@ -43,4 +43,5 @@ module.exports = {
     max: DB_MAX_POOL,
     acquire: DB_ACQUIRE,
   },
+  logging: false,
 }


### PR DESCRIPTION
## Problem
logging damn noisy, and the logging doesnt show the actual arguments anyways. maybe a better design is to allow this for prod, but I have never used these statements for production logging, and to be honest, most of the time it has hindered my ability to debug becasue this has been pure noise. 

## Solution
I can actually see my console.logs now without scrolling infinitely 
