### PR TITLE
fix: remove unnecessary push logs

### DIFF
--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -539,6 +539,10 @@ export default class GitFileSystemService {
                   .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
                   .push(gitOptions),
             (error) => {
+              logger.error(
+                `Error when pushing ${repoName}. Retrying git push operation for the first time...`
+              )
+
               if (error instanceof GitError) {
                 return new GitFileSystemError(
                   "Unable to push latest changes of repo"
@@ -560,6 +564,10 @@ export default class GitFileSystemService {
                   .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
                   .push(gitOptions),
             (error) => {
+              logger.error(
+                `Error when pushing ${repoName}. Retrying git push operation for the second time...`
+              )
+
               if (error instanceof GitError) {
                 return new GitFileSystemError(
                   "Unable to push latest changes of repo"
@@ -572,6 +580,7 @@ export default class GitFileSystemService {
         )
         .orElse(() =>
           // Retry push twice
+          // TODO: To eliminate duplicate code by using a backoff or retry package
           ResultAsync.fromPromise(
             isForce
               ? this.git
@@ -581,7 +590,9 @@ export default class GitFileSystemService {
                   .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
                   .push(gitOptions),
             (error) => {
-              logger.error(`Error when pushing ${repoName}: ${error}`)
+              logger.error(
+                `Both retries for git push have failed. Error when pushing ${repoName}: ${error}`
+              )
 
               if (error instanceof GitError) {
                 return new GitFileSystemError(

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -539,8 +539,6 @@ export default class GitFileSystemService {
                   .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
                   .push(gitOptions),
             (error) => {
-              logger.error(`Error when pushing ${repoName}: ${error}`)
-
               if (error instanceof GitError) {
                 return new GitFileSystemError(
                   "Unable to push latest changes of repo"
@@ -562,8 +560,6 @@ export default class GitFileSystemService {
                   .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
                   .push(gitOptions),
             (error) => {
-              logger.error(`Error when pushing ${repoName}: ${error}`)
-
               if (error instanceof GitError) {
                 return new GitFileSystemError(
                   "Unable to push latest changes of repo"


### PR DESCRIPTION
## Problem

We get a lot of false positives on git push failures which is affecting on-call productivity. 

Closes IS-847

## Solution

we should log only when git push is a complete failure (i.e. after 3 tries)

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

## Tests

- On first 2 push failures, it should log differently from the third try
- To test, we might need to simulate a divergence in EFS vs GH states
- Perform edits on GH for a repo that is currently on EFS
- Go to CMS now and perform some edits. These edits cannot be push due to the divergence
- Check the logs to ensure that only the third try and error case prints out the actual Git error (i.e. should read like `error: failed to push some refs .......` )
