### PR TITLE
fix(start-commands): update commands to be different by env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN echo "[user]" > /root/.gitconfig
 RUN echo "  name = Isomer Admin" >> /root/.gitconfig
 RUN echo "  email = admin@isomer.gov.sg" >> /root/.gitconfig
 
+RUN chmod +x ./scripts/02_fetch_ssh_keys.sh
 
 EXPOSE "8081"
-CMD ["bash", "-c", "chmod +x ./scripts/02_fetch_ssh_keys.sh && bash ./scripts/02_fetch_ssh_keys.sh & npm run start:ecs"] 
+CMD ["bash", "-c", "bash ./scripts/02_fetch_ssh_keys.sh & npm run start:ecs:$NODE_ENV"] 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "start": "node --unhandled-rejections=warn -r ts-node/register/transpile-only -r tsconfig-paths/register -r dotenv/config build/server.js dotenv_config_path=/efs/isomer/.isomer.env",
-    "start:ecs": "ts-node-dev --unhandled-rejections=warn --respawn src/server.js",
+    "start:ecs:prod": "ts-node --unhandled-rejections=warn -T -r tsconfig-paths/register src/server.js",
+    "start:ecs:staging": "ts-node --unhandled-rejections=warn -T -r tsconfig-paths/register src/server.js",
+    "start::ecs:dev": "ts-node-dev --unhandled-rejections=warn --respawn src/server.js",
     "dev": "source .env && docker compose -f docker-compose.dev.yml up",
     "test:docker": "docker run -d -p 54321:5432 --name postgres -e POSTGRES_USER=isomer -e POSTGRES_PASSWORD=password -e POSTGRES_DB=isomercms_test postgres:latest",
     "test": "source .env.test && jest --runInBand",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "start": "node --unhandled-rejections=warn -r ts-node/register/transpile-only -r tsconfig-paths/register -r dotenv/config build/server.js dotenv_config_path=/efs/isomer/.isomer.env",
-    "start:ecs:prod": "ts-node -T -r tsconfig-paths/register src/server.js",
-    "start:ecs:staging": "ts-node -T -r tsconfig-paths/register src/server.js",
+    "start:ecs:prod": "node --unhandled-rejections=warn -r ts-node/register/transpile-only -r tsconfig-paths/register src/server.js",
+    "start:ecs:staging": "node --unhandled-rejections=warn -r ts-node/register/transpile-only -r tsconfig-paths/register src/server.js",
     "start::ecs:dev": "ts-node-dev --respawn src/server.js",
     "dev": "source .env && docker compose -f docker-compose.dev.yml up",
     "test:docker": "docker run -d -p 54321:5432 --name postgres -e POSTGRES_USER=isomer -e POSTGRES_PASSWORD=password -e POSTGRES_DB=isomercms_test postgres:latest",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "start": "node --unhandled-rejections=warn -r ts-node/register/transpile-only -r tsconfig-paths/register -r dotenv/config build/server.js dotenv_config_path=/efs/isomer/.isomer.env",
-    "start:ecs:prod": "ts-node --unhandled-rejections=warn -T -r tsconfig-paths/register src/server.js",
-    "start:ecs:staging": "ts-node --unhandled-rejections=warn -T -r tsconfig-paths/register src/server.js",
-    "start::ecs:dev": "ts-node-dev --unhandled-rejections=warn --respawn src/server.js",
+    "start:ecs:prod": "ts-node -T -r tsconfig-paths/register src/server.js",
+    "start:ecs:staging": "ts-node -T -r tsconfig-paths/register src/server.js",
+    "start::ecs:dev": "ts-node-dev --respawn src/server.js",
     "dev": "source .env && docker compose -f docker-compose.dev.yml up",
     "test:docker": "docker run -d -p 54321:5432 --name postgres -e POSTGRES_USER=isomer -e POSTGRES_PASSWORD=password -e POSTGRES_DB=isomercms_test postgres:latest",
     "test": "source .env.test && jest --runInBand",


### PR DESCRIPTION
## Problem
right now, we run the same command for start across all our environments. this PR adds a different start command **by environment**

## Solution
1. utilise the fact that `CMD` is ran as the entrypoint **at run-time**. this means that env vars will be available 
2. create different commands for start **by environment** and use the env-var to differentiate
3. due to variable expansion, the command will be transformed from `start:ecs:$ENV_TYPE` into `start:ecs:dev/prod/staging`.

**NOTE: UNTESTED PR, TEST ON STAGING PRIOR TO MERGE**