### PR TITLE
fix(docker): ensure that the app runs with webapp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN adduser -u 900 webapp -D -h /home/webapp -s /bin/sh
 USER webapp
 COPY . .
 
+# NOTE: We need to set up as root again because we need to perform chmod
+# We will fix all the permissions issue with a final chown to webapp
 USER root
 
 RUN mkdir /home/webapp/.ssh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 FROM node:18-alpine AS base
 WORKDIR /opt/isomercms-backend
-COPY . .
 
-RUN apk update && \ 
+RUN apk update && \
   apk add --no-cache bash && \
   apk add git && \
   apk add openssh-client
 
-RUN mkdir /root/.ssh
+RUN adduser -u 900 webapp -D -h /home/webapp -s /bin/sh
+USER webapp
+COPY . .
+
+USER root
+
+RUN mkdir /home/webapp/.ssh
 
 RUN chmod +x ./scripts/03_add_keys_to_ssh_config.sh
 RUN sh ./scripts/03_add_keys_to_ssh_config.sh
@@ -15,16 +20,21 @@ RUN sh ./scripts/03_add_keys_to_ssh_config.sh
 RUN chmod +x ./scripts/04_add_github_to_known_hosts.sh
 RUN sh ./scripts/04_add_github_to_known_hosts.sh
 
-RUN npm ci 
+RUN npm ci
 # NOTE: Removing the cache here to keep the image small
 RUN rm -rf /var/cache/apk/*
 
 RUN git config --system --add safe.directory '*'
-RUN echo "[user]" > /root/.gitconfig 
+RUN echo "[user]" > /root/.gitconfig
 RUN echo "  name = Isomer Admin" >> /root/.gitconfig
 RUN echo "  email = admin@isomer.gov.sg" >> /root/.gitconfig
 
 RUN chmod +x ./scripts/02_fetch_ssh_keys.sh
 
+RUN chown -R webapp:webapp /home/webapp/.ssh
+
+# NOTE: We need to run the app as webapp, otherwise we will encounter
+# permissions issues on EFS, and all files will be erroneously owned by root.
+USER webapp
 EXPOSE "8081"
-CMD ["bash", "-c", "bash ./scripts/02_fetch_ssh_keys.sh & npm run start:ecs:$NODE_ENV"] 
+CMD ["bash", "-c", "bash ./scripts/02_fetch_ssh_keys.sh & npm run start:ecs:$NODE_ENV"]

--- a/scripts/02_fetch_ssh_keys.sh
+++ b/scripts/02_fetch_ssh_keys.sh
@@ -5,24 +5,24 @@ SSH_PUBLIC_KEY_PARAM_NAME="${ENV_TYPE}_SSH_PUBLIC_KEY"
 SSH_PRIVATE_KEY_PARAM_NAME="${ENV_TYPE}_SSH_PRIVATE_KEY"
 
 # create .ssh folder if it does not exist
-mkdir -p /root/.ssh
+mkdir -p /home/webapp/.ssh
 
 SSH_PUBLIC_KEY_VALUE="${!SSH_PUBLIC_KEY_PARAM_NAME}"
 SSH_PRIVATE_KEY_VALUE="${!SSH_PRIVATE_KEY_PARAM_NAME}"
 
 echo "Fetching keys"
-echo "$SSH_PUBLIC_KEY_VALUE" >/root/.ssh/github.pub || {
+echo "$SSH_PUBLIC_KEY_VALUE" >/home/webapp/.ssh/github.pub || {
     echo "Failed to fetch SSH public key"
     exit 1
 }
-echo "$SSH_PRIVATE_KEY_VALUE" >/root/.ssh/github || {
+echo "$SSH_PRIVATE_KEY_VALUE" >/home/webapp/.ssh/github || {
     echo "Failed to fetch SSH private key"
     exit 1
 }
 
 # Set the permissions for the keys
 echo "Setting permissions"
-chmod 600 /root/.ssh/github.pub
-chmod 600 /root/.ssh/github
+chmod 600 /home/webapp/.ssh/github.pub
+chmod 600 /home/webapp/.ssh/github
 
 echo "Fetching keys complete"

--- a/scripts/03_add_keys_to_ssh_config.sh
+++ b/scripts/03_add_keys_to_ssh_config.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # add github as host and ssh key to ssh config
-cat << EOF > /root/.ssh/config
+cat << EOF > /home/webapp/.ssh/config
 Host github.com
-  IdentityFile /root/.ssh/github
+  IdentityFile /home/webapp/.ssh/github
   User git
 EOF

--- a/scripts/04_add_github_to_known_hosts.sh
+++ b/scripts/04_add_github_to_known_hosts.sh
@@ -15,7 +15,7 @@ OFFICIAL_FINGERPRINT="SHA256:uNiVztksCsDhcc0u9e8BujQXVUpKZIDTMczCvj3tD2s"
 # Note: This check is important to prevent any MITM attacks
 if [ "$SERVER_FINGERPRINT" = "$OFFICIAL_FINGERPRINT" ]; then
     # If the fingerprints match, add the public key to the known_hosts file
-    cat github_rsa.pub >/root/.ssh/known_hosts
+    cat github_rsa.pub >/home/webapp/.ssh/known_hosts
     echo "GitHub's public key added to known_hosts." >>/tmp/setup-github-known-hosts.txt
 else
     # If the fingerprints don't match, output a warning and exit with an error


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The ECS tasks are running the web application as root, which causes permission issues on EFS when co-existing with the EB instances.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Ensure that we execute the docker container as the webapp user.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Create a new folder in the images page for any repo.
- [ ] Perform a task exec and open a shell session with an ECS container.
- [ ] Change directory to the repo chosen earlier and go into the images folder.
- [ ] Perform `ls -l` and verify that the newly created folder is owned by webapp:webapp.
- [ ] Perform `ls -ln` and verify that the newly created folder is owned by 900:900.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

- [ ] After deployment, bring the traffic routing of prod to 10% ECS and 90% EB.
- [ ] Verify the above tests again on prod while on OGP VPN.
- [ ] Attempt to edit a page and ensure that you are able to save successfully.
- [ ] Disconnect from OGP VPN and ensure that you refresh your browser tab to avoid sticky sessions.
- [ ] Attempt to upload an image into the newly created folder and verify that you can successfully upload.
- [ ] Attempt to edit a page and ensure that you are able to save successfully.