### PR TITLE
fix: send updated data back to client, from all update pages endpoints

### DIFF
--- a/src/services/fileServices/MdPageServices/CollectionPageService.js
+++ b/src/services/fileServices/MdPageServices/CollectionPageService.js
@@ -70,6 +70,10 @@ class CollectionPageService {
   ) {
     const parsedCollectionName = `_${collectionName}`
     const newContent = convertDataToMarkdown(frontMatter, content)
+    const {
+      frontMatter: newFrontMatter,
+      pageContent: newPageContent,
+    } = retrieveDataFromMarkdown(newContent)
     const { newSha } = await this.gitHubService.update(sessionData, {
       fileContent: newContent,
       sha,
@@ -78,7 +82,7 @@ class CollectionPageService {
     })
     return {
       fileName,
-      content: { frontMatter, pageBody: content },
+      content: { frontMatter: newFrontMatter, pageBody: newPageContent },
       oldSha: sha,
       newSha,
     }

--- a/src/services/fileServices/MdPageServices/ResourcePageService.js
+++ b/src/services/fileServices/MdPageServices/ResourcePageService.js
@@ -93,6 +93,10 @@ class ResourcePageService {
       resourceCategoryName,
     })
     const newContent = convertDataToMarkdown(frontMatter, content)
+    const {
+      frontMatter: newFrontMatter,
+      pageContent: newPageContent,
+    } = retrieveDataFromMarkdown(newContent)
     const { newSha } = await this.gitHubService.update(sessionData, {
       fileContent: newContent,
       sha,
@@ -101,7 +105,7 @@ class ResourcePageService {
     })
     return {
       fileName,
-      content: { frontMatter, pageBody: content },
+      content: { frontMatter: newFrontMatter, pageBody: newPageContent },
       oldSha: sha,
       newSha,
     }

--- a/src/services/fileServices/MdPageServices/SubcollectionPageService.js
+++ b/src/services/fileServices/MdPageServices/SubcollectionPageService.js
@@ -69,6 +69,10 @@ class SubcollectionPageService {
   ) {
     const parsedDirectoryName = `_${collectionName}/${subcollectionName}`
     const newContent = convertDataToMarkdown(frontMatter, content)
+    const {
+      frontMatter: newFrontMatter,
+      pageContent: newPageContent,
+    } = retrieveDataFromMarkdown(newContent)
     const { newSha } = await this.gitHubService.update(sessionData, {
       fileContent: newContent,
       sha,
@@ -77,7 +81,7 @@ class SubcollectionPageService {
     })
     return {
       fileName,
-      content: { frontMatter, pageBody: content },
+      content: { frontMatter: newFrontMatter, pageBody: newPageContent },
       oldSha: sha,
       newSha,
     }

--- a/src/services/fileServices/MdPageServices/UnlinkedPageService.js
+++ b/src/services/fileServices/MdPageServices/UnlinkedPageService.js
@@ -51,6 +51,10 @@ class UnlinkedPageService {
 
   async update(sessionData, { fileName, content, frontMatter, sha }) {
     const newContent = convertDataToMarkdown(frontMatter, content)
+    const {
+      frontMatter: newFrontMatter,
+      pageContent: newPageContent,
+    } = retrieveDataFromMarkdown(newContent)
     const { newSha } = await this.gitHubService.update(sessionData, {
       fileContent: newContent,
       sha,
@@ -59,7 +63,7 @@ class UnlinkedPageService {
     })
     return {
       fileName,
-      content: { frontMatter, pageBody: content },
+      content: { frontMatter: newFrontMatter, pageBody: newPageContent },
       oldSha: sha,
       newSha,
     }


### PR DESCRIPTION
## Problem
https://opengovproducts.slack.com/archives/CK68JNFHR/p1709007514442959?thread_ts=1708332491.637599&cid=CK68JNFHR

Fixes issue where users see warning modal even after saving changes

Closes [insert issue #]

## Solution
1. updating/saving/syncing state logic is honestly quite convoluted on the FE
2. However, frontend is indeed updating editor content **after** the POST request returns (see `useUpdatePageHook` in `EditPageLayout`)
3. issue is that `/update` endpoints are not returning the updated `frontmatter` and `pageContent` to the client

This seems like the simplest solution to fixing this bug, i.e returning updated `pageContent` to the client



**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests
1. Go to Prod CMS, edit a page to leave trailing whitespace then save changes
2. Click Back on the navbar -> should see the unsaved changes modal
3. Go to Staging CMS, edit a page to leave trailing whitespace then save changes
4. After saving, should see that trailing whitespace is removed from the editor (to match backend)
5. Click Back on the navbar -> should not see the modal

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details
    - [ ] added env var to 1PW + SSM script (`fetch_ssm_parameters.sh`)

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details