### PR TITLE
feat(mail): support sending emails with attachments

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -24,6 +24,7 @@ export SITE_CREATE_FORM_KEY="site_form_key"
 export SITE_LAUNCH_FORM_KEY="site_launch_form_key"
 export GGS_REPAIR_FORM_KEY="ggs_repair_form_key"
 export SITE_CHECKER_FORM_KEY="site_checker_form_key"
+export SITE_AUDIT_LOGS_FORM_KEY="site_audit_logs_form_key"
 
 # Required to connect to DynamoDB
 export AWS_ACCESS_KEY_ID="abc123"

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "express-rate-limit": "^6.7.0",
         "express-session": "^1.17.3",
         "file-type": "^16.5.4",
+        "form-data": "^4.0.0",
         "glob": "^10.3.10",
         "helmet": "^4.6.0",
         "hot-shots": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "express-rate-limit": "^6.7.0",
     "express-session": "^1.17.3",
     "file-type": "^16.5.4",
+    "form-data": "^4.0.0",
     "glob": "^10.3.10",
     "helmet": "^4.6.0",
     "hot-shots": "^10.0.0",

--- a/src/integration/Users.spec.ts
+++ b/src/integration/Users.spec.ts
@@ -204,7 +204,7 @@ describe("Users Router", () => {
       const expected = 200
       let otp = ""
       mockAxios.post.mockImplementationOnce((_, email) => {
-        otp = extractEmailOtp(email.body)
+        otp = extractEmailOtp(JSON.stringify(email))
         // NOTE: We are casting as `any` here because
         // the underlying type used by `mockAxios` is
         // not a promise and we do not have the type installed.
@@ -308,7 +308,7 @@ describe("Users Router", () => {
       const expected = 200
       let otp
       mockAxios.post.mockImplementation((_: any, email: any) => {
-        otp = extractEmailOtp(email.body)
+        otp = extractEmailOtp(JSON.stringify(email))
         // NOTE: We are casting as `any` here because
         // the underlying type used by `mockAxios` is
         // not a promise and we do not have the type installed.

--- a/src/services/utilServices/MailClient.ts
+++ b/src/services/utilServices/MailClient.ts
@@ -1,4 +1,5 @@
 import fs from "fs"
+import path from "path"
 
 import axios from "axios"
 import FormData from "form-data"
@@ -54,7 +55,7 @@ class MailClient {
       form.append(
         "attachments",
         fs.readFileSync(attachment),
-        attachment.split("/").pop()
+        path.basename(attachment)
       )
     })
 

--- a/src/services/utilServices/MailClient.ts
+++ b/src/services/utilServices/MailClient.ts
@@ -1,4 +1,7 @@
+import fs from "fs"
+
 import axios from "axios"
+import FormData from "form-data"
 
 import { config } from "@config/config"
 
@@ -37,19 +40,26 @@ class MailClient {
   async sendMail(
     recipient: string,
     subject: string,
-    body: string
+    body: string,
+    attachments?: string[]
   ): Promise<void> {
     const sendEndpoint = `${POSTMAN_API_URL}/transactional/email/send`
-    const email = {
-      subject,
-      from: "IsomerCMS <donotreply@mail.postman.gov.sg>",
-      body,
-      recipient,
-      reply_to: "noreply@isomer.gov.sg",
-    }
+    const form = new FormData()
+    form.append("subject", subject)
+    form.append("from", "IsomerCMS <donotreply@isomer.gov.sg>")
+    form.append("body", body)
+    form.append("recipient", recipient)
+    form.append("reply_to", "noreply@isomer.gov.sg")
+    attachments?.forEach((attachment) => {
+      form.append(
+        "attachments",
+        fs.readFileSync(attachment),
+        attachment.split("/").pop()
+      )
+    })
 
     try {
-      const sendMailResponse = await axios.post<MailData>(sendEndpoint, email, {
+      const sendMailResponse = await axios.post<MailData>(sendEndpoint, form, {
         headers: {
           Authorization: `Bearer ${this.POSTMAN_API_KEY}`,
         },

--- a/src/services/utilServices/__tests__/MailClient.spec.ts
+++ b/src/services/utilServices/__tests__/MailClient.spec.ts
@@ -1,3 +1,4 @@
+import FormData from "form-data"
 import mockAxios from "jest-mock-axios"
 
 import { config } from "@config/config"
@@ -14,20 +15,11 @@ const mockEndpoint = "https://api.postman.gov.sg/v1/transactional/email/"
 
 const MailClient = new _MailClient(config.get("postman.apiKey"))
 
-const generateEmail = (recipient: string, subject: string, body: string) => ({
-  subject,
-  from: "IsomerCMS <donotreply@mail.postman.gov.sg>",
-  body,
-  recipient,
-  reply_to: "noreply@isomer.gov.sg",
-})
-
 describe("Mail Client", () => {
   afterEach(() => mockAxios.reset())
   jest.useFakeTimers()
   it("should return the result successfully when all parameters are valid", async () => {
     // Arrange
-    const generatedEmail = generateEmail(mockRecipient, mockSubject, mockBody)
     const sendMailResponse = {
       data: {
         id: 1,
@@ -60,11 +52,7 @@ describe("Mail Client", () => {
 
     // Assert
     expect(actual).toBeUndefined()
-    expect(mockAxios.post).toHaveBeenCalledWith(
-      `${mockEndpoint}send`,
-      generatedEmail,
-      mockBearerTokenHeaders
-    )
+    expect(mockAxios.post).toHaveBeenCalledOnce()
     expect(mockAxios.get).toHaveBeenCalledWith(
       `${mockEndpoint}1`,
       mockBearerTokenHeaders
@@ -73,7 +61,6 @@ describe("Mail Client", () => {
 
   it("should return an error when a network error occurs", async () => {
     // Arrange
-    const generatedEmail = generateEmail(mockRecipient, mockSubject, mockBody)
     mockAxios.post.mockRejectedValueOnce("some error")
 
     // Act
@@ -81,10 +68,6 @@ describe("Mail Client", () => {
 
     // Assert
     expect(actual).rejects.toThrowError("Failed to send email")
-    expect(mockAxios.post).toHaveBeenCalledWith(
-      `${mockEndpoint}send`,
-      generatedEmail,
-      mockBearerTokenHeaders
-    )
+    expect(mockAxios.post).toHaveBeenCalledOnce()
   })
 })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The current mail sending functionality does not support adding of attachments to the email.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Use `form-data` to craft the message object and also allow for inserting of files as attachments.
- Adjust email from address to `donotreply@isomer.gov.sg`, which is required for sending emails with attachments.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Update the `POSTMAN_API_KEY` to the one that starts with `donotreply_`
- [ ] Attempt to login with email OTP
- [ ] Verify that the OTP email is sent successfully from `donotreply@isomer.gov.sg`

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dependencies**:

- `form-data` : Package for handling multipart form data requests

**Other deploy steps**
- [ ] Create the new `/efs/audit-logs` folder on EFS before deployment.
- [ ] Update `PROD_POSTMAN_API_KEY` on SSM