### PR TITLE
feat(auditlogs): add relevant GitHub link for each audit log entry

### DIFF
--- a/src/services/admin/__tests__/AuditLogsService.spec.ts
+++ b/src/services/admin/__tests__/AuditLogsService.spec.ts
@@ -1,0 +1,181 @@
+import DatabaseError from "@root/errors/DatabaseError"
+import _AuditLogsService from "@services/admin/AuditLogsService"
+import CollaboratorsService from "@services/identity/CollaboratorsService"
+import IsomerAdminsService from "@services/identity/IsomerAdminsService"
+import NotificationsService from "@services/identity/NotificationsService"
+import SitesService from "@services/identity/SitesService"
+import UsersService from "@services/identity/UsersService"
+import ReviewRequestService from "@services/review/ReviewRequestService"
+
+const MockCollaboratorsService = {
+  getRole: jest.fn(),
+}
+
+const MockIsomerAdminsService = {
+  isUserIsomerAdmin: jest.fn(),
+}
+
+const MockNotificationsService = {
+  findAllForSite: jest.fn(),
+}
+
+const MockReviewRequestService = {
+  getReviewRequest: jest.fn(),
+}
+
+const MockSitesService = {
+  getBySiteName: jest.fn(),
+}
+
+const MockUsersService = {
+  findById: jest.fn(),
+  findByGitHubId: jest.fn(),
+  findByEmail: jest.fn(),
+}
+
+const AuditLogsService = new _AuditLogsService({
+  collaboratorsService: (MockCollaboratorsService as unknown) as CollaboratorsService,
+  isomerAdminsService: (MockIsomerAdminsService as unknown) as IsomerAdminsService,
+  notificationsService: (MockNotificationsService as unknown) as NotificationsService,
+  reviewRequestService: (MockReviewRequestService as unknown) as ReviewRequestService,
+  sitesService: (MockSitesService as unknown) as SitesService,
+  usersService: (MockUsersService as unknown) as UsersService,
+})
+
+describe("AuditLogsService", () => {
+  // Prevent inter-test pollution of mocks
+  afterEach(() => jest.clearAllMocks())
+
+  describe("getAuditLogActorNameFromId", () => {
+    it("should get the correct actor email address for a given user ID", async () => {
+      const mockUserEmail = "email@domain.com"
+
+      MockIsomerAdminsService.isUserIsomerAdmin.mockResolvedValueOnce(false)
+      MockUsersService.findById.mockResolvedValueOnce({
+        email: mockUserEmail,
+      })
+
+      const result = await AuditLogsService.getAuditLogActorNameFromId("userId")
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual(mockUserEmail)
+    })
+
+    it("should return an error with false if the user is not found", async () => {
+      MockIsomerAdminsService.isUserIsomerAdmin.mockResolvedValueOnce(false)
+      MockUsersService.findById.mockResolvedValueOnce(null)
+
+      const result = await AuditLogsService.getAuditLogActorNameFromId("userId")
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBe(false)
+    })
+
+    it("should return a DatabaseError if UsersService is not able to get the user", async () => {
+      MockIsomerAdminsService.isUserIsomerAdmin.mockResolvedValueOnce(false)
+      MockUsersService.findById.mockRejectedValueOnce(new Error())
+
+      const result = await AuditLogsService.getAuditLogActorNameFromId("userId")
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
+    })
+
+    it("should show as Isomer Admin if the user is an Isomer Admin", async () => {
+      MockIsomerAdminsService.isUserIsomerAdmin.mockResolvedValueOnce(true)
+
+      const result = await AuditLogsService.getAuditLogActorNameFromId("userId")
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual("Isomer Admin")
+    })
+
+    it("should get the correct actor email address even if IsomerAdminsService is not able to get the user's IsomerAdmin status", async () => {
+      const mockUserEmail = "email@domain.com"
+
+      MockIsomerAdminsService.isUserIsomerAdmin.mockRejectedValueOnce(
+        new Error()
+      )
+      MockUsersService.findById.mockResolvedValueOnce({
+        email: mockUserEmail,
+      })
+
+      const result = await AuditLogsService.getAuditLogActorNameFromId("userId")
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual(mockUserEmail)
+    })
+  })
+
+  describe("getAuditLogActorNameFromGitHubId", () => {
+    it("should get the correct actor email address for the given GitHub ID", async () => {
+      const mockUserEmail = "email@domain.com"
+
+      MockUsersService.findByGitHubId.mockResolvedValueOnce({
+        id: "userId",
+        email: mockUserEmail,
+      })
+      MockIsomerAdminsService.isUserIsomerAdmin.mockResolvedValueOnce(false)
+
+      const result = await AuditLogsService.getAuditLogActorNameFromGitHubId(
+        "githubId"
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual(mockUserEmail)
+    })
+
+    it("should show as Isomer Admin if the user is an Isomer Admin", async () => {
+      MockUsersService.findByGitHubId.mockResolvedValueOnce({
+        id: "userId",
+      })
+      MockIsomerAdminsService.isUserIsomerAdmin.mockResolvedValueOnce(true)
+
+      const result = await AuditLogsService.getAuditLogActorNameFromGitHubId(
+        "githubId"
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual("Isomer Admin")
+    })
+
+    it("should return a DatabaseError if IsomerAdminsService is not able to get the user's IsomerAdmin status", async () => {
+      MockUsersService.findByGitHubId.mockResolvedValueOnce({
+        id: "userId",
+      })
+      MockIsomerAdminsService.isUserIsomerAdmin.mockRejectedValueOnce(
+        new Error()
+      )
+
+      const result = await AuditLogsService.getAuditLogActorNameFromGitHubId(
+        "userId"
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
+    })
+
+    it("should return an error with false if the user is not found", async () => {
+      MockUsersService.findByGitHubId.mockResolvedValueOnce(null)
+      MockIsomerAdminsService.isUserIsomerAdmin.mockResolvedValueOnce(false)
+
+      const result = await AuditLogsService.getAuditLogActorNameFromGitHubId(
+        "githubId"
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBe(false)
+    })
+
+    it("should return a DatabaseError if UsersService is not able to get the user", async () => {
+      MockUsersService.findByGitHubId.mockRejectedValueOnce(new Error())
+
+      const result = await AuditLogsService.getAuditLogActorNameFromGitHubId(
+        "githubId"
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
+    })
+  })
+})

--- a/src/types/auditLog.ts
+++ b/src/types/auditLog.ts
@@ -16,4 +16,5 @@ export type AuditLog = {
   actor: string
   page: string
   remarks: string
+  link?: string
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The CSV file is very limiting and is very difficult for users to tell exactly what changed from the commit message.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Add a link to the relevant GitHub item (either commit or PR) for users to find out more information about the individual audit log items.
- Also added some basic unit tests for some of the supporting functionality. The core functionality remains untested as it is still subject to change.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Fill in the form for staging to get the audit logs for a valid test site
- [ ] Verify that the link columns show up links to the respective GitHub commit or PR

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

_None_