### PR TITLE
Feat/send email on rr creation

### DIFF
--- a/src/integration/NotificationOnEditHandler.spec.ts
+++ b/src/integration/NotificationOnEditHandler.spec.ts
@@ -45,6 +45,7 @@ import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/Fo
 import DeploymentsService from "@root/services/identity/DeploymentsService"
 import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
+import MailClient from "@root/services/utilServices/MailClient"
 import RepoService from "@services/db/RepoService"
 import { ConfigYmlService } from "@services/fileServices/YmlFileServices/ConfigYmlService"
 import { getUsersService, notificationsService } from "@services/identity"
@@ -62,6 +63,9 @@ const mockGithubService = {
   getComments: jest.fn(),
   getCommitDiff: jest.fn(),
 }
+const mockMailer = ({
+  sendMail: jest.fn(),
+} as unknown) as MailClient
 const usersService = getUsersService(sequelize)
 const footerYmlService = new FooterYmlService({
   gitHubService: mockGithubService,
@@ -114,6 +118,7 @@ const pageService = new PageService({
 const configService = new ConfigService()
 const reviewRequestService = new ReviewRequestService(
   (mockGithubService as unknown) as RepoService,
+  mockMailer,
   User,
   ReviewRequest,
   Reviewer,

--- a/src/integration/Notifications.spec.ts
+++ b/src/integration/Notifications.spec.ts
@@ -53,6 +53,7 @@ import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import SitesService from "@root/services/identity/SitesService"
 import ReviewRequestService from "@root/services/review/ReviewRequestService"
+import MailClient from "@root/services/utilServices/MailClient"
 import { isomerRepoAxiosInstance } from "@services/api/AxiosInstance"
 import GitFileSystemService from "@services/db/GitFileSystemService"
 import RepoService from "@services/db/RepoService"
@@ -68,6 +69,9 @@ const MOCK_SITE = "mockSite"
 const MOCK_SITE_ID = "1"
 const MOCK_SITE_MEMBER_ID = "1"
 
+const mockMailer = ({
+  sendMail: jest.fn(),
+} as unknown) as MailClient
 const gitFileSystemService = new GitFileSystemService(simpleGit())
 const gitFileCommitService = new GitFileCommitService(gitFileSystemService)
 const gitHubService = new RepoService({
@@ -116,6 +120,7 @@ const pageService = new PageService({
 const configService = new ConfigService()
 const reviewRequestService = new ReviewRequestService(
   (gitHubService as unknown) as RepoService,
+  mockMailer,
   User,
   ReviewRequest,
   Reviewer,

--- a/src/integration/Privatisation.spec.ts
+++ b/src/integration/Privatisation.spec.ts
@@ -63,6 +63,7 @@ import DeploymentsService from "@root/services/identity/DeploymentsService"
 import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
 import AuthorizationMiddlewareService from "@root/services/middlewareServices/AuthorizationMiddlewareService"
+import MailClient from "@root/services/utilServices/MailClient"
 import { isomerRepoAxiosInstance } from "@services/api/AxiosInstance"
 import GitFileSystemService from "@services/db/GitFileSystemService"
 import RepoService from "@services/db/RepoService"
@@ -97,6 +98,9 @@ jest.mock("../services/identity/DeploymentClient", () =>
       .mockImplementation(() => ok(mockDeleteInput)),
   }))
 )
+const mockMailer = ({
+  sendMail: jest.fn(),
+} as unknown) as MailClient
 const gitFileSystemService = new GitFileSystemService(simpleGit())
 const gitFileCommitService = new GitFileCommitService(gitFileSystemService)
 
@@ -146,6 +150,7 @@ const pageService = new PageService({
 const configService = new ConfigService()
 const reviewRequestService = new ReviewRequestService(
   (gitHubService as unknown) as RepoService,
+  mockMailer,
   User,
   ReviewRequest,
   Reviewer,

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -90,6 +90,7 @@ import { FooterYmlService } from "@root/services/fileServices/YmlFileServices/Fo
 import DeploymentsService from "@root/services/identity/DeploymentsService"
 import PreviewService from "@root/services/identity/PreviewService"
 import { SitesCacheService } from "@root/services/identity/SitesCacheService"
+import MailClient from "@root/services/utilServices/MailClient"
 import { ReviewRequestDto } from "@root/types/dto/review"
 import { isomerRepoAxiosInstance } from "@services/api/AxiosInstance"
 import GitFileSystemService from "@services/db/GitFileSystemService"
@@ -101,6 +102,10 @@ import IsomerAdminsService from "@services/identity/IsomerAdminsService"
 import SitesService from "@services/identity/SitesService"
 import ReviewRequestService from "@services/review/ReviewRequestService"
 import { sequelize } from "@tests/database"
+
+const mockMailer = ({
+  sendMail: jest.fn(),
+} as unknown) as MailClient
 
 const gitFileSystemService = new GitFileSystemService(simpleGit())
 const gitFileCommitService = new GitFileCommitService(gitFileSystemService)
@@ -151,6 +156,7 @@ const pageService = new PageService({
 const configService = new ConfigService()
 const reviewRequestService = new ReviewRequestService(
   (gitHubService as unknown) as RepoService,
+  mockMailer,
   User,
   ReviewRequest,
   Reviewer,

--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -52,6 +52,7 @@ import DynamoDBService from "@root/services/infra/DynamoDBService"
 import InfraService from "@root/services/infra/InfraService"
 import StepFunctionsService from "@root/services/infra/StepFunctionsService"
 import ReviewRequestService from "@root/services/review/ReviewRequestService"
+import MailClient from "@root/services/utilServices/MailClient"
 import GitFileSystemService from "@services/db/GitFileSystemService"
 import RepoService from "@services/db/RepoService"
 import { getIdentityAuthService, getUsersService } from "@services/identity"
@@ -65,6 +66,9 @@ const mockUpdatedAt = "now"
 const mockPermissions = { push: true }
 const mockPrivate = true
 
+const mockMailer = ({
+  sendMail: jest.fn(),
+} as unknown) as MailClient
 const gitFileSystemService = new GitFileSystemService(simpleGit())
 
 const gitFileCommitService = new GitFileCommitService(gitFileSystemService)
@@ -114,6 +118,7 @@ const pageService = new PageService({
 const configService = new ConfigService()
 const reviewRequestService = new ReviewRequestService(
   gitHubService,
+  mockMailer,
   User,
   ReviewRequest,
   Reviewer,

--- a/src/server.js
+++ b/src/server.js
@@ -67,6 +67,7 @@ import SitesService from "@services/identity/SitesService"
 import InfraService from "@services/infra/InfraService"
 import StepFunctionsService from "@services/infra/StepFunctionsService"
 import ReviewRequestService from "@services/review/ReviewRequestService"
+import { mailer } from "@services/utilServices/MailClient"
 
 import { apiLogger } from "./middleware/apiLogger"
 import { NotificationOnEditHandler } from "./middleware/notificationOnEditHandler"
@@ -216,6 +217,7 @@ const pageService = new PageService({
 })
 const reviewRequestService = new ReviewRequestService(
   gitHubService,
+  mailer,
   User,
   ReviewRequest,
   Reviewer,

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -364,7 +364,8 @@ export default class ReviewRequestService {
     </li>
     </ul>
     </p>
-    <p>Best,\nIsomerCMS Support Team</p>`
+    <p>Best,</p>
+    <p>IsomerCMS Support Team</p>`
     await Promise.all(
       reviewers.map(async ({ id, email: reviewerEmail }) => {
         await this.reviewers.create({

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -355,17 +355,15 @@ export default class ReviewRequestService {
       siteId: site.id,
     })
     const subject = `[${siteName}] You've been requested to review some changes`
-    const emailBody = `<p>${requestor.email} has requested you to review and approve changes made on ${siteName}. You can either approve the changes or add comments for your collaborators to see.</p>
-    <p><a href="https://cms.isomer.gov.sg/sites/${siteName}/review/${pullRequestNumber}" target="_blank">View review request on IsomerCMS</a></p>
-    <p>Is this your first time approving and publishing a review request? Don’t worry, here is an article from the Isomer Guide for you:
-    <ul>
-    <li>
-    <a href="https://guide.isomer.gov.sg/publish-changes-and-site-launch/for-email-login-users/approve-and-publish-a-review-request" target="_blank">How to approve and publish a review request</a> 
-    </li>
-    </ul>
-    </p>
-    <p>Best,</p>
-    <p>IsomerCMS Support Team</p>`
+    const emailBody = `<p>Hi there,</p>
+    <p>${requestor.email} has requested you to review and approve changes made to site-name. You can see the changes and approve them, or add comments for site collaborators to see.</p>
+    <br />
+    <p><a href="https://cms.isomer.gov.sg/sites/${siteName}/review/${pullRequestNumber}" target="_blank">Click to see the review request on IsomerCMS</a></p>
+    <br />
+    <p>If this is your first time approving or publishing a review request, <a href="https://guide.isomer.gov.sg/publish-changes-and-site-launch/for-email-login-users/approve-and-publish-a-review-request" target="_blank">this article from our Isomer Guide</a> might help.</p>
+    <br />
+    <p>Best,<br />
+    The Isomer Team</p>`
     await Promise.all(
       reviewers.map(async ({ id, email: reviewerEmail }) => {
         await this.reviewers.create({
@@ -376,8 +374,7 @@ export default class ReviewRequestService {
           // Should not reach here
           throw new Error(`Reviewer with id ${id} has no email`)
         }
-        const emailContent = `<p>Hi ${reviewerEmail},</p>${emailBody}`
-        await this.mailer.sendMail(reviewerEmail, subject, emailContent)
+        await this.mailer.sendMail(reviewerEmail, subject, emailBody)
       })
     )
 

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -356,11 +356,11 @@ export default class ReviewRequestService {
     })
     const subject = `[${siteName}] You've been requested to review some changes`
     const emailBody = `<p>${requestor.email} has requested you to review and approve changes made on ${siteName}. You can either approve the changes or add comments for your collaborators to see.</p>
-    <p><a href="cms.isomer.gov.sg/sites/${siteName}/review/${pullRequestNumber}" target="_blank"> View review request on IsomerCMS </a></p>
+    <p><a href="https://cms.isomer.gov.sg/sites/${siteName}/review/${pullRequestNumber}" target="_blank">View review request on IsomerCMS</a></p>
     <p>Is this your first time approving and publishing a review request? Don’t worry, here is an article from the Isomer Guide for you:
     <ul>
     <li>
-    <a href=”guide.isomer.gov.sg/publish-changes-and-site-launch/for-email-login-users/approve-and-publish-a-review-request” target="_blank"> How to approve and publish a review request </a> 
+    <a href="https://guide.isomer.gov.sg/publish-changes-and-site-launch/for-email-login-users/approve-and-publish-a-review-request" target="_blank">How to approve and publish a review request</a> 
     </li>
     </ul>
     </p>

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -55,6 +55,7 @@ import RepoService from "../db/RepoService"
 import { PageService } from "../fileServices/MdPageServices/PageService"
 import PlaceholderService from "../fileServices/utils/PlaceholderService"
 import { ConfigService } from "../fileServices/YmlFileServices/ConfigService"
+import MailClient from "../utilServices/MailClient"
 
 const injectDefaultEditMeta = ({
   path,
@@ -82,6 +83,8 @@ const injectDefaultEditMeta = ({
 export default class ReviewRequestService {
   private readonly apiService: RepoService
 
+  private readonly mailer: MailClient
+
   private readonly repository: ModelStatic<ReviewRequest>
 
   private readonly users: ModelStatic<User>
@@ -100,6 +103,7 @@ export default class ReviewRequestService {
 
   constructor(
     apiService: RepoService,
+    mailer: MailClient,
     users: ModelStatic<User>,
     repository: ModelStatic<ReviewRequest>,
     reviewers: ModelStatic<Reviewer>,
@@ -110,6 +114,7 @@ export default class ReviewRequestService {
     sequelize: Sequelize
   ) {
     this.apiService = apiService
+    this.mailer = mailer
     this.users = users
     this.repository = repository
     this.reviewers = reviewers
@@ -349,13 +354,30 @@ export default class ReviewRequestService {
       requestorId: requestor.id,
       siteId: site.id,
     })
+    const subject = `[${siteName}] You've been requested to review some changes`
+    const emailBody = `<p>${requestor.email} has requested you to review and approve changes made on ${siteName}. You can either approve the changes or add comments for your collaborators to see.</p>
+    <p><a href="cms.isomer.gov.sg/sites/${siteName}/review/${pullRequestNumber}" target="_blank"> View review request on IsomerCMS </a></p>
+    <p>Is this your first time approving and publishing a review request? Don’t worry, here is an article from the Isomer Guide for you:
+    <ul>
+    <li>
+    <a href=”guide.isomer.gov.sg/publish-changes-and-site-launch/for-email-login-users/approve-and-publish-a-review-request” target="_blank"> How to approve and publish a review request </a> 
+    </li>
+    </ul>
+    </p>
+    <p>Best,\nIsomerCMS Support Team</p>`
     await Promise.all(
-      reviewers.map(({ id }) =>
-        this.reviewers.create({
+      reviewers.map(async ({ id, email: reviewerEmail }) => {
+        await this.reviewers.create({
           requestId: reviewRequest.id,
           reviewerId: id,
         })
-      )
+        if (!reviewerEmail) {
+          // Should not reach here
+          throw new Error(`Reviewer with id ${id} has no email`)
+        }
+        const emailContent = `<p>Hi ${reviewerEmail},</p>${emailBody}`
+        await this.mailer.sendMail(reviewerEmail, subject, emailContent)
+      })
     )
 
     await this.reviewMeta.create({

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -356,7 +356,7 @@ export default class ReviewRequestService {
     })
     const subject = `[${siteName}] You've been requested to review some changes`
     const emailBody = `<p>Hi there,</p>
-    <p>${requestor.email} has requested you to review and approve changes made to site-name. You can see the changes and approve them, or add comments for site collaborators to see.</p>
+    <p>${requestor.email} has requested you to review and approve changes made to ${siteName}. You can see the changes and approve them, or add comments for site collaborators to see.</p>
     <br />
     <p><a href="https://cms.isomer.gov.sg/sites/${siteName}/review/${pullRequestNumber}" target="_blank">Click to see the review request on IsomerCMS</a></p>
     <br />

--- a/src/services/review/__tests__/ReviewRequestService.spec.ts
+++ b/src/services/review/__tests__/ReviewRequestService.spec.ts
@@ -53,6 +53,7 @@ import {
 import { mockUserWithSiteSessionData } from "@root/fixtures/sessionData"
 import { PageService } from "@root/services/fileServices/MdPageServices/PageService"
 import { ConfigService } from "@root/services/fileServices/YmlFileServices/ConfigService"
+import MailClient from "@root/services/utilServices/MailClient"
 import { GithubCommentData } from "@root/types/dto/review"
 import { Commit } from "@root/types/github"
 import RepoService from "@services/db/RepoService"
@@ -119,8 +120,13 @@ const MockSequelize = {
   transaction: jest.fn((transaction) => transaction()),
 }
 
+const mockMailer = ({
+  sendMail: jest.fn(),
+} as unknown) as MailClient
+
 const ReviewRequestService = new _ReviewRequestService(
   (MockReviewApi as unknown) as RepoService,
+  mockMailer,
   (MockUsersRepository as unknown) as ModelStatic<User>,
   (MockReviewRequestRepository as unknown) as ModelStatic<ReviewRequest>,
   (MockReviewersRepository as unknown) as ModelStatic<Reviewer>,


### PR DESCRIPTION
This PR adds email functionality for review request creation. On RR creation, the requested reviewers will receive the following email:
![image (6)](https://github.com/isomerpages/isomercms-backend/assets/22111124/f25c5a19-ff34-458c-82ae-c421a588011c)

Related figma doc: https://www.notion.so/opengov/Onboarding-RR-04607617b36043e68f3411fc80804394#0ca5d9c8295849fea26ac214b587be25