### PR TITLE
fix(api): fix media route timeout

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,7 +12,6 @@ services:
       - .env
     volumes:
       - ./:/opt/isomercms-backend
-      - /opt/isomercms-backend/node_modules
       - ${EFS_VOL_PATH}:${EFS_VOL_PATH}
       - "~/.gitconfig:/etc/gitconfig"
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node --unhandled-rejections=warn -r ts-node/register/transpile-only -r tsconfig-paths/register -r dotenv/config build/server.js dotenv_config_path=/efs/isomer/.isomer.env",
     "start:ecs:prod": "node --unhandled-rejections=warn -r ts-node/register/transpile-only -r tsconfig-paths/register src/server.js",
     "start:ecs:staging": "node --unhandled-rejections=warn -r ts-node/register/transpile-only -r tsconfig-paths/register src/server.js",
-    "start::ecs:dev": "ts-node-dev --respawn src/server.js",
+    "start:ecs:dev": "ts-node-dev --respawn src/server.js",
     "dev": "source .env && docker compose -f docker-compose.dev.yml up",
     "test:docker": "docker run -d -p 54321:5432 --name postgres -e POSTGRES_USER=isomer -e POSTGRES_PASSWORD=password -e POSTGRES_DB=isomercms_test postgres:latest",
     "test": "source .env.test && jest --runInBand",

--- a/src/errors/RouteNotFoundError.ts
+++ b/src/errors/RouteNotFoundError.ts
@@ -1,0 +1,11 @@
+import { BaseIsomerError } from "./BaseError"
+
+export default class RouteNotFoundError extends BaseIsomerError {
+  constructor(meta = {}) {
+    super({
+      status: 404,
+      code: "Route Not Found Error",
+      meta,
+    })
+  }
+}

--- a/src/middleware/catchNonExistentRouteHandler.ts
+++ b/src/middleware/catchNonExistentRouteHandler.ts
@@ -1,0 +1,13 @@
+import { NextFunction, Request, Response } from "express"
+
+import RouteNotFoundError from "@root/errors/RouteNotFoundError"
+
+export const catchNonExistentRoutesMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  next(new RouteNotFoundError())
+}
+
+export default catchNonExistentRoutesMiddleware

--- a/src/routes/v2/authenticatedSites/__tests__/Media.spec.ts
+++ b/src/routes/v2/authenticatedSites/__tests__/Media.spec.ts
@@ -7,6 +7,7 @@ import {
   mockGithubSessionData,
 } from "@root/fixtures/sessionData"
 import { MOCK_REPO_NAME_ONE } from "@root/fixtures/sites"
+import catchNonExistentRoutesMiddleware from "@root/middleware/catchNonExistentRouteHandler"
 import { attachReadRouteHandlerWrapper } from "@root/middleware/routeHandler"
 import { MediaDirectoryService } from "@root/services/directoryServices/MediaDirectoryService"
 import { MediaFileService } from "@root/services/fileServices/MdPageServices/MediaFileService"
@@ -79,6 +80,8 @@ describe("Media Router", () => {
     "/:siteName/media/:directoryName/pages/:fileName",
     attachReadRouteHandlerWrapper(router.deleteMediaFile)
   )
+
+  subrouter.use(catchNonExistentRoutesMiddleware)
 
   const app = generateRouterForDefaultUserWithSite(subrouter)
   const siteName = MOCK_REPO_NAME_ONE
@@ -436,6 +439,12 @@ describe("Media Router", () => {
         undefined,
         expectedServiceInput
       )
+    })
+  })
+
+  describe("catchNonExistentRoutes", () => {
+    it("returns 404 for non-existent routes", async () => {
+      await request(app).get(`/${siteName}/media/imagesblah/pages`).expect(404)
     })
   })
 })

--- a/src/routes/v2/authenticatedSites/media.ts
+++ b/src/routes/v2/authenticatedSites/media.ts
@@ -11,6 +11,7 @@ import {
 import GithubSessionData from "@classes/GithubSessionData"
 import UserWithSiteSessionData from "@classes/UserWithSiteSessionData"
 
+import { catchNonExistentRoutesMiddleware } from "@root/middleware/catchNonExistentRouteHandler"
 import type {
   MediaDirOutput,
   MediaFileOutput,
@@ -83,6 +84,7 @@ export class MediaRouter {
     { page: number; limit: number; search: string },
     { userWithSiteSessionData: UserWithSiteSessionData }
   > = async (req, res) => {
+    console.log("in listMediaDirectoryFiles")
     const { userWithSiteSessionData } = res.locals
 
     const { directoryName } = req.params
@@ -444,6 +446,8 @@ export class MediaRouter {
       "/:directoryName/pages/:fileName",
       attachRollbackRouteHandlerWrapper(this.deleteMediaFile)
     )
+
+    router.use(catchNonExistentRoutesMiddleware)
 
     return router
   }

--- a/src/routes/v2/authenticatedSites/media.ts
+++ b/src/routes/v2/authenticatedSites/media.ts
@@ -84,7 +84,6 @@ export class MediaRouter {
     { page: number; limit: number; search: string },
     { userWithSiteSessionData: UserWithSiteSessionData }
   > = async (req, res) => {
-    console.log("in listMediaDirectoryFiles")
     const { userWithSiteSessionData } = res.locals
 
     const { directoryName } = req.params


### PR DESCRIPTION
## Problem

We had an issue where a request such as "media/images%20blah/pages"  timeing out, see incident [here](https://opengovproducts.slack.com/archives/CK68JNFHR/p1708651983715799). while we do have an overall catch all in our main router, there are quite a number of calls in our subrouter that fails. 

## Solution

for the media subrouter, this should return a 404. this is not applied across all the routes as some of the routes depend on the fall through behaviour to function. therefore, this pr is only scoped to return only for the media subrouter 

# Other solutions that did not work
1. adding a `next()` to every subrouter 
2. adding an error handler to every subrouter such that if subrouter captures a group and does not handle it, an error should be thrown. unfortunately, this caused quite a number of functionality to break, rather this hotfix go in first while and revisit this when we get timeouts again 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)



## Tests
- [ ] Get call an authenticated request (ie you have assess to the site with the relevant valid cookie) to the backend 
```
GET http://localhost:8081/v2/sites/kishore-test-dev-gh/media/images%2Fblah.png/pages
```
- [ ] Assert that you receive a res not found error rather than a timeout 

<img width="1211" alt="Screenshot 2024-03-04 at 8 21 16 AM" src="https://github.com/isomerpages/isomercms-backend/assets/42832651/a88d2115-d4fc-47d3-b264-fbb5b1138953">



