### PR TITLE
Feat/add back repair form lock

### DIFF
--- a/src/routes/formsg/formsgGGsRepair.ts
+++ b/src/routes/formsg/formsgGGsRepair.ts
@@ -122,7 +122,7 @@ export class FormsgGGsRepairRouter {
 
     const clonedStagingRepos: string[] = []
     const syncedStagingAndStagingLiteRepos: string[] = []
-    const LOCK_TIME_SECONDS = 5 * 60 * repoNames.length // 5 minutes per repo being fixed
+    const LOCK_TIME_SECONDS = 15 * 60 // 15 minutes
     repoNames.forEach((repoName) => {
       const repoUrl = `git@github.com:isomerpages/${repoName}.git`
 

--- a/src/routes/formsg/formsgGGsRepair.ts
+++ b/src/routes/formsg/formsgGGsRepair.ts
@@ -113,6 +113,7 @@ export class FormsgGGsRepairRouter {
       logger.error("Requester email is not from @open.gov.sg")
       return
     }
+    res.sendStatus(200) // we have received the form and obtained relevant field
     this.handleGGsFormSubmission(repoNames, requesterEmail)
   }
 
@@ -121,7 +122,7 @@ export class FormsgGGsRepairRouter {
 
     const clonedStagingRepos: string[] = []
     const syncedStagingAndStagingLiteRepos: string[] = []
-    const LOCK_TIME_SECONDS = 15 * 60 // 15 minutes
+    const LOCK_TIME_SECONDS = 5 * 60 * repoNames.length // 5 minutes per repo being fixed
     repoNames.forEach((repoName) => {
       const repoUrl = `git@github.com:isomerpages/${repoName}.git`
 

--- a/src/utils/mutex-utils.js
+++ b/src/utils/mutex-utils.js
@@ -35,10 +35,10 @@ const mockUnlock = (siteName) => {
   mockMutexObj[siteName] = false
 }
 
-const lock = async (siteName) => {
+const lock = async (siteName, lockLengthSeconds = 60) => {
   try {
-    const ONE_MIN_FROM_CURR_DATE_IN_SECONDS_FROM_EPOCH_TIME =
-      Math.floor(new Date().valueOf() / 1000) + 60
+    const expiryTime =
+      Math.floor(new Date().valueOf() / 1000) + lockLengthSeconds
 
     if (isE2eTestRepo(siteName)) return
     if (!IS_DEV) {
@@ -46,7 +46,7 @@ const lock = async (siteName) => {
         TableName: MUTEX_TABLE_NAME,
         Item: {
           repo_id: siteName,
-          expdate: ONE_MIN_FROM_CURR_DATE_IN_SECONDS_FROM_EPOCH_TIME,
+          expdate: expiryTime,
         },
         ConditionExpression: "attribute_not_exists(repo_id)",
       }


### PR DESCRIPTION
This PR adds back the lock for site repair form. Previously we removed the lock due to the issues we were facing on prod - this was most likely due to the lack of response to forms causing unexpected 4xx errors, in addition to the large number of repos we were repairing at the same time. This PR adds in the response to forms so that we can avoid that issue.

In addition, the time for locking has been set at 15 minutes instead of a scaling amount as discussed offline - this is because repos are being locked and repaired concurrently and will unlock when their respective operation completes without having to wait for the entire set to complete.