### PR TITLE
chore: copy instead of clone

### DIFF
--- a/src/routes/formsg/formsgGGsRepair.ts
+++ b/src/routes/formsg/formsgGGsRepair.ts
@@ -10,7 +10,10 @@ import { ResultAsync, errAsync, fromPromise, okAsync } from "neverthrow"
 
 import { config } from "@config/config"
 
-import { EFS_VOL_PATH_STAGING_LITE } from "@root/constants"
+import {
+  EFS_VOL_PATH_STAGING,
+  EFS_VOL_PATH_STAGING_LITE,
+} from "@root/constants"
 import GitFileSystemError from "@root/errors/GitFileSystemError"
 import InitializationError from "@root/errors/InitializationError"
 import { consoleLogger } from "@root/logger/console.logger"
@@ -147,6 +150,7 @@ export class FormsgGGsRepairRouter {
               .andThen(() =>
                 fromPromise(
                   this.reposService.setUpStagingLite(
+                    path.join(EFS_VOL_PATH_STAGING, repoName),
                     path.join(EFS_VOL_PATH_STAGING_LITE, repoName),
                     repoUrl
                   ),

--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -265,7 +265,7 @@ export default class ReposService {
       .checkout("staging") // reset local branch back to staging
 
     // Make sure the local path is empty, just in case dir was used on a previous attempt.
-    await this.setUpStagingLite(stgLiteDir, repoUrl)
+    await this.setUpStagingLite(stgDir, stgLiteDir, repoUrl)
   }
 
   createDnsIndirectionFile = (
@@ -375,22 +375,15 @@ export const createRecords = (zoneId: string): Record[] => {
       .map(() => undefined)
   }
 
-  async setUpStagingLite(stgLiteDir: string, repoUrl: string) {
+  async setUpStagingLite(stgDir: string, stgLiteDir: string, repoUrl: string) {
     fs.rmSync(`${stgLiteDir}`, { recursive: true, force: true })
     // create a empty folder stgLiteDir
     fs.mkdirSync(stgLiteDir)
+    fs.cpSync(stgDir, stgLiteDir, { recursive: true })
 
     // note: for some reason, combining below commands led to race conditions
     // so we have to do it separately
     // Create staging lite branch in other repo path
-
-    await this.simpleGit
-      .cwd({ path: stgLiteDir, root: false })
-      .clone(repoUrl, stgLiteDir)
-    await this.simpleGit.cwd({ path: stgLiteDir, root: false }).pull() // some repos are large, clone takes time
-    await this.simpleGit
-      .cwd({ path: stgLiteDir, root: false })
-      .checkout("staging")
 
     if (fs.existsSync(path.join(`${stgLiteDir}`, `images`))) {
       await this.simpleGit


### PR DESCRIPTION
This PR adjusts our site repair form to copy from the existing staging branch when repairing staging-lite, instead of using `git clone`, which is slower due to the additional network call.