### PR TITLE
feat(routes): add link checker routes

### DIFF
--- a/.aws/deploy/backend-task-definition.prod.json
+++ b/.aws/deploy/backend-task-definition.prod.json
@@ -181,6 +181,10 @@
         {
           "name": "UPTIME_ROBOT_API_KEY",
           "valueFrom": "PROD_UPTIME_ROBOT_API_KEY"
+        },
+        {
+          "name": "SITE_CHECKER_FORM_KEY",
+          "valueFrom": "PROD_SITE_CHECKER_FORM_KEY"
         }
       ],
       "logConfiguration": {

--- a/.aws/deploy/backend-task-definition.staging.json
+++ b/.aws/deploy/backend-task-definition.staging.json
@@ -192,8 +192,8 @@
           "valueFrom": "STAGING_UPTIME_ROBOT_API_KEY"
         },
         {
-          "name": "SITE_LAUNCH_FORM_KEY",
-          "valueFrom": "STAGING_SITE_LAUNCH_FORM_KEY"
+          "name": "SITE_CHECKER_FORM_KEY",
+          "valueFrom": "STAGING_SITE_CHECKER_FORM_KEY"
         }
       ],
       "logConfiguration": {

--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -51,6 +51,7 @@ import DynamoDBDocClient from "@root/services/infra/DynamoDBClient"
 import DynamoDBService from "@root/services/infra/DynamoDBService"
 import InfraService from "@root/services/infra/InfraService"
 import StepFunctionsService from "@root/services/infra/StepFunctionsService"
+import RepoCheckerService from "@root/services/review/RepoCheckerService"
 import ReviewRequestService from "@root/services/review/ReviewRequestService"
 import MailClient from "@root/services/utilServices/MailClient"
 import GitFileSystemService from "@services/db/GitFileSystemService"
@@ -196,11 +197,23 @@ const infraService = new InfraService({
   usersService,
 })
 
+const siteMemberRepository = SiteMember
+const repoRepository = Repo
+const git = simpleGit()
+
+const repoCheckerService = new RepoCheckerService({
+  siteMemberRepository,
+  repoRepository,
+  gitFileSystemService,
+  git,
+})
+
 const SitesRouter = new _SitesRouter({
   sitesService,
   authorizationMiddleware,
   statsMiddleware,
   infraService,
+  repoCheckerService,
 })
 const sitesSubrouter = SitesRouter.getRouter()
 

--- a/src/routes/v2/authenticated/__tests__/Sites.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/Sites.spec.ts
@@ -13,6 +13,7 @@ import {
 } from "@fixtures/sessionData"
 import { StatsMiddleware } from "@root/middleware/stats"
 import InfraService from "@root/services/infra/InfraService"
+import RepoCheckerService from "@root/services/review/RepoCheckerService"
 import type SitesService from "@services/identity/SitesService"
 
 import { SitesRouter } from "../sites"
@@ -38,11 +39,16 @@ describe("Sites Router", () => {
     countMigratedSites: jest.fn(),
   }
 
+  const mockRepoCheckerService = {
+    checkRepo: jest.fn(),
+  }
+
   const router = new SitesRouter({
     sitesService: (mockSitesService as unknown) as SitesService,
     authorizationMiddleware: (mockAuthorizationMiddleware as unknown) as AuthorizationMiddleware,
     statsMiddleware: (mockStatsMiddleware as unknown) as StatsMiddleware,
     infraService: (mockInfraService as unknown) as InfraService,
+    repoCheckerService: (mockRepoCheckerService as unknown) as RepoCheckerService,
   })
 
   const subrouter = express()

--- a/src/routes/v2/authenticated/index.js
+++ b/src/routes/v2/authenticated/index.js
@@ -26,6 +26,7 @@ const getAuthenticatedSubrouter = ({
   reviewRouter,
   notificationsService,
   infraService,
+  repoCheckerService,
 }) => {
   const netlifyTomlService = new NetlifyTomlService()
 
@@ -34,6 +35,7 @@ const getAuthenticatedSubrouter = ({
     authorizationMiddleware,
     statsMiddleware,
     infraService,
+    repoCheckerService,
   })
   const collaboratorsRouter = new CollaboratorsRouter({
     collaboratorsService,

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -295,7 +295,7 @@ export class SitesRouter {
       "/:siteName/checkLinks",
       routeCheckerMiddleware.verifySiteName,
       attachSiteHandler,
-      this.authorizationMiddleware.verifySiteAdmin,
+      this.authorizationMiddleware.verifySiteMember,
       attachReadRouteHandlerWrapper(this.checkLinks)
     )
 

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -210,7 +210,7 @@ export class SitesRouter {
     if (result.isOk()) {
       return res.status(200).json(result.value)
     }
-    return res.status(404).json({ status: "error" })
+    return res.status(400).json({ status: "error" })
   }
 
   getRouter() {

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -50,7 +50,6 @@ export class SitesRouter {
     infraService,
     repoCheckerService,
   }: SitesRouterProps) {
-    console.log({ repoCheckerService }, "in sites router")
     this.sitesService = sitesService
     this.authorizationMiddleware = authorizationMiddleware
     this.statsMiddleware = statsMiddleware

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -212,7 +212,7 @@ export class SitesRouter {
     return res.status(404).json({ status: "error" })
   }
 
-  checkLinks: RequestHandler<
+  triggerCheckLinks: RequestHandler<
     { siteName: string },
     BrokenLinkErrorDto | ResponseErrorBody,
     never,
@@ -296,7 +296,7 @@ export class SitesRouter {
       routeCheckerMiddleware.verifySiteName,
       attachSiteHandler,
       this.authorizationMiddleware.verifySiteMember,
-      attachReadRouteHandlerWrapper(this.checkLinks)
+      attachReadRouteHandlerWrapper(this.triggerCheckLinks)
     )
 
     // The /sites/preview is a POST endpoint as the frontend sends

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -18,7 +18,7 @@ import { ResponseErrorBody } from "@root/types/dto/error"
 import { ProdPermalink, StagingPermalink } from "@root/types/pages"
 import { PreviewInfo } from "@root/types/previewInfo"
 import { RepositoryData } from "@root/types/repoInfo"
-import { RepoErrorDto } from "@root/types/siteChecker"
+import { BrokenLinkErrorDto } from "@root/types/siteChecker"
 import { SiteInfo, SiteLaunchDto } from "@root/types/siteInfo"
 import { StagingBuildStatus } from "@root/types/stagingBuildStatus"
 import type SitesService from "@services/identity/SitesService"
@@ -197,7 +197,7 @@ export class SitesRouter {
 
   getLinkCheckerStatus: RequestHandler<
     { siteName: string },
-    RepoErrorDto | ResponseErrorBody,
+    BrokenLinkErrorDto | ResponseErrorBody,
     never,
     never,
     { userWithSiteSessionData: UserWithSiteSessionData }

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -209,7 +209,7 @@ export class SitesRouter {
     if (result.isOk()) {
       return res.status(200).json(result.value)
     }
-    return res.status(400).json({ status: "error" })
+    return res.status(404).json({ status: "error" })
   }
 
   checkLinks: RequestHandler<

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -203,6 +203,23 @@ export class SitesRouter {
     { userWithSiteSessionData: UserWithSiteSessionData }
   > = async (req, res) => {
     const { userWithSiteSessionData } = res.locals
+    const result = await this.repoCheckerService.readRepoErrors(
+      userWithSiteSessionData.siteName
+    )
+    if (result.isOk()) {
+      return res.status(200).json(result.value)
+    }
+    return res.status(400).json({ status: "error" })
+  }
+
+  checkLinks: RequestHandler<
+    { siteName: string },
+    BrokenLinkErrorDto | ResponseErrorBody,
+    never,
+    never,
+    { userWithSiteSessionData: UserWithSiteSessionData }
+  > = async (req, res) => {
+    const { userWithSiteSessionData } = res.locals
     const result = await this.repoCheckerService.checkRepo(
       userWithSiteSessionData.siteName
     )
@@ -273,6 +290,13 @@ export class SitesRouter {
       attachSiteHandler,
       this.authorizationMiddleware.verifySiteMember,
       attachReadRouteHandlerWrapper(this.getLinkCheckerStatus)
+    )
+    router.post(
+      "/:siteName/checkLinks",
+      routeCheckerMiddleware.verifySiteName,
+      attachSiteHandler,
+      this.authorizationMiddleware.verifySiteAdmin,
+      attachReadRouteHandlerWrapper(this.checkLinks)
     )
 
     // The /sites/preview is a POST endpoint as the frontend sends

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -220,7 +220,7 @@ export class SitesRouter {
     { userWithSiteSessionData: UserWithSiteSessionData }
   > = async (req, res) => {
     const { userWithSiteSessionData } = res.locals
-    const result = await this.repoCheckerService.checkRepo(
+    const result = await this.repoCheckerService.runBrokenLinkChecker(
       userWithSiteSessionData.siteName
     )
     if (result.isOk()) {

--- a/src/server.js
+++ b/src/server.js
@@ -304,7 +304,6 @@ const infraService = new InfraService({
 
 const repoCheckerService = new RepoCheckerService({
   siteMemberRepository: SiteMember,
-  sitesService,
   gitFileSystemService,
   repoRepository: Repo,
   git: simpleGitInstance,

--- a/src/server.js
+++ b/src/server.js
@@ -349,6 +349,7 @@ const authenticatedSubrouterV2 = getAuthenticatedSubrouter({
   reviewRouter,
   notificationsService,
   infraService,
+  repoCheckerService,
 })
 
 const authenticatedSitesSubrouterV2 = getAuthenticatedSitesSubrouter({

--- a/src/services/review/RepoCheckerService.ts
+++ b/src/services/review/RepoCheckerService.ts
@@ -528,10 +528,10 @@ export default class RepoCheckerService {
             this.deleteErrorLog(repo).andThen(() =>
               this.checkRepo(repo, startTime)
             )
+          } else {
+            // this process can run async, so we can just return the loading state early
+            this.checkRepo(repo, startTime)
           }
-
-          // this process can run async, so we can just return the loading state early
-          this.checkRepo(repo, startTime)
           return okAsync<BrokenLinkErrorDto>({ status: "loading" })
         })
       )
@@ -576,7 +576,6 @@ export default class RepoCheckerService {
       this.cloner(repo)
         .andThen((cloned) => {
           const repoExists = !cloned
-          console.log({ repoExists })
 
           return this.checker(repo)
             .andThen((errors) => this.reporter(repo, errors))

--- a/src/services/review/RepoCheckerService.ts
+++ b/src/services/review/RepoCheckerService.ts
@@ -443,7 +443,7 @@ export default class RepoCheckerService {
         .fetch()
         .merge(["origin/main"])
         .add(["."])
-        .commit("site checker logs")
+        .commit(`Site checker logs added for ${repo}`)
         .push(),
       (error) => new SiteCheckerError(`${error}`)
     ).map(() => errors)

--- a/src/services/review/RepoCheckerService.ts
+++ b/src/services/review/RepoCheckerService.ts
@@ -516,7 +516,10 @@ export default class RepoCheckerService {
      * the repo to the EFS
      */
     let repoExists = true
+    logger.info(`Link checker for ${repo} started`)
 
+    // time the process taken to check the repo
+    const start = process.hrtime()
     return this.isCurrentlyLocked(repo)
       .andThen(() => okAsync<BrokenLinkErrorDto>({ status: "loading" }))
       .orElse(() =>
@@ -547,7 +550,13 @@ export default class RepoCheckerService {
                       return this.remover(repo).andThen(() => ok(errors))
                     })
                     .andThen((errors) =>
-                      this.deleteLock(repo).andThen(() => ok(errors))
+                      this.deleteLock(repo).andThen(() => {
+                        const end = process.hrtime(start)
+                        logger.info(
+                          `Link checker for ${repo} completed in ${end[0]}s`
+                        )
+                        return ok(errors)
+                      })
                     )
                     .orElse((error) => {
                       this.deleteLock(repo)

--- a/src/services/review/RepoCheckerService.ts
+++ b/src/services/review/RepoCheckerService.ts
@@ -439,6 +439,7 @@ export default class RepoCheckerService {
     return ResultAsync.fromPromise(
       this.git
         .cwd({ path: SITE_CHECKER_REPO_PATH, root: false })
+        .checkout("main")
         .fetch()
         .merge(["origin/main"])
         .add(["."])
@@ -570,12 +571,12 @@ export default class RepoCheckerService {
   checkRepo = (
     repo: string,
     start: [number, number]
-  ): ResultAsync<BrokenLinkErrorDto, SiteCheckerError> => {
-    let repoExists = true
-    return this.createLock(repo).andThen(() =>
+  ): ResultAsync<BrokenLinkErrorDto, SiteCheckerError> =>
+    this.createLock(repo).andThen(() =>
       this.cloner(repo)
         .andThen((cloned) => {
-          repoExists = cloned
+          const repoExists = !cloned
+          console.log({ repoExists })
 
           return this.checker(repo)
             .andThen((errors) => this.reporter(repo, errors))
@@ -615,7 +616,6 @@ export default class RepoCheckerService {
           return error
         })
     )
-  }
 
   convertToCSV(errors: RepoError[]) {
     const data = errors.map((error) => ({

--- a/src/services/review/RepoCheckerService.ts
+++ b/src/services/review/RepoCheckerService.ts
@@ -439,6 +439,8 @@ export default class RepoCheckerService {
     return ResultAsync.fromPromise(
       this.git
         .cwd({ path: SITE_CHECKER_REPO_PATH, root: false })
+        .fetch()
+        .merge(["origin/main"])
         .add(["."])
         .commit("site checker logs")
         .push(),

--- a/src/services/review/RepoCheckerService.ts
+++ b/src/services/review/RepoCheckerService.ts
@@ -421,7 +421,7 @@ export default class RepoCheckerService {
     ).map(() => errors)
   }
 
-  checkRepo(repo: string): ResultAsync<RepoErrorDto, never> {
+  checkRepo(repo: string): ResultAsync<RepoErrorDto, RepoErrorDto> {
     /**
      * To allow for an easy running of the script, we can temporarily clone
      * the repo to the EFS
@@ -464,7 +464,7 @@ export default class RepoCheckerService {
         }
         this.deleteLock(repo)
         logger.error(`Error running site checker for repo ${repo}: ${error}`)
-        return okAsync<RepoErrorDto>({
+        return errAsync<RepoErrorDto, RepoErrorDto>({
           status: "error",
         })
       })

--- a/src/services/review/RepoCheckerService.ts
+++ b/src/services/review/RepoCheckerService.ts
@@ -32,7 +32,6 @@ const { JSDOM } = jsdom
 interface RepoCheckerServiceProps {
   siteMemberRepository: ModelStatic<SiteMember>
   repoRepository: ModelStatic<Repo>
-  sitesService: SitesService
   gitFileSystemService: GitFileSystemService
   git: SimpleGit
 }
@@ -47,8 +46,6 @@ export const SITE_CHECKER_REPO_PATH = path.join(
 export default class RepoCheckerService {
   private readonly siteMemberRepository: RepoCheckerServiceProps["siteMemberRepository"]
 
-  private readonly sitesService: RepoCheckerServiceProps["sitesService"]
-
   private readonly gitFileSystemService: RepoCheckerServiceProps["gitFileSystemService"]
 
   private readonly git: RepoCheckerServiceProps["git"]
@@ -58,12 +55,11 @@ export default class RepoCheckerService {
   constructor({
     siteMemberRepository,
     repoRepository,
-    sitesService,
     gitFileSystemService,
     git,
   }: RepoCheckerServiceProps) {
     this.siteMemberRepository = siteMemberRepository
-    this.sitesService = sitesService
+
     this.gitFileSystemService = gitFileSystemService
     this.git = git
     this.repoRepository = repoRepository

--- a/src/types/siteChecker.ts
+++ b/src/types/siteChecker.ts
@@ -47,7 +47,7 @@ export function isRepoError(error: any): error is RepoError {
   )
 }
 
-export type RepoErrorDto =
+export type BrokenLinkErrorDto =
   | {
       status: "error" | "loading"
     }

--- a/src/types/siteChecker.ts
+++ b/src/types/siteChecker.ts
@@ -46,3 +46,12 @@ export function isRepoError(error: any): error is RepoError {
       error.type === RepoErrorTypes.DUPLICATE_PERMALINK)
   )
 }
+
+export type RepoErrorDto =
+  | {
+      status: "error" | "loading"
+    }
+  | {
+      status: "success"
+      errors: RepoError[]
+    }


### PR DESCRIPTION
## Problem

adding backend routes to allow for site checker to be done via the fe. corresponding fe pr will be up soon
Closes [insert issue #]

## Solution
hooking up existing func call done for form sg into a route to be called form fe.  gb will be introduced in the fe so as to not introduce 4xx errors. this is not private info anyways, dont really care if an agency is able to view their own site's broken links just by querying this path. 

a locking pattern is added to prevent multiple runs of the same repo state that might use unnecessary compute. 

there are two main api calls, a checker and a result getter. the front end will be call the checker through a manual button for now, (this is user triggered). the getter will be called once every 10 seconds. (or window refetch i dont have a strong opinion here). 

### Newer Changes

After offline disc with @harishv7 
1. Error states will persist when there is an error during a trigger, by the existence of an `error.log` file
2. We want to enable users to be self-reliant, so we allow them to retry during error states. By extension, `error.log` will be deleted + the function will be retried during this session. (DANGER, but I cannot seem to think of a case where this would lead to recursive calls, lmk if this is ok)
3. The two main function calls in `RepoCheckerService` are `readRepoErrors` and `runBrokenLinkChecker`. For observability, am wrapping an overall `mapErr` to log with the specific string that starts with `SiteCheckerError: `. This will be useful for devs to monitor error states from this newly rolled out feature.
4. only push to github is only done as i am returning the result back to the user. this allows for prod + design to look easily while not affecting user flow.



<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)


