### PR TITLE
Fix/add validators

### DIFF
--- a/src/fixtures/sessionData.ts
+++ b/src/fixtures/sessionData.ts
@@ -21,7 +21,7 @@ import {
 export const mockAccessToken = "mockAccessToken"
 export const mockGithubId = "mockGithubId"
 export const mockIsomerUserId = "1"
-export const mockEmail = "mockEmail"
+export const mockEmail = "mockEmail@email.com"
 export const mockTreeSha = "mockTreeSha"
 export const mockCurrentCommitSha = "mockCurrentCommitSha"
 export const mockSiteName = "mockSiteName"

--- a/src/integration/Reviews.spec.ts
+++ b/src/integration/Reviews.spec.ts
@@ -975,9 +975,11 @@ describe("Review Requests Integration Tests", () => {
       )
 
       // Act
-      const actual = await request(app).post(
-        `/${MOCK_REPO_NAME_TWO}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}`
-      )
+      const actual = await request(app)
+        .post(`/${MOCK_REPO_NAME_TWO}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}`)
+        .send({
+          reviewers: [MOCK_USER_EMAIL_THREE],
+        })
 
       // Assert
       expect(actual.statusCode).toEqual(404)
@@ -992,7 +994,11 @@ describe("Review Requests Integration Tests", () => {
       )
 
       // Act
-      const actual = await request(app).post(`/${MOCK_REPO_NAME_ONE}/123456`)
+      const actual = await request(app)
+        .post(`/${MOCK_REPO_NAME_ONE}/123456`)
+        .send({
+          reviewers: [MOCK_USER_EMAIL_THREE],
+        })
 
       // Assert
       expect(actual.statusCode).toEqual(404)
@@ -1007,9 +1013,11 @@ describe("Review Requests Integration Tests", () => {
       )
 
       // Act
-      const actual = await request(app).post(
-        `/${MOCK_REPO_NAME_ONE}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}`
-      )
+      const actual = await request(app)
+        .post(`/${MOCK_REPO_NAME_ONE}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}`)
+        .send({
+          reviewers: [MOCK_USER_EMAIL_THREE],
+        })
 
       // Assert
       expect(actual.statusCode).toEqual(403)
@@ -1078,24 +1086,6 @@ describe("Review Requests Integration Tests", () => {
       })
     })
 
-    it("should close the review request successfully", async () => {
-      // Arrange
-      const app = generateRouterForUserWithSite(
-        subrouter,
-        MOCK_USER_SESSION_DATA_ONE,
-        MOCK_REPO_NAME_ONE
-      )
-      mockGenericAxios.patch.mockResolvedValueOnce(null)
-
-      // Act
-      const actual = await request(app).delete(
-        `/${MOCK_REPO_NAME_ONE}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}`
-      )
-
-      // Assert
-      expect(actual.statusCode).toEqual(200)
-    })
-
     it("should return 404 if site is not found", async () => {
       // Arrange
       const app = generateRouterForUserWithSite(
@@ -1105,7 +1095,7 @@ describe("Review Requests Integration Tests", () => {
       )
 
       // Act
-      const actual = await request(app).post(
+      const actual = await request(app).delete(
         `/${MOCK_REPO_NAME_TWO}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}`
       )
 
@@ -1122,7 +1112,7 @@ describe("Review Requests Integration Tests", () => {
       )
 
       // Act
-      const actual = await request(app).post(`/${MOCK_REPO_NAME_ONE}/123456`)
+      const actual = await request(app).delete(`/${MOCK_REPO_NAME_ONE}/123456`)
 
       // Assert
       expect(actual.statusCode).toEqual(404)
@@ -1137,7 +1127,7 @@ describe("Review Requests Integration Tests", () => {
       )
 
       // Act
-      const actual = await request(app).post(
+      const actual = await request(app).delete(
         `/${MOCK_REPO_NAME_ONE}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}`
       )
 
@@ -1154,12 +1144,30 @@ describe("Review Requests Integration Tests", () => {
       )
 
       // Act
-      const actual = await request(app).post(
+      const actual = await request(app).delete(
         `/${MOCK_REPO_NAME_ONE}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}`
       )
 
       // Assert
       expect(actual.statusCode).toEqual(403)
+    })
+
+    it("should close the review request successfully", async () => {
+      // Arrange
+      const app = generateRouterForUserWithSite(
+        subrouter,
+        MOCK_USER_SESSION_DATA_ONE,
+        MOCK_REPO_NAME_ONE
+      )
+      mockGenericAxios.patch.mockResolvedValueOnce(null)
+
+      // Act
+      const actual = await request(app).delete(
+        `/${MOCK_REPO_NAME_ONE}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}`
+      )
+
+      // Assert
+      expect(actual.statusCode).toEqual(200)
     })
   })
 
@@ -1871,9 +1879,11 @@ describe("Review Requests Integration Tests", () => {
       mockGenericAxios.post.mockResolvedValueOnce(null)
 
       // Act
-      const actual = await request(app).post(
-        `/${MOCK_REPO_NAME_ONE}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}/comments`
-      )
+      const actual = await request(app)
+        .post(
+          `/${MOCK_REPO_NAME_ONE}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}/comments`
+        )
+        .send({ message: "blahblah" })
 
       // Assert
       expect(actual.statusCode).toEqual(200)
@@ -1888,9 +1898,11 @@ describe("Review Requests Integration Tests", () => {
       )
 
       // Act
-      const actual = await request(app).post(
-        `/${MOCK_REPO_NAME_TWO}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}/comments`
-      )
+      const actual = await request(app)
+        .post(
+          `/${MOCK_REPO_NAME_TWO}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}/comments`
+        )
+        .send({ message: "blahblah" })
 
       // Assert
       expect(actual.statusCode).toEqual(404)
@@ -1905,9 +1917,11 @@ describe("Review Requests Integration Tests", () => {
       )
 
       // Act
-      const actual = await request(app).post(
-        `/${MOCK_REPO_NAME_ONE}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}/comments`
-      )
+      const actual = await request(app)
+        .post(
+          `/${MOCK_REPO_NAME_ONE}/${MOCK_GITHUB_PULL_REQUEST_NUMBER}/comments`
+        )
+        .send({ message: "blahblah" })
 
       // Assert
       expect(actual.statusCode).toEqual(404)
@@ -1922,9 +1936,9 @@ describe("Review Requests Integration Tests", () => {
       )
 
       // Act
-      const actual = await request(app).post(
-        `/${MOCK_REPO_NAME_ONE}/123456/comments`
-      )
+      const actual = await request(app)
+        .post(`/${MOCK_REPO_NAME_ONE}/123456/comments`)
+        .send({ message: "blahblah" })
 
       // Assert
       expect(actual.statusCode).toEqual(404)

--- a/src/integration/Users.spec.ts
+++ b/src/integration/Users.spec.ts
@@ -40,7 +40,7 @@ const subrouter = express()
 // that allows us to set this properties also
 subrouter.use((req, res, next) => {
   const userSessionData = new UserSessionData({
-    isomerUserId: req.body.userId,
+    isomerUserId: mockIsomerUserId,
     githubId: req.body.githubId,
     email: req.body.email,
   })
@@ -223,7 +223,6 @@ describe("Users Router", () => {
       const actual = await request(app).post("/email/verifyOtp").send({
         email: mockValidEmail,
         otp,
-        userId: mockIsomerUserId,
       })
       const updatedUser = await User.findOne({
         where: {
@@ -252,7 +251,6 @@ describe("Users Router", () => {
       const actual = await request(app).post("/email/verifyOtp").send({
         email: mockValidEmail,
         otp: wrongOtp,
-        userId: mockIsomerUserId,
       })
 
       // Assert
@@ -274,7 +272,6 @@ describe("Users Router", () => {
       const actual = await request(app).post("/email/verifyOtp").send({
         email: mockValidEmail,
         otp: "",
-        userId: mockIsomerUserId,
       })
 
       // Assert
@@ -296,7 +293,6 @@ describe("Users Router", () => {
       const actual = await request(app).post("/email/verifyOtp").send({
         email: mockValidEmail,
         otp: undefined,
-        userId: mockIsomerUserId,
       })
 
       // Assert
@@ -326,7 +322,6 @@ describe("Users Router", () => {
       const actual = await request(app).post("/email/verifyOtp").send({
         email: mockValidEmail,
         otp,
-        userId: mockIsomerUserId,
       })
       const oldOtp = otp
 
@@ -342,7 +337,6 @@ describe("Users Router", () => {
       const newActual = await request(app).post("/email/verifyOtp").send({
         email: mockValidEmail,
         otp: oldOtp,
-        userId: mockIsomerUserId,
       })
 
       // Assert
@@ -366,7 +360,6 @@ describe("Users Router", () => {
         const actual = await request(app).post("/email/verifyOtp").send({
           email: mockValidEmail,
           otp: mockInvalidOtp,
-          userId: mockIsomerUserId,
         })
         const otpEntry = await Otp.findOne({
           where: { email: mockValidEmail },
@@ -402,7 +395,6 @@ describe("Users Router", () => {
         await request(app).post("/email/verifyOtp").send({
           email: mockValidEmail,
           otp: mockInvalidOtp,
-          userId: mockIsomerUserId,
         })
       }
 
@@ -504,7 +496,6 @@ describe("Users Router", () => {
       const actual = await request(app).post("/mobile/verifyOtp").send({
         mobile: mockValidNumber,
         otp,
-        userId: mockIsomerUserId,
       })
       const updatedUser = await User.findOne({
         where: {
@@ -531,7 +522,6 @@ describe("Users Router", () => {
       const actual = await request(app).post("/mobile/verifyOtp").send({
         mobile: mockValidNumber,
         otp: wrongOtp,
-        userId: mockIsomerUserId,
       })
 
       // Assert
@@ -551,7 +541,6 @@ describe("Users Router", () => {
       const actual = await request(app).post("/mobile/verifyOtp").send({
         mobile: mockValidNumber,
         otp: "",
-        userId: mockIsomerUserId,
       })
 
       // Assert
@@ -571,7 +560,6 @@ describe("Users Router", () => {
       const actual = await request(app).post("/mobile/verifyOtp").send({
         mobile: mockValidNumber,
         otp: undefined,
-        userId: mockIsomerUserId,
       })
 
       // Assert
@@ -596,7 +584,6 @@ describe("Users Router", () => {
       const actual = await request(app).post("/mobile/verifyOtp").send({
         mobile: mockValidNumber,
         otp,
-        userId: mockIsomerUserId,
       })
       const oldOtp = otp
 
@@ -612,7 +599,6 @@ describe("Users Router", () => {
       const newActual = await request(app).post("/mobile/verifyOtp").send({
         mobile: mockValidNumber,
         otp: oldOtp,
-        userId: mockIsomerUserId,
       })
 
       // Assert
@@ -634,7 +620,6 @@ describe("Users Router", () => {
         const actual = await request(app).post("/mobile/verifyOtp").send({
           mobile: mockValidNumber,
           otp: mockInvalidOtp,
-          userId: mockIsomerUserId,
         })
         const otpEntry = await Otp.findOne({
           where: { mobileNumber: mockValidNumber },
@@ -668,7 +653,6 @@ describe("Users Router", () => {
         await request(app).post("/mobile/verifyOtp").send({
           mobile: mockValidNumber,
           otp: mockInvalidOtp,
-          userId: mockIsomerUserId,
         })
       }
 

--- a/src/integration/Users.spec.ts
+++ b/src/integration/Users.spec.ts
@@ -528,6 +528,28 @@ describe("Users Router", () => {
       expect(actual.statusCode).toBe(expected)
     })
 
+    it("should return 400 when the request body format is wrong", async () => {
+      // Arrange
+      const expected = 400
+      const otp = "123456"
+      mockAxios.post.mockResolvedValueOnce(200)
+      await User.create({ id: mockIsomerUserId })
+      await request(app).post("/mobile/otp").send({
+        mobile: mockValidNumber,
+      })
+
+      // Act
+      const actual = await request(app)
+        .post("/mobile/verifyOtp")
+        .send({
+          mobile: [mockValidNumber, "98765432"],
+          otp,
+        })
+
+      // Assert
+      expect(actual.statusCode).toBe(expected)
+    })
+
     it("should return 400 when there is no otp", async () => {
       // Arrange
       const expected = 400

--- a/src/routes/v2/auth.js
+++ b/src/routes/v2/auth.js
@@ -11,6 +11,11 @@ const { attachReadRouteHandlerWrapper } = require("@middleware/routeHandler")
 const FRONTEND_URL = config.get("app.frontendUrl")
 const { isSecure } = require("@utils/auth-utils")
 
+const {
+  EmailSchema,
+  VerifyRequestSchema,
+} = require("@root/validators/RequestSchema")
+
 const CSRF_TOKEN_EXPIRY_MS = 600000
 const CSRF_COOKIE_NAME = "isomer-csrf"
 const COOKIE_NAME = "isomercms"
@@ -76,6 +81,11 @@ class AuthRouter {
 
   async login(req, res) {
     const { email: rawEmail } = req.body
+    const { error } = EmailSchema.validate(rawEmail)
+    if (error)
+      return res.status(400).json({
+        message: `Invalid request format: ${error.message}`,
+      })
     const email = rawEmail.toLowerCase()
     try {
       await this.authService.sendOtp(email)
@@ -90,6 +100,11 @@ class AuthRouter {
 
   async verify(req, res) {
     const { email: rawEmail, otp } = req.body
+    const { error } = VerifyRequestSchema.validate(req.body)
+    if (error)
+      return res.status(400).json({
+        message: `Invalid request format: ${error.message}`,
+      })
     const email = rawEmail.toLowerCase()
     const userInfo = await this.authService.verifyOtp({ email, otp })
     Object.assign(req.session, { userInfo })

--- a/src/routes/v2/authenticated/__tests__/collaborators.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/collaborators.spec.ts
@@ -13,7 +13,7 @@ import { AuthorizationMiddleware } from "@root/middleware/authorization"
 import CollaboratorsService from "@root/services/identity/CollaboratorsService"
 
 describe("Collaborator Router", () => {
-  const MOCK_EMAIL = "mockemail"
+  const MOCK_EMAIL = "mockemail@email.com"
   const MOCK_ACK_VALUE = true
   const mockCollaboratorsService = {
     create: jest.fn(),

--- a/src/routes/v2/authenticated/__tests__/review.spec.ts
+++ b/src/routes/v2/authenticated/__tests__/review.spec.ts
@@ -182,6 +182,7 @@ describe("Review Requests Router", () => {
   })
 
   describe("createReviewRequest", () => {
+    const mockEmail = "mock@test.gov.sg"
     it("should return 200 with the pull request number of the created review request", async () => {
       // Arrange
       const mockPullRequestNumber = 1
@@ -235,7 +236,11 @@ describe("Review Requests Router", () => {
       // Act
       const response = await request(app)
         .post("/mockSite/review/request")
-        .send({})
+        .send({
+          reviewers: [mockEmail],
+          title: "Fake title",
+          description: "",
+        })
 
       // Assert
       expect(response.status).toEqual(404)
@@ -257,7 +262,11 @@ describe("Review Requests Router", () => {
       // Act
       const response = await request(app)
         .post("/mockSite/review/request")
-        .send({})
+        .send({
+          reviewers: [mockEmail],
+          title: "Fake title",
+          description: "",
+        })
 
       // Assert
       expect(response.status).toEqual(404)
@@ -614,10 +623,10 @@ describe("Review Requests Router", () => {
   })
 
   describe("updateReviewRequest", () => {
+    const mockReviewer = "reviewer@test.gov.sg"
     it("should return 200 with the updated review request", async () => {
       // Arrange
       const mockReviewRequest = { requestor: { email: MOCK_USER_EMAIL_ONE } }
-      const mockReviewer = "reviewer@test.gov.sg"
 
       mockReviewRequestService.getReviewRequest.mockResolvedValueOnce(
         mockReviewRequest
@@ -659,7 +668,11 @@ describe("Review Requests Router", () => {
       )
 
       // Act
-      const response = await request(app).post(`/mockSite/review/12345`)
+      const response = await request(app)
+        .post(`/mockSite/review/12345`)
+        .send({
+          reviewers: [mockReviewer],
+        })
 
       // Assert
       expect(response.status).toEqual(404)
@@ -679,7 +692,11 @@ describe("Review Requests Router", () => {
       )
 
       // Act
-      const response = await request(app).post(`/mockSite/review/12345`)
+      const response = await request(app)
+        .post(`/mockSite/review/12345`)
+        .send({
+          reviewers: [mockReviewer],
+        })
 
       // Assert
       expect(response.status).toEqual(404)
@@ -700,7 +717,11 @@ describe("Review Requests Router", () => {
       )
 
       // Act
-      const response = await request(app).post(`/mockSite/review/12345`)
+      const response = await request(app)
+        .post(`/mockSite/review/12345`)
+        .send({
+          reviewers: [mockReviewer],
+        })
 
       // Assert
       expect(response.status).toEqual(403)
@@ -1274,7 +1295,7 @@ describe("Review Requests Router", () => {
       expect(mockNotificationsService.create).not.toHaveBeenCalled()
     })
 
-    it("should return 404 if the user is not the requestor of the review request", async () => {
+    it("should return 403 if the user is not the requestor of the review request", async () => {
       // Arrange
       const mockReviewRequest = { requestor: { email: "other@test.gov.sg" } }
 
@@ -1286,7 +1307,7 @@ describe("Review Requests Router", () => {
       const response = await request(app).delete(`/mockSite/review/12345`)
 
       // Assert
-      expect(response.status).toEqual(404)
+      expect(response.status).toEqual(403)
       expect(mockSitesService.getBySiteName).toHaveBeenCalledTimes(1)
       expect(mockReviewRequestService.getReviewRequest).toHaveBeenCalledTimes(1)
       expect(mockReviewRequestService.closeReviewRequest).not.toHaveBeenCalled()

--- a/src/routes/v2/authenticated/collaborators.ts
+++ b/src/routes/v2/authenticated/collaborators.ts
@@ -13,6 +13,7 @@ import { attachSiteHandler } from "@root/middleware"
 import { RouteCheckerMiddleware } from "@root/middleware/routeChecker"
 import { RequestHandler } from "@root/types"
 import { UserDto } from "@root/types/dto/review"
+import { CreateCollaboratorRequestSchema } from "@root/validators/RequestSchema"
 import CollaboratorsService from "@services/identity/CollaboratorsService"
 
 interface CollaboratorsRouterProps {
@@ -43,6 +44,11 @@ export class CollaboratorsRouter {
     { userWithSiteSessionData: UserWithSiteSessionData }
   > = async (req, res) => {
     const { email, acknowledge = false } = req.body
+    const { error } = CreateCollaboratorRequestSchema.validate(req.body)
+    if (error)
+      return res.status(400).json({
+        message: `Invalid request format: ${error.message}`,
+      })
     const { siteName } = req.params
     const { userWithSiteSessionData } = res.locals
     logger.info(

--- a/src/routes/v2/authenticated/metrics.ts
+++ b/src/routes/v2/authenticated/metrics.ts
@@ -5,6 +5,7 @@ import { ISOMER_ADMIN_EMAIL } from "@root/constants"
 import { mailer } from "@root/services/utilServices/MailClient"
 import { RequestHandler } from "@root/types"
 import { FeedbackDto } from "@root/types/dto/feedback"
+import { CollateUserFeedbackRequestSchema } from "@root/validators/RequestSchema"
 import { statsService } from "@services/infra/StatsService"
 
 const getFeedbackHtml = ({
@@ -30,6 +31,11 @@ export class MetricsRouter {
     { userWithSiteSessionData: UserWithSiteSessionData }
   > = (req, res) => {
     const { userType } = req.body
+    const { error } = CollateUserFeedbackRequestSchema.validate(req.body)
+    if (error)
+      return res.status(400).json({
+        message: `Invalid request format: ${error.message}`,
+      })
     mailer.sendMail(
       ISOMER_ADMIN_EMAIL,
       "[METRICS] User feedback",

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -31,6 +31,11 @@ import {
   BlobDiffDto,
   EditedItemDto,
 } from "@root/types/dto/review"
+import {
+  CreateCommentSchema,
+  CreateReviewRequestSchema,
+  UpdateReviewRequestSchema,
+} from "@root/validators/RequestSchema"
 import ReviewRequestService from "@services/review/ReviewRequestService"
 // eslint-disable-next-line import/prefer-default-export
 export class ReviewsRouter {
@@ -147,6 +152,11 @@ export class ReviewsRouter {
     unknown,
     { userWithSiteSessionData: UserWithSiteSessionData }
   > = async (req, res) => {
+    const { error } = CreateReviewRequestSchema.validate(req.body)
+    if (error)
+      return res.status(400).json({
+        message: `Invalid request format: ${error.message}`,
+      })
     // Step 1: Check that the site exists
     const { siteName } = req.params
     const site = await this.sitesService.getBySiteName(siteName)
@@ -566,6 +576,11 @@ export class ReviewsRouter {
     unknown,
     { userWithSiteSessionData: UserWithSiteSessionData }
   > = async (req, res) => {
+    const { error } = UpdateReviewRequestSchema.validate(req.body)
+    if (error)
+      return res.status(400).json({
+        message: `Invalid request format: ${error.message}`,
+      })
     // Step 1: Check that the site exists
     const { siteName, requestId } = req.params
     const { userWithSiteSessionData } = res.locals
@@ -959,6 +974,11 @@ export class ReviewsRouter {
     unknown,
     { userWithSiteSessionData: UserWithSiteSessionData }
   > = async (req, res) => {
+    const { error } = CreateCommentSchema.validate(req.body)
+    if (error)
+      return res.status(400).json({
+        message: `Invalid request format: ${error.message}`,
+      })
     const { siteName, requestId } = req.params
     const { message } = req.body
     const { userWithSiteSessionData } = res.locals
@@ -1152,7 +1172,7 @@ export class ReviewsRouter {
           requestId,
         },
       })
-      return res.status(404).json({
+      return res.status(403).json({
         message: "Only the requestor can close the Review Request!",
       })
     }

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -21,6 +21,10 @@ import { RepositoryData } from "@root/types/repoInfo"
 import { BrokenLinkErrorDto } from "@root/types/siteChecker"
 import { SiteInfo, SiteLaunchDto } from "@root/types/siteInfo"
 import { StagingBuildStatus } from "@root/types/stagingBuildStatus"
+import {
+  GetPreviewInfoSchema,
+  LaunchSiteSchema,
+} from "@root/validators/RequestSchema"
 import type SitesService from "@services/identity/SitesService"
 
 type SitesRouterProps = {
@@ -137,6 +141,11 @@ export class SitesRouter {
     never,
     { userWithSiteSessionData: UserWithSiteSessionData }
   > = (req, res) => {
+    const { error } = LaunchSiteSchema.validate(req.body)
+    if (error)
+      return res.status(400).json({
+        message: `Invalid request format: ${error.message}`,
+      })
     const { userWithSiteSessionData } = res.locals
     const { email } = userWithSiteSessionData
     // Note, launching the site is an async operation,
@@ -173,10 +182,16 @@ export class SitesRouter {
     { sites: string[]; email: string },
     never,
     { userSessionData: UserSessionData }
-  > = async (req, res) =>
-    this.sitesService
+  > = async (req, res) => {
+    const { error } = GetPreviewInfoSchema.validate(req.body)
+    if (error)
+      return res.status(400).json({
+        message: `Invalid request format: ${error.message}`,
+      })
+    return this.sitesService
       .getSitesPreview(req.body.sites, res.locals.userSessionData)
       .then((previews) => res.status(200).json(previews))
+  }
 
   getUserStagingSiteBuildStatus: RequestHandler<
     { siteName: string },

--- a/src/routes/v2/authenticated/users.ts
+++ b/src/routes/v2/authenticated/users.ts
@@ -11,6 +11,10 @@ import { attachReadRouteHandlerWrapper } from "@middleware/routeHandler"
 import UserSessionData from "@classes/UserSessionData"
 
 import { isError, RequestHandler } from "@root/types"
+import {
+  VerifyEmailOtpSchema,
+  VerifyMobileNumberOtpSchema,
+} from "@root/validators/RequestSchema"
 import UsersService from "@services/identity/UsersService"
 
 interface UsersRouterProps {
@@ -66,6 +70,11 @@ export class UsersRouter {
     { userSessionData: UserSessionData }
   > = async (req, res) => {
     const { email, otp } = req.body
+    const { error } = VerifyEmailOtpSchema.validate(req.body)
+    if (error)
+      return res.status(400).json({
+        message: `Invalid request format: ${error.message}`,
+      })
     const { userSessionData } = res.locals
     const userId = userSessionData.isomerUserId
     const parsedEmail = email.toLowerCase()
@@ -101,6 +110,14 @@ export class UsersRouter {
     { userSessionData: UserSessionData }
   > = async (req, res) => {
     const { mobile, otp } = req.body
+    if (!mobile || !validator.isMobilePhone(mobile)) {
+      throw new BadRequestError("Please provide a valid mobile number")
+    }
+    const { error } = VerifyMobileNumberOtpSchema.validate(req.body)
+    if (error)
+      return res.status(400).json({
+        message: `Invalid request format: ${error.message}`,
+      })
     const { userSessionData } = res.locals
     const userId = userSessionData.isomerUserId
 

--- a/src/routes/v2/authenticated/users.ts
+++ b/src/routes/v2/authenticated/users.ts
@@ -110,14 +110,14 @@ export class UsersRouter {
     { userSessionData: UserSessionData }
   > = async (req, res) => {
     const { mobile, otp } = req.body
-    if (!mobile || !validator.isMobilePhone(mobile)) {
-      throw new BadRequestError("Please provide a valid mobile number")
-    }
     const { error } = VerifyMobileNumberOtpSchema.validate(req.body)
     if (error)
       return res.status(400).json({
         message: `Invalid request format: ${error.message}`,
       })
+    if (!mobile || !validator.isMobilePhone(mobile)) {
+      throw new BadRequestError("Please provide a valid mobile number")
+    }
     const { userSessionData } = res.locals
     const userId = userSessionData.isomerUserId
 

--- a/src/routes/v2/authenticatedSites/repoManagement.ts
+++ b/src/routes/v2/authenticatedSites/repoManagement.ts
@@ -11,6 +11,7 @@ import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import GitFileSystemError from "@root/errors/GitFileSystemError"
 import { attachSiteHandler } from "@root/middleware"
 import type { RequestHandler } from "@root/types"
+import { ResetRepoSchema } from "@root/validators/RequestSchema"
 import RepoManagementService from "@services/admin/RepoManagementService"
 
 interface RepoManagementRouterProps {
@@ -41,6 +42,11 @@ export class RepoManagementRouter {
   > = async (req, res) => {
     const { userWithSiteSessionData } = res.locals
     const { branchName, commitSha } = req.body
+    const { error } = ResetRepoSchema.validate(req.body)
+    if (error)
+      return res.status(400).json({
+        message: `Invalid request format: ${error.message}`,
+      })
 
     return this.repoManagementService
       .resetRepo(userWithSiteSessionData, branchName, commitSha)

--- a/src/routes/v2/sgidAuth.ts
+++ b/src/routes/v2/sgidAuth.ts
@@ -20,6 +20,7 @@ import { RequestHandler } from "@root/types"
 import { ResponseErrorBody } from "@root/types/dto/error"
 import { isPublicOfficerData, PublicOfficerData } from "@root/types/sgid"
 import { isSecure } from "@root/utils/auth-utils"
+import { EmailSchema } from "@root/validators/RequestSchema"
 import UsersService from "@services/identity/UsersService"
 import SgidAuthService from "@services/utilServices/SgidAuthService"
 
@@ -167,6 +168,11 @@ export class SgidAuthRouter {
     never
   > = async (req, res) => {
     const { email } = req.body
+    const { error } = EmailSchema.validate(email)
+    if (error)
+      return res.status(400).json({
+        message: `Invalid request format: ${error.message}`,
+      })
     const token = req.cookies[SGID_MULTIUSER_COOKIE_NAME]
     res.clearCookie(SGID_MULTIUSER_COOKIE_NAME, { path: "/" })
 

--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -478,12 +478,12 @@ const GetPreviewInfoSchema = Joi.object().keys({
 
 const VerifyEmailOtpSchema = Joi.object().keys({
   email: EmailSchema,
-  otp: Joi.string().required(),
+  otp: Joi.string().length(6).required(),
 })
 
 const VerifyMobileNumberOtpSchema = Joi.object().keys({
   mobile: Joi.string().required(),
-  otp: Joi.string().required(),
+  otp: Joi.string().length(6).required(),
 })
 
 const ResetRepoSchema = Joi.object().keys({

--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -6,6 +6,9 @@ const {
   MAX_TEXTCARDS_CARDS,
   MAX_INFOCOLS_BOXES,
 } = require("@root/constants")
+const { UserTypes } = require("@root/types/user")
+
+const EmailSchema = Joi.string().email().required()
 
 const FileSchema = Joi.object().keys({
   name: Joi.string().required(),
@@ -435,7 +438,61 @@ const UpdateRepoPasswordRequestSchema = Joi.object().keys({
   enablePassword: Joi.boolean().required(),
 })
 
+const VerifyRequestSchema = Joi.object().keys({
+  email: EmailSchema,
+  otp: Joi.string().required(),
+})
+
+const CreateCollaboratorRequestSchema = Joi.object().keys({
+  email: EmailSchema,
+  acknowledge: Joi.boolean().optional(),
+})
+
+const CollateUserFeedbackRequestSchema = Joi.object().keys({
+  userType: Joi.string().valid(...Object.values(UserTypes)),
+})
+
+const CreateReviewRequestSchema = Joi.object().keys({
+  reviewers: Joi.array().items(Joi.string()).required(),
+  title: Joi.string().required(),
+  description: Joi.string().allow(""),
+})
+
+const UpdateReviewRequestSchema = Joi.object().keys({
+  reviewers: Joi.array().items(Joi.string()).required(),
+})
+
+const CreateCommentSchema = Joi.object().keys({
+  message: Joi.string().required(),
+})
+
+const LaunchSiteSchema = Joi.object().keys({
+  siteUrl: Joi.string().required(),
+  useWwwSubdomain: Joi.boolean().required(),
+})
+
+const GetPreviewInfoSchema = Joi.object().keys({
+  sites: Joi.array().items(Joi.string()).required(),
+  email: EmailSchema,
+})
+
+const VerifyEmailOtpSchema = Joi.object().keys({
+  email: EmailSchema,
+  otp: Joi.string().required(),
+})
+
+const VerifyMobileNumberOtpSchema = Joi.object().keys({
+  mobile: Joi.string().required(),
+  otp: Joi.string().required(),
+})
+
+const ResetRepoSchema = Joi.object().keys({
+  branchName: Joi.string().required(),
+  commitSha: Joi.string().required(),
+})
+
 module.exports = {
+  EmailSchema,
   UpdateContactUsSchema,
   UpdateHomepageSchema,
   CreatePageRequestSchema,
@@ -461,4 +518,15 @@ module.exports = {
   UpdateNavigationRequestSchema,
   UpdateSettingsRequestSchema,
   UpdateRepoPasswordRequestSchema,
+  VerifyRequestSchema,
+  CreateCollaboratorRequestSchema,
+  CollateUserFeedbackRequestSchema,
+  CreateReviewRequestSchema,
+  UpdateReviewRequestSchema,
+  CreateCommentSchema,
+  LaunchSiteSchema,
+  GetPreviewInfoSchema,
+  VerifyEmailOtpSchema,
+  VerifyMobileNumberOtpSchema,
+  ResetRepoSchema,
 }


### PR DESCRIPTION
## Problem

This PR adds validation for request bodies to several endpoints which did not have this implemented. It also modifies our existing tests to work with the new validation.

## Tests
Check that the following endpoints do not throw an error from validation:

- [ ] Create collaborator
- [ ] Feedback
- [ ] Create Review Request
- [ ] Update review request
- [ ] Create Comment
- [ ] Launch site
- [ ] get preview info
- [ ] Verify email otp
- [ ] Verify mobile otp
  - [ ] Specifically, verify that the `/mobile/verifyOtp` endpoint no longer accepts an array for `mobile`
- [ ] Reset repo
- [ ] Sgid login