### PR TITLE
Fix/privatisation quickie interaction

### DIFF
--- a/src/services/configServices/SettingsService.js
+++ b/src/services/configServices/SettingsService.js
@@ -173,6 +173,14 @@ class SettingsService {
       // only when changing from public to private - not awaited as this is slow and non-blocking
       privatiseNetlifySite(siteName, password)
     }
+    const updatePasswordResp = await this.deploymentsService.updateAmplifyPassword(
+      siteName,
+      password,
+      enablePassword
+    )
+    if (updatePasswordResp.isErr()) {
+      return updatePasswordResp
+    }
     if (isPrivate !== enablePassword) {
       // For public -> private or private -> public, we also need to update the repo privacy on github
       const privatiseRepoRes = await this.gitHubService.changeRepoPrivacy(
@@ -189,11 +197,7 @@ class SettingsService {
         return errAsync(err)
       }
     }
-    return this.deploymentsService.updateAmplifyPassword(
-      siteName,
-      password,
-      enablePassword
-    )
+    return updatePasswordResp
   }
 
   shouldUpdateHomepage(updatedConfigContent, configContent) {

--- a/src/services/identity/DeploymentClient.ts
+++ b/src/services/identity/DeploymentClient.ts
@@ -143,19 +143,23 @@ class DeploymentClient {
     },
   })
 
-  generateDeletePasswordInput = (appId: string): UpdateBranchCommandInput => ({
+  generateDeletePasswordInput = (
+    appId: string,
+    branchName = "staging"
+  ): UpdateBranchCommandInput => ({
     appId,
-    branchName: "staging",
+    branchName,
     enableBasicAuth: false,
     basicAuthCredentials: "",
   })
 
   generateUpdatePasswordInput = (
     appId: string,
-    password: string
+    password: string,
+    branchName = "staging"
   ): UpdateBranchCommandInput => ({
     appId,
-    branchName: "staging",
+    branchName,
     enableBasicAuth: true,
     basicAuthCredentials: Buffer.from(`user:${password}`).toString("base64"),
   })


### PR DESCRIPTION
This PR fixes an issue with the integration of privatisation with quickie. To be reviewed in conjunction with PR[#1763](https://github.com/isomerpages/isomercms-frontend/pull/1763) on the frontend repo. There are two existing issues being tackled by this PR:

- Repos which are being made private/unprivate should also affect their respective staging-lite sites, otherwise a site might still contain a publicly accessible version in staging-lite
- Our DB automatically self corrects to switch any site which has been placed on quickie via growthbook to the `staging-lite.` variant, but this should not be true for private sites

Note that this PR does not handle the issue of inconsistent states fully right now - it is possible that a user who attempts to privatise/unprivatise a site will have the request to the second amplify site fail, leaving us in an inconsistent state - this needs to be manually resolved for now, as the resolution is complicated. We can look into making this more robust if we find that this is a consistent issue, but I am opting to leave this as is for now and pipe alarms that notify us instead. The issue is also fixable on the user's end if they try again - the inconsistent state will not block cms operations.

TODOs:

- [x] ~Add cloudwatch alarm for inconsistent state resolution~
- [x] ~Add entry in runbook for handling inconsistent state~

Tests

- [ ] Privatise a site
  - [ ] Ensure that the staging and staging lite sites on amplify get updated with the password
- [ ] Deprivatise a site
  - [ ] Ensure that the staging and staging-lite sites on amplify have removed password