### PR TITLE
fix(redir): add in other 2 records

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -401,14 +401,6 @@ const config = convict({
       default: false,
     },
   },
-  redirectionServer: {
-    elasticIp: {
-      doc: "Elastic IP of the redirection server",
-      env: "REDIRECTION_SERVER_ELASTIC_IP",
-      format: String,
-      default: "18.136.36.203",
-    },
-  },
   netlify: {
     accessToken: {
       doc: "Access token for netlify actions",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -71,7 +71,12 @@ export const ISOMER_E2E_TEST_REPOS = [
 
 export const INACTIVE_USER_THRESHOLD_DAYS = 60
 export const GITHUB_ORG_REPOS_ENDPOINT = `https://api.github.com/orgs/${ISOMER_GITHUB_ORG_NAME}/repos`
-export const REDIRECTION_SERVER_IP = config.get("redirectionServer.elasticIp")
+
+export const REDIRECTION_SERVER_IPS = [
+  "18.136.36.203",
+  "18.138.108.8",
+  "18.139.47.66",
+]
 export const DNS_INDIRECTION_DOMAIN = "hostedon.isomer.gov.sg"
 export const DNS_INDIRECTION_REPO = "isomer-indirection"
 export const ISOMER_ADMIN_EMAIL = "admin@isomer.gov.sg"

--- a/src/services/identity/LaunchesService.ts
+++ b/src/services/identity/LaunchesService.ts
@@ -13,7 +13,7 @@ import {
   JobStatus,
   RedirectionTypes,
   SiteStatus,
-  REDIRECTION_SERVER_IP,
+  REDIRECTION_SERVER_IPS,
 } from "@root/constants/constants"
 import SiteLaunchError from "@root/errors/SiteLaunchError"
 import { AmplifyError } from "@root/types/index"
@@ -217,13 +217,11 @@ export class LaunchesService {
           type: RedirectionTypes.CNAME,
         },
         ...(doesRedirectionRecordExist
-          ? [
-              {
-                source: redirectionRecord.value.source,
-                target: REDIRECTION_SERVER_IP,
-                type: RedirectionTypes.A,
-              },
-            ]
+          ? REDIRECTION_SERVER_IPS.map((ip) => ({
+              source: redirectionRecord.value!.source, // safe as we check for existence above
+              target: ip,
+              type: RedirectionTypes.A,
+            }))
           : []),
       ],
     })

--- a/src/services/infra/InfraService.ts
+++ b/src/services/infra/InfraService.ts
@@ -21,7 +21,7 @@ import {
   SiteStatus,
   JobStatus,
   RedirectionTypes,
-  REDIRECTION_SERVER_IP,
+  REDIRECTION_SERVER_IPS,
   ISOMER_SUPPORT_EMAIL,
   DNS_INDIRECTION_DOMAIN,
 } from "@root/constants"
@@ -543,7 +543,9 @@ export default class InfraService {
 
       if (redirectionDomainList?.length) {
         newLaunchParams.redirectionDomainSource = `www.${primaryDomain}` // we only support 'www' redirections for now
-        newLaunchParams.redirectionDomainTarget = REDIRECTION_SERVER_IP
+        // any IP is ok
+        const [redirectionServerIp] = REDIRECTION_SERVER_IPS
+        newLaunchParams.redirectionDomainTarget = redirectionServerIp
       }
 
       // Create launches records table
@@ -565,12 +567,12 @@ export default class InfraService {
       }
 
       if (newLaunchParams.redirectionDomainSource) {
-        const redirectionDomainObject = {
-          source: newLaunchParams.primaryDomainSource,
-          target: REDIRECTION_SERVER_IP,
+        const redirectionDomainObject = REDIRECTION_SERVER_IPS.map((ip) => ({
+          source: newLaunchParams.redirectionDomainSource as string, // checked above
+          target: ip,
           type: RedirectionTypes.A,
-        }
-        message.redirectionDomain = [redirectionDomainObject]
+        }))
+        message.redirectionDomain = redirectionDomainObject
       }
 
       await this.dynamoDBService.createItem(message)

--- a/src/services/utilServices/SendDNSRecordEmailClient.ts
+++ b/src/services/utilServices/SendDNSRecordEmailClient.ts
@@ -1,5 +1,6 @@
 import { groupBy } from "lodash"
 
+import { REDIRECTION_SERVER_IPS } from "@root/constants"
 import { DigType } from "@root/types/dig"
 
 export interface DigDNSRecord {
@@ -72,7 +73,7 @@ export function getDNSRecordsEmailBody(
 
     html += `<tr style="${headerRowStyle}">
           <td style="${repoNameStyle}" rowspan="${
-      hasRedirection ? 4 : 3
+      hasRedirection ? 3 + REDIRECTION_SERVER_IPS.length : 3
     }">${repoName}</td>
         </tr>`
     groupedDnsRecords[repoName].forEach((dnsRecords) => {
@@ -95,13 +96,15 @@ export function getDNSRecordsEmailBody(
         </tr>`
 
       if (hasRedirection) {
-        html += `
+        for (let i = 0; i < REDIRECTION_SERVER_IPS.length; i += 1) {
+          html += `
           <tr style="${tdStyle}">
             <td style="${tdStyle}">${dnsRecords.primaryDomainSource}</td>
-            <td style="${tdStyle}">${dnsRecords.redirectionDomainTarget}</td>
+            <td style="${tdStyle}">${REDIRECTION_SERVER_IPS[i]}</td>
             <td style="${tdStyle}">A Record</td>
           </tr>
         `
+        }
       }
     })
   })

--- a/src/types/siteLaunch.ts
+++ b/src/types/siteLaunch.ts
@@ -31,13 +31,11 @@ export interface SiteLaunchMessage {
   requestorEmail: string
   agencyEmail: string
   githubRedirectionUrl?: string
-  redirectionDomain?: [
-    {
-      source: string
-      target: string
-      type: string
-    }
-  ]
+  redirectionDomain?: {
+    source: string
+    target: string
+    type: string
+  }[]
   status?: SiteLaunchStatus
   statusMetadata?: string
 }


### PR DESCRIPTION
## Problem

ops has been doing this manually, we want to add this as part of sl process for a more resilient redirection service

## Solution

add in the two records
this also changes the shape of the site launch message, this has been updated in the infra pr [here](https://github.com/isomerpages/isomer-infra/pull/66) 

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)


- Details ...

## Before & After Screenshots

**BEFORE**:
<img width="869" alt="Screenshot 2024-03-12 at 8 17 56 AM" src="https://github.com/isomerpages/isomercms-backend/assets/42832651/189c0f46-c2f5-41fa-9dbc-0247dbbebf0f">



**AFTER**:
![Screenshot 2024-03-12 at 8 16 58 AM](https://github.com/isomerpages/isomercms-backend/assets/42832651/9cfea64d-e5f5-40ad-9df2-7e89611ac78d)



## Manual Local Tests
- [ ] add these lines of code in your server.js
```
const formResponses = [
  {
    submissionId: "",
    requesterEmail: "kishore@open.gov.sg",
    repoName: "kishore-test",
    primaryDomain: "yahoo.com",
    redirectionDomain: "isomer.gov.sg",
    agencyEmail: "kishore@open.gov.sg",
  },
]

formsgSiteLaunchRouter.handleSiteLaunchResults(formResponses, "test")
```

![Screenshot 2024-03-12 at 8 28 56 AM](https://github.com/isomerpages/isomercms-backend/assets/42832651/8d255194-7dc5-4303-9e97-1fc793ba952f)
