### PR TITLE
Chore/lock repos when repairing

### DIFF
--- a/src/routes/formsg/formsgGGsRepair.ts
+++ b/src/routes/formsg/formsgGGsRepair.ts
@@ -121,12 +121,13 @@ export class FormsgGGsRepairRouter {
 
     const clonedStagingRepos: string[] = []
     const syncedStagingAndStagingLiteRepos: string[] = []
+    const LOCK_TIME_SECONDS = 15 * 60 // 15 minutes
     repoNames.forEach((repoName) => {
       const repoUrl = `git@github.com:isomerpages/${repoName}.git`
 
       repairs.push(
         ResultAsync.fromPromise(
-          lock(repoName),
+          lock(repoName, LOCK_TIME_SECONDS),
           (err) => new LockedError(`Unable to lock repo ${repoName}`)
         )
           .andThen(() => this.doesRepoNeedClone(repoName))
@@ -177,7 +178,7 @@ export class FormsgGGsRepairRouter {
             // Failure to unlock is not blocking
             ResultAsync.fromPromise(unlock(repoName), () => {
               logger.error(
-                "Failed to unlock repo - repo will unlock after 1 min"
+                "Failed to unlock repo - repo will unlock after at most 15 min"
               )
             })
             return okAsync(result)

--- a/src/routes/formsg/formsgGGsRepair.ts
+++ b/src/routes/formsg/formsgGGsRepair.ts
@@ -10,12 +10,15 @@ import { ResultAsync, errAsync, fromPromise, okAsync } from "neverthrow"
 
 import { config } from "@config/config"
 
+import { lock, unlock } from "@utils/mutex-utils"
+
 import {
   EFS_VOL_PATH_STAGING,
   EFS_VOL_PATH_STAGING_LITE,
 } from "@root/constants"
 import GitFileSystemError from "@root/errors/GitFileSystemError"
 import InitializationError from "@root/errors/InitializationError"
+import LockedError from "@root/errors/LockedError"
 import { consoleLogger } from "@root/logger/console.logger"
 import logger from "@root/logger/logger"
 import { attachFormSGHandler } from "@root/middleware"
@@ -114,7 +117,7 @@ export class FormsgGGsRepairRouter {
   }
 
   handleGGsFormSubmission = (repoNames: string[], requesterEmail: string) => {
-    const repairs: ResultAsync<string, GitFileSystemError>[] = []
+    const repairs: ResultAsync<string, GitFileSystemError | LockedError>[] = []
 
     const clonedStagingRepos: string[] = []
     const syncedStagingAndStagingLiteRepos: string[] = []
@@ -122,7 +125,11 @@ export class FormsgGGsRepairRouter {
       const repoUrl = `git@github.com:isomerpages/${repoName}.git`
 
       repairs.push(
-        this.doesRepoNeedClone(repoName)
+        ResultAsync.fromPromise(
+          lock(repoName),
+          (err) => new LockedError(`Unable to lock repo ${repoName}`)
+        )
+          .andThen(() => this.doesRepoNeedClone(repoName))
           .andThen(() => {
             const isStaging = true
             return (
@@ -166,6 +173,15 @@ export class FormsgGGsRepairRouter {
                 return okAsync(result)
               })
           )
+          .andThen((result) => {
+            // Failure to unlock is not blocking
+            ResultAsync.fromPromise(unlock(repoName), () => {
+              logger.error(
+                "Failed to unlock repo - repo will unlock after 1 min"
+              )
+            })
+            return okAsync(result)
+          })
       )
     })
 

--- a/src/utils/mutex-utils.js
+++ b/src/utils/mutex-utils.js
@@ -37,7 +37,7 @@ const mockUnlock = (siteName) => {
 
 const lock = async (siteName, lockLengthSeconds = 60) => {
   try {
-    const ONE_MIN_FROM_CURR_DATE_IN_SECONDS_FROM_EPOCH_TIME =
+    const expiryTime =
       Math.floor(new Date().valueOf() / 1000) + lockLengthSeconds
 
     if (isE2eTestRepo(siteName)) return
@@ -46,7 +46,7 @@ const lock = async (siteName, lockLengthSeconds = 60) => {
         TableName: MUTEX_TABLE_NAME,
         Item: {
           repo_id: siteName,
-          expdate: ONE_MIN_FROM_CURR_DATE_IN_SECONDS_FROM_EPOCH_TIME,
+          expdate: expiryTime,
         },
         ConditionExpression: "attribute_not_exists(repo_id)",
       }

--- a/src/utils/mutex-utils.js
+++ b/src/utils/mutex-utils.js
@@ -35,10 +35,10 @@ const mockUnlock = (siteName) => {
   mockMutexObj[siteName] = false
 }
 
-const lock = async (siteName) => {
+const lock = async (siteName, lockLengthSeconds = 60) => {
   try {
     const ONE_MIN_FROM_CURR_DATE_IN_SECONDS_FROM_EPOCH_TIME =
-      Math.floor(new Date().valueOf() / 1000) + 60
+      Math.floor(new Date().valueOf() / 1000) + lockLengthSeconds
 
     if (isE2eTestRepo(siteName)) return
     if (!IS_DEV) {


### PR DESCRIPTION
This PR locks the repo during the time site repair is being done, to prevent editing by users during this period.