### PR TITLE
fix(sl): include issuewild if CAA records are needed

### DIFF
--- a/src/services/utilServices/SendDNSRecordEmailClient.ts
+++ b/src/services/utilServices/SendDNSRecordEmailClient.ts
@@ -79,7 +79,7 @@ export function getDNSRecordsEmailBody(
       // check if dnsRecords.redirectionDomain is undefined
       html += `
         <tr style="${tdStyle}">
-  
+
           <td style="${tdStyle}">${dnsRecords.domainValidationSource}</td>
           <td style="${tdStyle}">${dnsRecords.domainValidationTarget}</td>
           <td style="${tdStyle}">CNAME</td>
@@ -126,21 +126,20 @@ export function getDNSRecordsEmailBody(
           </tr>
         </thead>
         <tbody>
-        <tr style="${tdStyle}">
-        <td style="${tdStyle}  background-color: #f2f2f2" rowspan="2" >${repoName}</td>
-        <td style="${tdStyle}">${dnsRecord.primaryDomainSource}</td>
-        <td style="${tdStyle}">0</td>
-        <td style="${tdStyle}">issue</td>
-        <td style="${tdStyle}">amazontrust.com</td>
-      </tr>
-      <tr style="${tdStyle}">
-      <td style="${tdStyle}">${dnsRecord.primaryDomainSource}</td>
-        <td style="${tdStyle}">0</td>
-        <td style="${tdStyle}">issue</td>
-        <td style="${tdStyle}">amazontrust.com</td>
-      </tr>
-    
-    </tbody>
+          <tr style="${tdStyle}">
+            <td style="${tdStyle}  background-color: #f2f2f2" rowspan="2" >${repoName}</td>
+            <td style="${tdStyle}">${dnsRecord.primaryDomainSource}</td>
+            <td style="${tdStyle}">0</td>
+            <td style="${tdStyle}">issue</td>
+            <td style="${tdStyle}">amazontrust.com</td>
+          </tr>
+          <tr style="${tdStyle}">
+            <td style="${tdStyle}">${dnsRecord.primaryDomainSource}</td>
+            <td style="${tdStyle}">0</td>
+            <td style="${tdStyle}">issuewild</td>
+            <td style="${tdStyle}">amazontrust.com</td>
+          </tr>
+        </tbody>
   </table>`
       }
     })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Both CAA records are tagged "issue", but one of them should be "issuewild".

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Changed the tag for one of the CAA records to be "issuewild"

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to Cloudflare and add a CAA record to "letsencrypt.org" for any subdomain that you prefer.
- [ ] Use the staging site launch form to launch a site on that particular subdomain that you have chosen.
- [ ] Verify that the DNS records email sent to you contains "issue" and "issuewild" CAA records.
- [ ] Perform a cleanup
    - [ ] Delete the CAA record that you have created earlier in Cloudflare.
    - [ ] Reset the isomer-indirection repo by removing the latest commit that was added for the subdomain that you have chosen earlier.
    - [ ] Go to the staging database and delete the site launch record for the subdomain that you have chosen earlier.
    - [ ] Go to AWS Amplify and delete the domain association for the subdomain that you have chosen earlier.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*