### PR TITLE
allow apng ext

### DIFF
--- a/src/utils/file-upload-utils.js
+++ b/src/utils/file-upload-utils.js
@@ -13,6 +13,7 @@ const CLOUDMERSIVE_API_KEY = config.get("cloudmersiveKey")
 const ALLOWED_FILE_EXTENSIONS = [
   "pdf",
   "png",
+  "apng",
   "jpg",
   "jpeg",
   "gif",


### PR DESCRIPTION
## Problem

team wants to upload "APNG" format, the extension is still in ".png", but when we validate the sanitised file format it is interpreted as APNG and is blocked from uploading. Suggested using GIF but their reason was the following:

But because GIF has limited colour palette and low resolution, the usability CoP advised us to change from gif to apng for better quality

Which makes sense actually. I saw their sample file and the resolution is much better

## Solution

Whitelist apng
