### PR TITLE
ref(doc): updated GIG DNS API swagger doc

### DIFF
--- a/docs/gigDnsApi.yaml
+++ b/docs/gigDnsApi.yaml
@@ -35,12 +35,18 @@ paths:
                   description: The contact email address for this DNS record.
                 record:
                   $ref: "#/components/schemas/DNSRecord"
+                rootDomain:
+                  type: string
+                  description: The root domain associated with this DNS record.
+                  example: "example.com"
               example:
                 email: "admin@example.com"
                 record:
                   type: "A"
                   name: "example.com"
                   content: "192.168.1.1"
+                rootDomain: "example.com"
+              
       responses:
         "201":
           description: DNS record successfully added.
@@ -64,6 +70,81 @@ paths:
                   message:
                     type: string
                     example: "Invalid data provided."
+        "500":
+          description: Server error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Internal server error."
+    put:
+      summary: Update a DNS record
+      description: Update an existing DNS record in the DNS management system.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - in: header
+          name: X-API-KEY
+          required: true
+          schema:
+            type: string
+          description: API key required to authorize requests.
+          example: "1234567890abcdef"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - record
+              properties:
+                email:
+                  type: string
+                  format: email
+                  description: The contact email address for this DNS record.
+                record:
+                  $ref: "#/components/schemas/DNSRecord"
+                rootDomain:
+                  type: string
+                  description: The root domain associated with this DNS record.
+                  example: "example.com"
+              example:
+                email: "admin@example.com"
+                record:
+                  type: "A"
+                  name: "example.com"
+                  content: "192.168.1.1"
+                rootDomain: "example.com"
+      responses:
+        "200":
+          description: DNS record successfully updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "DNS record updated successfully."
+        "401":
+          description: Unauthorized.
+        "400":
+          description: Invalid request data.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Invalid data provided."
+        "404":
+          description: DNS record not found.
         "500":
           description: Server error.
           content:
@@ -128,6 +209,19 @@ paths:
                 "DS",
               ]
           description: The type of the DNS record to be deleted.
+        - in: query
+          name: rootDomain
+          required: false
+          schema:
+            type: string
+          description: The root domain associated with the DNS record to be deleted.
+        - in: query
+          name: email
+          required: true
+          schema:
+            type: string
+            format: email
+          description: The contact email address associated with the DNS record to be deleted.
       responses:
         "200":
           description: DNS record successfully deleted.


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [IS-812](https://isomeropengov.atlassian.net/browse/IS-812?atlOrigin=eyJpIjoiZWNiNzI1ZDNmZjEwNDM0YmIyODM5MjcxZDU5YWE4MDQiLCJwIjoiaiJ9)

The GIG DNS API swagger doc is outdated with a few new incoming requirements from GIG team. 

## Solution

<!-- How did you solve the problem? -->
Updated the API swagger doc to reflect the latest requirements from GIG team: 
- Added `PUT` call to the API suite for updating DNS records 
- Added an optional field `rootDomain` to `PUT` and `POST` calls in the request body
- Added an optional query parameter `rootDomain` and a required parameter `email` to `DELETE` call 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ ] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Improvements**:

- Updated the API swagger doc to reflect the latest requirements from GIG team. 

## Before & After Screenshots

**AFTER**:

- The swagger file can be loaded manually on [swagger.io ](https://editor.swagger.io/)

## Tests

<!-- What tests should be run to confirm functionality? -->
- The swagger file can be loaded manually on [swagger.io ](https://editor.swagger.io/)

[IS-812]: https://isomeropengov.atlassian.net/browse/IS-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