### PR TITLE
feat(pino): add logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "papaparse": "^5.4.1",
         "pg": "^8.6.0",
         "pg-connection-string": "^2.5.0",
+        "pino": "^8.19.0",
         "query-string": "^6.14.1",
         "reflect-metadata": "^0.1.13",
         "sequelize": "^6.29.0",
@@ -5297,6 +5298,17 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -5686,6 +5698,14 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/auto-bind": {
@@ -9190,6 +9210,14 @@
       "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.3.tgz",
       "integrity": "sha512-8qz9nOz5VeD2z96elrEKD2U433+L3DWdUdDkOINLGOJvx1GsMBbMn0aCeu28y8/e85A6mCigBiFlYMnTBEGlSw=="
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -9502,6 +9530,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-redact": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.4.0.tgz",
+      "integrity": "sha512-2gwPvyna0zwBdxKnng1suu/dTL5s8XEy2ZqH8mwDUwJdDkV8w5kp+JV26mupdK68HmPMbm6yjW9m7/Ys/BHEHg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -14980,6 +15016,14 @@
         "node": "^10.13.0 || >=12.0.0"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -15456,6 +15500,106 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.19.0.tgz",
+      "integrity": "sha512-oswmokxkav9bADfJ2ifrvfHUwad6MLp73Uat0IkQWY3iAw5xTRoznXbXksZs8oaOUMpmhVWD+PZogNzllWpJaA==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.1.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
+      "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/pino-abstract-transport/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+    },
     "node_modules/pirates": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
@@ -15619,10 +15763,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -15829,6 +15986,11 @@
         }
       ]
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+    },
     "node_modules/random-bytes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
@@ -15950,6 +16112,14 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/reflect-metadata": {
@@ -16846,6 +17016,14 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/sonic-boom": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.0.tgz",
+      "integrity": "sha512-ybz6OYOUjoQQCQ/i4LU8kaToD8ACtYP+Cj5qd2AO36bwbdewxWJ3ArmJ2cr6AvxlL2o0PqnCcPGUgkILbfkaCA==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -17568,6 +17746,14 @@
       "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
       "engines": {
         "node": ">=0.2.6"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.4.1.tgz",
+      "integrity": "sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/throat": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "pg": "^8.6.0",
         "pg-connection-string": "^2.5.0",
         "pino": "^8.19.0",
+        "pino-pretty": "^10.3.1",
         "query-string": "^6.14.1",
         "reflect-metadata": "^0.1.13",
         "sequelize": "^6.29.0",
@@ -8011,6 +8012,14 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/dc-polyfill": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.3.tgz",
@@ -8439,7 +8448,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -9486,6 +9494,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10374,6 +10387,11 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="
     },
     "node_modules/hexoid": {
       "version": "1.0.0",
@@ -13513,6 +13531,14 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-base64": {
       "version": "3.7.6",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.6.tgz",
@@ -14345,7 +14371,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -15595,6 +15620,100 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/pino-pretty": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
+      "integrity": "sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
+    },
+    "node_modules/pino-pretty/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/pino-pretty/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/pino-std-serializers": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
@@ -15891,7 +16010,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -16470,6 +16588,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -17342,7 +17465,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "pg": "^8.6.0",
     "pg-connection-string": "^2.5.0",
     "pino": "^8.19.0",
+    "pino-pretty": "^10.3.1",
     "query-string": "^6.14.1",
     "reflect-metadata": "^0.1.13",
     "sequelize": "^6.29.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "papaparse": "^5.4.1",
     "pg": "^8.6.0",
     "pg-connection-string": "^2.5.0",
+    "pino": "^8.19.0",
     "query-string": "^6.14.1",
     "reflect-metadata": "^0.1.13",
     "sequelize": "^6.29.0",

--- a/src/logger/console.logger.ts
+++ b/src/logger/console.logger.ts
@@ -1,38 +1,15 @@
+import pino from "pino"
+
+import { PINO_OPTIONS } from "./constants"
 import { ExtendedLogger } from "./logger.types"
 
