### PR TITLE
fix(rr): skip checking the existence of review request for blob

### DIFF
--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -1274,7 +1274,9 @@ export class ReviewsRouter {
     { userWithSiteSessionData: UserWithSiteSessionData }
   > = async (req, res) => {
     // Step 1: Check that the site exists
-    const { siteName, requestId } = req.params
+    // NOTE: We don't check for the existence of the review request, as we
+    // assume that we are comparing between the staging and master branch
+    const { siteName } = req.params
     const { path } = req.query
     const { userWithSiteSessionData } = res.locals
     const site = await this.sitesService.getBySiteName(siteName)
@@ -1308,30 +1310,7 @@ export class ReviewsRouter {
       })
     }
 
-    // Step 2: Retrieve review request
-    const possibleReviewRequest = await this.reviewRequestService.getReviewRequest(
-      site.value,
-      requestId
-    )
-
-    if (isIsomerError(possibleReviewRequest)) {
-      logger.error({
-        message: "Invalid review request requested",
-        method: "getBlob",
-        meta: {
-          userId: userWithSiteSessionData.isomerUserId,
-          email: userWithSiteSessionData.email,
-          siteName,
-          requestId,
-          file: path,
-        },
-      })
-      return res.status(404).send({
-        message: "Please ensure that the site exists!",
-      })
-    }
-
-    // Step 3: Check if the user is a contributor of the site
+    // Step 2: Check if the user is a contributor of the site
     const role = await this.collaboratorsService.getRole(
       siteName,
       userWithSiteSessionData.isomerUserId


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

When a user is creating a new review request, we also try to obtain the diff between the staging and master branches. However, the logic requires a valid review request to be present, which may not be the case when the user is in the midst of creating one.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- For the time being, there is no reason for us to know if the review request is present, as we are only comparing between the staging and master branches. Hence, we can skip the check for the existence of the review request.
    - This is important when creating a new review request, as the review request ID is not present.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Navigate to any site and click on create a review request.
- [ ] Click on the Edited items tab (also ensure that you have a difference between staging and master).
- [ ] Click on any of the item's eye icon. You should be able to view the diff.
- [ ] Actually create the review request.
- [ ] Verify that you can view the same diff in the created review request.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*