### PR TITLE
fix(linkChecker): bug fixes

### DIFF
--- a/src/integration/Sites.spec.ts
+++ b/src/integration/Sites.spec.ts
@@ -52,8 +52,8 @@ import DynamoDBDocClient from "@root/services/infra/DynamoDBClient"
 import DynamoDBService from "@root/services/infra/DynamoDBService"
 import InfraService from "@root/services/infra/InfraService"
 import StepFunctionsService from "@root/services/infra/StepFunctionsService"
-import ReviewCommentService from "@root/services/review/ReviewCommentService"
 import RepoCheckerService from "@root/services/review/RepoCheckerService"
+import ReviewCommentService from "@root/services/review/ReviewCommentService"
 import ReviewRequestService from "@root/services/review/ReviewRequestService"
 import MailClient from "@root/services/utilServices/MailClient"
 import GitFileSystemService from "@services/db/GitFileSystemService"
@@ -210,6 +210,7 @@ const repoCheckerService = new RepoCheckerService({
   repoRepository,
   gitFileSystemService,
   git,
+  pageService,
 })
 
 const SitesRouter = new _SitesRouter({

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -221,7 +221,7 @@ export class SitesRouter {
   > = async (req, res) => {
     const { userWithSiteSessionData } = res.locals
     const result = await this.repoCheckerService.runBrokenLinkChecker(
-      userWithSiteSessionData.siteName
+      userWithSiteSessionData
     )
     if (result.isOk()) {
       return res.status(200).json(result.value)

--- a/src/server.js
+++ b/src/server.js
@@ -315,6 +315,7 @@ const repoCheckerService = new RepoCheckerService({
   gitFileSystemService,
   repoRepository: Repo,
   git: simpleGitInstance,
+  pageService,
 })
 
 const auditLogsService = new AuditLogsService({

--- a/src/services/fileServices/MdPageServices/PageService.ts
+++ b/src/services/fileServices/MdPageServices/PageService.ts
@@ -302,11 +302,10 @@ export class PageService {
           : err(new MissingResourceRoomError())
     )
 
-  retrieveCmsPermalink = (
+  retrieveRelativeCmsPermalink = (
     pageName: PageName,
-    siteName: string
+    baseUrl: string
   ): ResultAsync<string, BaseIsomerError> => {
-    const baseUrl = `${FRONTEND_URL}/sites/${siteName}`
     switch (pageName.kind) {
       case "Homepage": {
         return okAsync(`${baseUrl}/homepage`)
@@ -348,6 +347,14 @@ export class PageService {
         )
       }
     }
+  }
+
+  retrieveCmsPermalink = (
+    pageName: PageName,
+    siteName: string
+  ): ResultAsync<string, BaseIsomerError> => {
+    const baseUrl = `${FRONTEND_URL}/sites/${siteName}`
+    return this.retrieveRelativeCmsPermalink(pageName, baseUrl)
   }
 
   retrieveStagingPermalink = (

--- a/src/services/review/RepoCheckerService.ts
+++ b/src/services/review/RepoCheckerService.ts
@@ -506,7 +506,12 @@ export default class RepoCheckerService {
       fs.writeFileSync(filePath, stringifiedErrors)
     }
 
-    let gitOperations:
+    const isProd = config.get("env") === "prod"
+    if (!isProd) {
+      return okAsync(errors)
+    }
+
+    const gitOperations:
       | Response<CommitResult>
       | Response<PushResult> = this.git
       .cwd({ path: SITE_CHECKER_REPO_PATH, root: false })
@@ -515,11 +520,7 @@ export default class RepoCheckerService {
       .merge(["origin/main"])
       .add(["."])
       .commit(`Site checker logs added for ${repo}`)
-
-    const isProd = config.get("env") === "prod"
-    if (isProd) {
-      gitOperations = gitOperations.push()
-    }
+      .push()
 
     // pushing since there is no real time requirement for user
     return ResultAsync.fromPromise<CommitResult | PushResult, SiteCheckerError>(

--- a/src/services/review/__tests__/ReviewRequestService.spec.ts
+++ b/src/services/review/__tests__/ReviewRequestService.spec.ts
@@ -71,6 +71,7 @@ const MockPageService: {
   parsePageName: jest.fn(),
   retrieveStagingPermalink: jest.fn(),
   retrieveCmsPermalink: jest.fn(),
+  retrieveRelativeCmsPermalink: jest.fn(),
 }
 const MockReviewApi = {
   approvePullRequest: jest.fn(),


### PR DESCRIPTION
## Problem

Users have given feedback regarding link checker. 

1. Decoding issues 
The repo had the file 
`/images/Life @ JPJC/2023 Events/LTC2023/ltc photo 1.JPG`

User had sourced this in one of their pages using the path `/images/Life%20%40%20JPJC/2023%20Events/LTC2023/ltc%20photo%201.JPG`

In the live site, this is a vaild link.

When running 
```
const uri = '/images/Life%20%40%20JPJC/2023%20Events/LTC2023/ltc%20photo%201.JPG';
  console.log(decodeURIComponent(uri));
  console.log(decodeURI(uri));
```

we get the result 
```
> "/images/Life @ JPJC/2023 Events/LTC2023/ltc photo 1.JPG"
> "/images/Life %40 JPJC/2023 Events/LTC2023/ltc photo 1.JPG"
```

which is expected as the [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURI#decodeuri_vs._decodeuricomponent) states 
> decodeURI() assumes the input is a full URI, so it does not decode characters that are part of the URI syntax.

since we are dealing with user supplied inputs, we have to make the least guarantees, and assume that the user supplied value might contain characters that are part of the URI syntax. 

2. Anchor links
We have an agency that used pattern of 
`<a id="blah"></a>` 
for their anchor links. To them, this is not a broken link and a false positive, which is understandable. Since this is something that the end citizen will not notice, I am opting to make a call to not report any anchor tags without any text. 

3. Image links
There exist dangling image tags in .md files, eg
`<img/>` 
and this has confused the user. Similar to the reasoning above, removing reporting of empty img srcs. 

4. Trivial permalink normalisation issues. eg leading quotation marks 
5. any resources _post page in cms was not rendered properly
6. Remove query params when checking for local references, amplify allows it and returns a 200

Other optimisations
Allow faster dev iteration by removing the push to the remote repository isomer-link-checker

this pr should make link checker stable for the upcoming 8 sites to be whitelisted after release

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)


## Tests

nil

