### PR TITLE
tests: fix failing auth test

### DIFF
--- a/src/routes/v2/__tests__/Auth.spec.js
+++ b/src/routes/v2/__tests__/Auth.spec.js
@@ -1,5 +1,6 @@
 const express = require("express")
 const session = require("express-session")
+const { okAsync } = require("neverthrow")
 const request = require("supertest")
 
 const { config } = require("@config/config")
@@ -118,9 +119,11 @@ describe("Unlinked Pages Router", () => {
   })
   describe("verify", () => {
     const mockOtp = "123456"
-    mockAuthService.verifyOtp.mockImplementationOnce(() => ({
-      email: mockEmail,
-    }))
+    mockAuthService.verifyOtp.mockImplementationOnce(() =>
+      okAsync({
+        email: mockEmail,
+      })
+    )
     it("adds the cookie on login", async () => {
       mockAuthService.getAuthRedirectDetails.mockResolvedValueOnce(cookieToken)
       await request(app)

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -133,7 +133,7 @@ describe("GitFileSystemService", () => {
       const actual = result
         ._unsafeUnwrap()
         .sort((a, b) => a.name.localeCompare(b.name))
-      console.log(actual)
+
       expect(actual).toMatchObject([
         expectedAnotherFakeDir,
         expectedAnotherFakeFile,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The Auth test is failing due to a change in the return type.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Fixed the return type of the mock implementation.
- Also removed an extra console.log to avoid flooding the terminal.

## Tests

<!-- What tests should be run to confirm functionality? -->

No tests, just make sure CI passes.

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

_None_