### PR TITLE
feat: add validation for homepage frontmatter

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -90,3 +90,9 @@ export const STAGING_BRANCH = "staging"
 export const STAGING_LITE_BRANCH = "staging-lite"
 export const PLACEHOLDER_FILE_NAME = ".keep"
 export const GIT_SYSTEM_DIRECTORY = ".git"
+
+// Homepage blocks limits
+export const MAX_HERO_KEY_HIGHLIGHTS = 4
+export const MAX_ANNOUNCEMENT_ITEMS = 5
+export const MAX_TEXTCARDS_CARDS = 4
+export const MAX_INFOCOLS_BOXES = 4

--- a/src/routes/v2/authenticatedSites/__tests__/Homepage.spec.js
+++ b/src/routes/v2/authenticatedSites/__tests__/Homepage.spec.js
@@ -118,7 +118,7 @@ describe("Homepage Router", () => {
       )
     })
 
-    it("accepts valid homepage update requests with additional unspecified fields and returns the details of the file updated", async () => {
+    it("rejects homepage update requests with additional unspecified fields", async () => {
       const extraUpdateDetails = { ...updatePageDetails }
       // Add extra unspecified field
       extraUpdateDetails.content.frontMatter.extra = ""
@@ -131,7 +131,7 @@ describe("Homepage Router", () => {
       await request(app)
         .post(`/${siteName}/homepage`)
         .send(extraUpdateDetails)
-        .expect(200)
+        .expect(400)
 
       expect(mockHomepagePageService.update).toHaveBeenCalledWith(
         mockUserWithSiteSessionData,

--- a/src/routes/v2/authenticatedSites/__tests__/Homepage.spec.js
+++ b/src/routes/v2/authenticatedSites/__tests__/Homepage.spec.js
@@ -133,10 +133,7 @@ describe("Homepage Router", () => {
         .send(extraUpdateDetails)
         .expect(400)
 
-      expect(mockHomepagePageService.update).toHaveBeenCalledWith(
-        mockUserWithSiteSessionData,
-        expectedServiceInput
-      )
+      expect(mockHomepagePageService.update).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/routes/v2/authenticatedSites/__tests__/Homepage.spec.js
+++ b/src/routes/v2/authenticatedSites/__tests__/Homepage.spec.js
@@ -122,11 +122,6 @@ describe("Homepage Router", () => {
       const extraUpdateDetails = { ...updatePageDetails }
       // Add extra unspecified field
       extraUpdateDetails.content.frontMatter.extra = ""
-      const expectedServiceInput = {
-        content: updatePageDetails.content.pageBody,
-        frontMatter: updatePageDetails.content.frontMatter,
-        sha: updatePageDetails.sha,
-      }
 
       await request(app)
         .post(`/${siteName}/homepage`)

--- a/src/routes/v2/authenticatedSites/homepage.js
+++ b/src/routes/v2/authenticatedSites/homepage.js
@@ -33,9 +33,7 @@ class HomepageRouter {
   async updateHomepage(req, res, next) {
     const { userWithSiteSessionData } = res.locals
 
-    const { error } = UpdateHomepageSchema.validate(req.body, {
-      allowUnknown: true,
-    })
+    const { error } = UpdateHomepageSchema.validate(req.body)
     if (error) throw new BadRequestError(error.message)
     const {
       content: { frontMatter, pageBody },

--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -1,5 +1,12 @@
 const Joi = require("joi")
 
+const {
+  MAX_HERO_KEY_HIGHLIGHTS,
+  MAX_ANNOUNCEMENT_ITEMS,
+  MAX_TEXTCARDS_CARDS,
+  MAX_INFOCOLS_BOXES,
+} = require("@root/constants")
+
 const FileSchema = Joi.object().keys({
   name: Joi.string().required(),
   type: Joi.string().valid("file").required(),
@@ -93,7 +100,7 @@ const UpdateHomepageSchema = Joi.object({
                 ),
               }),
               key_highlights: Joi.array()
-                .max(4)
+                .max(MAX_HERO_KEY_HIGHLIGHTS)
                 .items(
                   Joi.object({
                     title: Joi.string().required(),
@@ -147,7 +154,7 @@ const UpdateHomepageSchema = Joi.object({
               id: Joi.string().allow(""),
               subtitle: Joi.string().allow(""),
               announcement_items: Joi.array()
-                .max(5)
+                .max(MAX_ANNOUNCEMENT_ITEMS)
                 .items(
                   Joi.object({
                     title: Joi.string().required(),
@@ -168,7 +175,7 @@ const UpdateHomepageSchema = Joi.object({
               subtitle: Joi.string().allow(""),
               description: Joi.string().allow(""),
               cards: Joi.array()
-                .max(4)
+                .max(MAX_TEXTCARDS_CARDS)
                 .items(
                   Joi.object({
                     title: Joi.string().required(),
@@ -189,7 +196,7 @@ const UpdateHomepageSchema = Joi.object({
               url: Joi.string().allow(""),
               linktext: Joi.string().allow(""),
               infoboxes: Joi.array()
-                .max(4)
+                .max(MAX_INFOCOLS_BOXES)
                 .items(
                   Joi.object({
                     title: Joi.string().required(),

--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -63,7 +63,143 @@ const UpdateHomepageSchema = Joi.object({
       permalink: Joi.string().required(),
       notification: Joi.string().allow(""),
       image: Joi.string(),
-      sections: Joi.array().required(),
+      sections: Joi.array()
+        .items(
+          // Hero section
+          Joi.object({
+            hero: Joi.object({
+              variant: Joi.string().allow(
+                "side",
+                "image",
+                "floating",
+                "center",
+                ""
+              ),
+              backgroundColor: Joi.string().allow("black", "white", "gray", ""),
+              background: Joi.string().allow(""),
+              size: Joi.string().allow("sm", "md", ""),
+              alignment: Joi.string().allow("left", "right", ""),
+              title: Joi.string().allow(""),
+              subtitle: Joi.string().allow(""),
+              button: Joi.string().allow(""),
+              url: Joi.string().allow(""),
+              dropdown: Joi.object({
+                title: Joi.string().required(),
+                options: Joi.array().items(
+                  Joi.object({
+                    title: Joi.string().required(),
+                    url: Joi.string().required(),
+                  })
+                ),
+              }),
+              key_highlights: Joi.array()
+                .max(4)
+                .items(
+                  Joi.object({
+                    title: Joi.string().required(),
+                    description: Joi.string().allow(""),
+                    url: Joi.string().allow(""),
+                  })
+                ),
+            }),
+          }),
+
+          // Resources section
+          Joi.object({
+            resources: Joi.object({
+              title: Joi.string().allow(""),
+              subtitle: Joi.string().allow(""),
+              id: Joi.string().allow(""),
+              button: Joi.string().allow(""),
+            }),
+          }),
+
+          // Infobar section
+          Joi.object({
+            infobar: Joi.object({
+              title: Joi.string().allow(""),
+              subtitle: Joi.string().allow(""),
+              id: Joi.string().allow(""),
+              description: Joi.string().allow(""),
+              button: Joi.string().allow(""),
+              url: Joi.string().allow(""),
+            }),
+          }),
+
+          // Infopic section
+          Joi.object({
+            infopic: Joi.object({
+              title: Joi.string(),
+              subtitle: Joi.string().allow(""),
+              id: Joi.string().allow(""),
+              description: Joi.string().allow(""),
+              button: Joi.string().allow(""),
+              url: Joi.string().allow(""),
+              image: Joi.string(),
+              alt: Joi.string(),
+            }),
+          }),
+
+          // Announcements section
+          Joi.object({
+            announcements: Joi.object({
+              title: Joi.string().allow(""),
+              id: Joi.string().allow(""),
+              subtitle: Joi.string().allow(""),
+              announcement_items: Joi.array()
+                .max(5)
+                .items(
+                  Joi.object({
+                    title: Joi.string().required(),
+                    date: Joi.string().required(),
+                    announcement: Joi.string().required(),
+                    link_text: Joi.string().allow(""),
+                    link_url: Joi.string().allow(""),
+                  })
+                ),
+            }),
+          }),
+
+          // Textcard section
+          Joi.object({
+            textcards: Joi.object({
+              title: Joi.string().required(),
+              id: Joi.string().allow(""),
+              subtitle: Joi.string().allow(""),
+              description: Joi.string().allow(""),
+              cards: Joi.array()
+                .max(4)
+                .items(
+                  Joi.object({
+                    title: Joi.string().required(),
+                    description: Joi.string().allow(""),
+                    linktext: Joi.string().allow(""),
+                    url: Joi.string().allow(""),
+                  })
+                ),
+            }),
+          }),
+
+          // Infocols section
+          Joi.object({
+            infocols: Joi.object({
+              title: Joi.string().required(),
+              id: Joi.string().allow(""),
+              subtitle: Joi.string().allow(""),
+              url: Joi.string().allow(""),
+              linktext: Joi.string().allow(""),
+              infoboxes: Joi.array()
+                .max(4)
+                .items(
+                  Joi.object({
+                    title: Joi.string().required(),
+                    description: Joi.string().allow(""),
+                  })
+                ),
+            }),
+          })
+        )
+        .required(),
     }).required(),
     pageBody: Joi.string().allow(""), // Joi does not allow empty string (pageBody: '') for Joi.string() even if not required
   }).required(),


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Our homepage frontmatter is not validated strictly.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Added homepage frontmatter validation. The information about the constraints are obtained from:
    - Static code analysis of the homepage components on the [isomerpages-template repo](https://github.com/isomerpages/isomerpages-template/tree/next-gen).
    - Observation on optional/required fields directly on the CMS.
    - Experimentation with various combinations + actual user homepages.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Navigate to any site and edit the homepage.
- [ ] Create one of every homepage block.
- [ ] Open the network developer tools, click on save. Verify that you can save.
- [ ] Capture the POST payload sent to update the homepage.
- [ ] Use Postman/Insomnia to send a request to the same endpoint (`POST /v2/sites/:siteName/homepage`), modify the description as [outlined in this message](https://opengovproducts.slack.com/archives/C06FXS46AFP/p1708077252043469?thread_ts=1708076966.452339&cid=C06FXS46AFP).
- [ ] Verify that you encounter a validation error.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*