### PR TITLE
chore: update README and .env.example with ssh key info

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -76,3 +76,8 @@ export GROWTHBOOK_CLIENT_KEY=""
 
 # Uptime robot
 export UPTIME_ROBOT_API_KEY=""
+
+# Git SSH Keys
+export ENV_TYPE="LOCAL"
+export LOCAL_SSH_PUBLIC_KEY=""
+export LOCAL_SSH_PRIVATE_KEY=""

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 1. grab a copy of the environment variables from the 1PW Isomer vault
 2. ensure that you have your `AWS_ACCESS_KEY_ID` together with `AWS_SECRET_ACCESS_KEY`. These can be generated from the IAM console, under security credentials. (see [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for more details)
-3. next, generate your ssh keys and save them under `.ssh/github` and `.ssh/github.pub`. (See [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) for details on generating a new SSH key and adding it to your Github account.)
+3. next, generate your ssh keys and add them to the .env file. (See [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) for details on generating a new SSH key and adding it to your Github account.)
 4. run `npm run dev`
 
 ## Setup


### PR DESCRIPTION
02_fetch_ssh_keys.sh has been updated to pull ssh keys from env vars, so update README and .env.example to match

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [insert issue #]

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ ] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details
    - [ ] added env var to 1PW + SSM script (`fetch_ssm_parameters.sh`)

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details