### PR TITLE
chore: revert to copy instead of clone

### DIFF
--- a/src/routes/formsg/formsgGGsRepair.ts
+++ b/src/routes/formsg/formsgGGsRepair.ts
@@ -10,10 +10,7 @@ import { ResultAsync, errAsync, fromPromise, okAsync } from "neverthrow"
 
 import { config } from "@config/config"
 
-import {
-  EFS_VOL_PATH_STAGING,
-  EFS_VOL_PATH_STAGING_LITE,
-} from "@root/constants"
+import { EFS_VOL_PATH_STAGING_LITE } from "@root/constants"
 import GitFileSystemError from "@root/errors/GitFileSystemError"
 import InitializationError from "@root/errors/InitializationError"
 import { consoleLogger } from "@root/logger/console.logger"
@@ -150,7 +147,6 @@ export class FormsgGGsRepairRouter {
               .andThen(() =>
                 fromPromise(
                   this.reposService.setUpStagingLite(
-                    path.join(EFS_VOL_PATH_STAGING, repoName),
                     path.join(EFS_VOL_PATH_STAGING_LITE, repoName),
                     repoUrl
                   ),


### PR DESCRIPTION
This reverts commit d25129cd41e0b19a1b5e6a34ffeb9802ca565f11. We were facing issues when repairing large repos, possibly due to memory issues - this PR reverts to git clone for slightly slower operations but allowing it to work for large repos again.

Note that we should also monitor CPU utilisation when running the site repair form for large sites - we were previously facing issues on this when using `cp`