### PR TITLE
fix(docker): ensure gitconfig is stored in the right place

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,6 @@ RUN npm ci
 RUN rm -rf /var/cache/apk/*
 
 RUN git config --system --add safe.directory '*'
-RUN echo "[user]" > /root/.gitconfig
-RUN echo "  name = Isomer Admin" >> /root/.gitconfig
-RUN echo "  email = admin@isomer.gov.sg" >> /root/.gitconfig
 
 RUN chmod +x ./scripts/02_fetch_ssh_keys.sh
 
@@ -38,5 +35,10 @@ RUN chown -R webapp:webapp /home/webapp/.ssh
 # NOTE: We need to run the app as webapp, otherwise we will encounter
 # permissions issues on EFS, and all files will be erroneously owned by root.
 USER webapp
+
+RUN echo "[user]" > /home/webapp/.gitconfig
+RUN echo "  name = Isomer Admin" >> /home/webapp/.gitconfig
+RUN echo "  email = admin@isomer.gov.sg" >> /home/webapp/.gitconfig
+
 EXPOSE "8081"
 CMD ["bash", "-c", "bash ./scripts/02_fetch_ssh_keys.sh & npm run start:ecs:$NODE_ENV"]


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The .gitconfig file is still being stored in root despite the application being run as webapp.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Fixed the location where the .gitconfig file is being stored at, to now store in the `webapp` user's home directory.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Navigate to any site using the ECS backend
- [ ] Make an edit on the site
- [ ] Ensure that the commit made on the site is by Isomer Admin and not Linux User

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*