### PR TITLE
chore(telemetry): report runtime metrics

### DIFF
--- a/src/utils/tracer.ts
+++ b/src/utils/tracer.ts
@@ -1,7 +1,8 @@
 import tracer from "dd-trace"
 
 tracer.init({
-  logInjection: true,
+  logInjection: true, // https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/nodejs/
+  runtimeMetrics: true, // https://docs.datadoghq.com/tracing/metrics/runtime_metrics/nodejs
   sampleRate: 1,
 })
 


### PR DESCRIPTION
## Problem

We have no view on nodejs runtime metrics to see garbage collection lock and event loop lag (which could totally be happening with sync IO operation for fs/git). datadog can report that data for us.

See [documentation](https://docs.datadoghq.com/tracing/metrics/runtime_metrics/nodejs/?tab=environmentvariables#data-collected)


## Solution

Enable `runtimeMetrics:true` for dd-trace

## Risk

Additional monitoring could cause additional cpu load. Instances should be monitored carefully on release.