-// NOTE: See [here](https://talyian.github.io/ansicolors/)
-// for an overview of the color codes.
-// Do note that this functions by having the form:
-// `{color code}{message}{reset code}`
-// where %s is where the message gets injected
-const COLORS = {
-  FOREGROUND: {
-    RED: "\x1b[31m%s\x1b[0m",
-    GREEN: "\x1b[32m%s\x1b[0m",
-    YELLOW: "\x1b[33m%s\x1b[0m",
-    BLUE: "\x1b[34m%s\x1b[0m",
-  },
-  BACKGROUND: {
-    RED: "\x1b[41m%s\x1b[0m",
-  },
-} as const
-
 // eslint-disable-next-line import/prefer-default-export
-export const consoleLogger: ExtendedLogger = {
-  info: (message: string | Record<string, unknown>): void => {
-    // NOTE: This adds RGB to our console logs
-    console.log(COLORS.FOREGROUND.GREEN, `[INFO]: ${message}`)
+export const consoleLogger: ExtendedLogger = pino({
+  transport: {
+    target: "pino-pretty",
+    options: {
+      colorize: true,
+    },
   },
-  warn: (message: string | Record<string, unknown>): void => {
-    console.warn(COLORS.FOREGROUND.YELLOW, `[WARN]: ${message}`)
-  },
-  error: (message: string | Record<string, unknown>): void => {
-    console.error(COLORS.FOREGROUND.RED, `[ERROR]: ${message}`)
-  },
-  debug: (message: string | Record<string, unknown>): void => {
-    console.debug(COLORS.FOREGROUND.BLUE, `[DEBUG]: ${message}`)
-  },
-  fatal: (message: string | Record<string, unknown>): void => {
-    console.error(COLORS.BACKGROUND.RED, `[FATAL]: ${message}`)
-  },
-}
+  ...PINO_OPTIONS,
+})

--- a/src/logger/constants.ts
+++ b/src/logger/constants.ts
@@ -1,0 +1,14 @@
+import pino from "pino"
+
+// eslint-disable-next-line import/prefer-default-export
+export const PINO_OPTIONS = {
+  // NOTE: DO NOT format time in-process
+  // as this will affect perf of the logger.
+  // See here: https://getpino.io/#/docs/api?id=timestamp-boolean-function
+  timestamp: pino.stdTimeFunctions.isoTime,
+  errorKey: "error",
+  messageKey: "message",
+  formatters: {
+    level: (label: string) => ({ level: label.toUpperCase() }),
+  },
+}

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -76,12 +76,10 @@ export class IsomerLogger implements ExtendedLogger {
 
 const logger = new IsomerLogger()
 
-if (!USE_CONSOLE_LOGGER) {
-  logger.use(pinoLogger)
-}
-
 if (USE_CONSOLE_LOGGER) {
   logger.use(consoleLogger)
+} else {
+  logger.use(pinoLogger)
 }
 
 export default logger

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -1,8 +1,5 @@
-import moment from "moment-timezone"
-
 import { config } from "@root/config/config"
 
-import CloudWatchLogger from "./cloudwatch.logger"
 import { consoleLogger } from "./console.logger"
 import {
   Formatter,
@@ -14,14 +11,11 @@ import {
   LoggerVariants,
   WithFatal,
 } from "./logger.types"
+import { pinoLogger } from "./pino.logger"
 
 const NODE_ENV = config.get("env")
-const useCloudwatchLogger =
-  NODE_ENV === "prod" || NODE_ENV === "vapt" || NODE_ENV === "staging"
-const useConsoleLogger = !(NODE_ENV === "test")
 
-const timestampGenerator = () =>
-  moment().tz("Asia/Singapore").format("YYYY-MM-DD HH:mm:ss")
+const USE_CONSOLE_LOGGER = NODE_ENV === "dev" || NODE_ENV === "test"
 
 const hasDebug = (logger: LoggerVariants): logger is WithDebug<Logger> =>
   (logger as WithDebug<Logger>).debug !== undefined
@@ -81,8 +75,13 @@ export class IsomerLogger implements ExtendedLogger {
 }
 
 const logger = new IsomerLogger()
-if (useConsoleLogger) logger.use(consoleLogger)
-if (useCloudwatchLogger) logger.use(new CloudWatchLogger())
-logger.useFormatter((message) => `${timestampGenerator()}: ${message}`)
+
+if (!USE_CONSOLE_LOGGER) {
+  logger.use(pinoLogger)
+}
+
+if (USE_CONSOLE_LOGGER) {
+  logger.use(consoleLogger)
+}
 
 export default logger

--- a/src/logger/pino.logger.ts
+++ b/src/logger/pino.logger.ts
@@ -1,0 +1,8 @@
+import pino from "pino"
+
+import { PINO_OPTIONS } from "./constants"
+
+// NOTE: `pino` writes to `stdout` by default
+// and this will get piped to our cloudwatch log group.
+// eslint-disable-next-line import/prefer-default-export
+export const pinoLogger = pino(PINO_OPTIONS)

--- a/src/routes/formsg/formsgGGsRepair.ts
+++ b/src/routes/formsg/formsgGGsRepair.ts
@@ -12,10 +12,7 @@ import { config } from "@config/config"
 
 import { lock, unlock } from "@utils/mutex-utils"
 
-import {
-  EFS_VOL_PATH_STAGING,
-  EFS_VOL_PATH_STAGING_LITE,
-} from "@root/constants"
+import { EFS_VOL_PATH_STAGING_LITE } from "@root/constants"
 import GitFileSystemError from "@root/errors/GitFileSystemError"
 import InitializationError from "@root/errors/InitializationError"
 import LockedError from "@root/errors/LockedError"

--- a/src/utils/tracer.ts
+++ b/src/utils/tracer.ts
@@ -1,6 +1,7 @@
 import tracer from "dd-trace"
 
 tracer.init({
+  logInjection: true,
   sampleRate: 1,
 })
 


### PR DESCRIPTION
## Problem
this pr adds a structured logging library (`pino`) to our codebase. it also supersedes `winston` (which hasn't been working anyway).

Closes [ISOM-772]

## Solution
1. add both `pino` and `pino-pretty` (will be described below) 
2. replaced `consoleLogger` implementation with a call to `pino` with transport as `pino-pretty`. `pino` pipes logs **by default** to `stdout`. this means that on local, the logs get transformed by `pino-pretty` before going to `stdout`, so it'll be seen as unstructured text instead of json. 
3. for production loggers, we **also pipe to `stdout`** - this gets picked up by aws and forwarded to the correct log group. **this is actually how logging works now** - our `winston` logger has been missing a `transport` and broken since forever. this was also chosen **over** using `pino-cloudwatch` because the latter is **legacy**.

![Screenshot 2024-03-13 at 2 56 56 PM](https://github.com/isomerpages/isomercms-backend/assets/44049504/b48d53c6-1271-465d-9b04-ff2a24a1111e)



see examples of the logger at work [https://ogp.datadoghq.com/logs?query=service:isomer-infra%20env:%22staging%22%20sourc[…]=stream&from_ts=1710241200000&to_ts=1710244740000&live=false](https://ogp.datadoghq.com/logs?query=service:isomer-infra%20env:%22staging%22%20source:%22elasticbeanstalk/cms-backend-staging-node18/var/log/web.stdout.log%22%20-@aws.awslogs.logStream:i-*%20&cols=host,service&fromUser=true&index=*&messageDisplay=inline&sort=time&storage=hot&stream_sort=time,asc&view=spans&viz=stream&from_ts=1710241200000&to_ts=1710244740000&live=false)