### PR TITLE
feat(deploy-prod): add step to `ci.yml` to deploy to production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           else:
             print('::set-output name=proceed::false')
 
-  deploy:
+  deploy_eb:
     name: Build and deploy to EB
     runs-on: ubuntu-latest
     needs: [gatekeep]
@@ -180,3 +180,14 @@ jobs:
             deployment_package: deploy.zip
             wait_for_deployment: true
             wait_for_environment_recovery: true
+
+  # NOTE: Not combining with above workflow to allow parallel execution
+  deploy_ecs:
+    name: Build and deploy to EB
+    runs-on: ubuntu-latest
+    needs: [gatekeep]
+    if: needs.gatekeep.outputs.proceed == 'true'
+    steps:
+        - name: Deploy to ECS 
+          uses: ./.github/wworkflows/deploy_prod.yml
+          

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -1,0 +1,30 @@
+name: Deploy to production 
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_call: 
+
+jobs:
+  deploy:
+    name: Deploy
+    uses: ./.github/workflows/aws_deploy.yml
+    with:
+      aws-region: "ap-southeast-1"
+      cicd-role: "arn:aws:iam::095733531422:role/isomer-infra-github-oidc-role-16ea937"
+      ecr-repository: "isomer-infra-prod-ecr"
+      ecs-cluster-name: "isomer-prod-ecs"
+      ecs-web-service-name: "isomer-prod-ecs-service"
+      ecs-container-name: "backend"
+      environment: "prod"
+      shortEnv: "prod"
+      task-definition-path: ".aws/deploy/backend-task-definition.prod.json" 
+      codedeploy-application: "isomer-prod-ecs-app"
+      codedeploy-deployment-group: "isomer-prod-ecs-dg"
+
+    secrets: 
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      EFS_FILE_SYSTEM_ID: ${{ secrets.PROD_EFS_FILE_SYSTEM_ID }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}


### PR DESCRIPTION
## Problem
We have no workflow that deploys to production now. We require a new workflow to push to both ecs and eb (so that deployment for be consistent across both)

## Solution
Add a new `deploy_prod` workflow that does the deploy to ecs/ecr

update `ci.yml` so that it uses a new job to run the above workflow. we do this instead of just invoking hte new workflow directly cos they have the same trigger (push) so it might fail if both `ci + deploy_prod` ran tgt 