### PR TITLE
perf(I/O): rm blocking fs calls

### DIFF
--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -399,21 +399,29 @@ export const createRecords = (zoneId: string): Record[] => {
       .cwd({ path: stgLiteDir, root: false })
       .checkout("staging")
 
-    const doesImagesFolderExist = await doesDirectoryExist(
+    const doesImagesFolderExistResult = await doesDirectoryExist(
       path.join(`${stgLiteDir}`, `images`)
     )
 
-    if (doesImagesFolderExist) {
+    if (doesImagesFolderExistResult.isErr()) {
+      throw doesImagesFolderExistResult.error
+    }
+
+    if (doesImagesFolderExistResult.value) {
       await this.simpleGit
         .cwd({ path: stgLiteDir, root: false })
         .rm(["-r", "images"])
     }
 
-    const doesFilesFolderExist = await doesDirectoryExist(
+    const doesFilesFolderExistResult = await doesDirectoryExist(
       path.join(`${stgLiteDir}`, `files`)
     )
 
-    if (doesFilesFolderExist) {
+    if (doesFilesFolderExistResult.isErr()) {
+      throw doesFilesFolderExistResult.error
+    }
+
+    if (doesFilesFolderExistResult.value) {
       await this.simpleGit
         .cwd({ path: stgLiteDir, root: false })
         .rm(["-r", "files"])

--- a/src/services/identity/ReposService.ts
+++ b/src/services/identity/ReposService.ts
@@ -1,4 +1,3 @@
-import { exec } from "child_process"
 import fs from "fs"
 import path from "path"
 
@@ -22,6 +21,7 @@ import {
 } from "@root/constants"
 import GitHubApiError from "@root/errors/GitHubApiError"
 import logger from "@root/logger/logger"
+import { doesDirectoryExist } from "@root/utils/fs-utils"
 
 const SYSTEM_GITHUB_TOKEN = config.get("github.systemToken")
 const octokit = new Octokit({ auth: SYSTEM_GITHUB_TOKEN })
@@ -120,7 +120,7 @@ export default class ReposService {
     const dir = this.getLocalStagingRepoPath(repoName)
 
     // 1. Set URLs in local _config.yml
-    this.setUrlsInLocalConfig(dir, repoName, stagingUrl, productionUrl)
+    await this.setUrlsInLocalConfig(dir, repoName, stagingUrl, productionUrl)
 
     // 2. Commit changes in local repo
     await this.simpleGit
@@ -151,14 +151,21 @@ export default class ReposService {
     await this.simpleGit.cwd({ path: dir, root: false }).checkout("staging")
   }
 
-  private setUrlsInLocalConfig(
+  private async setUrlsInLocalConfig(
     dir: string,
     repoName: string,
     stagingUrl: string,
     productionUrl: string
   ) {
     const configPath = `${dir}/_config.yml`
-    const configFile = fs.readFileSync(configPath, "utf-8")
+    let configFile: string
+    try {
+      configFile = await fs.promises.readFile(configPath, "utf-8")
+    } catch (error) {
+      throw new UnprocessableError(
+        `Error reading _config.yml for '${repoName}': ${error}`
+      )
+    }
     const lines = configFile.split("\n")
     const stagingIdx = lines.findIndex((line) => line.startsWith("staging:"))
     const prodIdx = lines.findIndex((line) => line.startsWith("prod:"))
@@ -169,7 +176,7 @@ export default class ReposService {
     }
     lines[stagingIdx] = `staging: ${stagingUrl}`
     lines[prodIdx] = `prod: ${productionUrl}`
-    fs.writeFileSync(configPath, lines.join("\n"))
+    await fs.promises.writeFile(configPath, lines.join("\n"))
   }
 
   createRepoOnGithub = (
@@ -227,16 +234,16 @@ export default class ReposService {
     const stgLiteDir = this.getLocalStagingLiteRepoPath(repoName)
 
     // Make sure the local path is empty, just in case dir was used on a previous attempt.
-    fs.rmSync(`${stgDir}`, { recursive: true, force: true })
+    await fs.promises.rm(`${stgDir}`, { recursive: true, force: true })
 
     // Clone base repo locally
-    fs.mkdirSync(stgDir)
+    await fs.promises.mkdir(stgDir)
     await this.simpleGit
       .cwd({ path: stgDir, root: false })
       .clone(SITE_CREATION_BASE_REPO_URL, stgDir, ["-b", "staging"])
 
     // Clear git
-    fs.rmSync(`${stgDir}/.git`, { recursive: true, force: true })
+    await fs.promises.rm(`${stgDir}/.git`, { recursive: true, force: true })
 
     // Prepare git repo
     await this.simpleGit
@@ -376,9 +383,9 @@ export const createRecords = (zoneId: string): Record[] => {
   }
 
   async setUpStagingLite(stgLiteDir: string, repoUrl: string) {
-    fs.rmSync(`${stgLiteDir}`, { recursive: true, force: true })
+    await fs.promises.rm(`${stgLiteDir}`, { recursive: true, force: true })
     // create a empty folder stgLiteDir
-    fs.mkdirSync(stgLiteDir)
+    await fs.promises.mkdir(stgLiteDir)
 
     // note: for some reason, combining below commands led to race conditions
     // so we have to do it separately
@@ -392,20 +399,28 @@ export const createRecords = (zoneId: string): Record[] => {
       .cwd({ path: stgLiteDir, root: false })
       .checkout("staging")
 
-    if (fs.existsSync(path.join(`${stgLiteDir}`, `images`))) {
+    const doesImagesFolderExist = await doesDirectoryExist(
+      path.join(`${stgLiteDir}`, `images`)
+    )
+
+    if (doesImagesFolderExist) {
       await this.simpleGit
         .cwd({ path: stgLiteDir, root: false })
         .rm(["-r", "images"])
     }
 
-    if (fs.existsSync(path.join(`${stgLiteDir}`, `files`))) {
+    const doesFilesFolderExist = await doesDirectoryExist(
+      path.join(`${stgLiteDir}`, `files`)
+    )
+
+    if (doesFilesFolderExist) {
       await this.simpleGit
         .cwd({ path: stgLiteDir, root: false })
         .rm(["-r", "files"])
     }
 
     // Clear git
-    fs.rmSync(`${stgLiteDir}/.git`, { recursive: true, force: true })
+    await fs.promises.rm(`${stgLiteDir}/.git`, { recursive: true, force: true })
 
     // Prepare git repo
     await this.simpleGit

--- a/src/services/review/RepoCheckerService.ts
+++ b/src/services/review/RepoCheckerService.ts
@@ -27,6 +27,7 @@ import {
   BrokenLinkErrorDto,
 } from "@root/types/siteChecker"
 import { extractPathInfo } from "@root/utils/files"
+import { doesDirectoryExist } from "@root/utils/fs-utils"
 
 import GitFileSystemService from "../db/GitFileSystemService"
 import { PageService } from "../fileServices/MdPageServices/PageService"
@@ -77,33 +78,57 @@ export default class RepoCheckerService {
     this.pageService = pageService
   }
 
-  isCurrentlyLocked(repo: string): ResultAsync<true, SiteCheckerError> {
+  createLogsFolder(
+    repo: string
+  ): ResultAsync<string | undefined, SiteCheckerError> {
     const logsFilePath = path.join(SITE_CHECKER_REPO_PATH, repo)
     // create logs folder if it does not exist
+    return ResultAsync.fromPromise(doesDirectoryExist(logsFilePath), (err) => {
+      logger.error(
+        `SiteCheckerError: error finding if logs directory exists for ${repo} :${err}`
+      )
+      return new SiteCheckerError(
+        `Error finding if logs directory exists for ${repo} :${err}`
+      )
+    }).andThen((doesLogsFolderExist) => {
+      if (!doesLogsFolderExist) {
+        return ResultAsync.fromPromise(
+          fs.promises.mkdir(logsFilePath, { recursive: true }),
+          (err) => {
+            logger.error(`SiteCheckerError: Unable to create logs dir: ${err}`)
+            return new SiteCheckerError(
+              `SiteCheckerError: Unable to create logs dir: ${err}`
+            )
+          }
+        )
+      }
+      return okAsync("ok")
+    })
+  }
 
-    if (!fs.existsSync(logsFilePath)) {
-      fs.mkdirSync(logsFilePath, { recursive: true })
-    }
-
+  isCurrentlyLocked(repo: string): ResultAsync<true, SiteCheckerError> {
+    const logsFilePath = path.join(SITE_CHECKER_REPO_PATH, repo)
     // check if checker.lock exists
     const lockFilePath = path.join(logsFilePath, LOCK_CONTENT)
-
-    return ResultAsync.fromPromise(
-      fs.promises.access(lockFilePath, fs.constants.F_OK),
-      (err) => new SiteCheckerError(`${err}`)
-    ).map(() => true)
+    return this.createLogsFolder(repo)
+      .andThen(() =>
+        ResultAsync.fromPromise(
+          fs.promises.access(lockFilePath, fs.constants.F_OK),
+          (err) => new SiteCheckerError(`${err}`)
+        )
+      )
+      .map(() => true)
   }
 
   createLock(repo: string) {
     const folderPath = path.join(SITE_CHECKER_REPO_PATH, repo)
-    if (!fs.existsSync(folderPath)) {
-      fs.mkdirSync(folderPath, { recursive: true })
-    }
     // create a checker.lock file
     const lockFilePath = path.join(folderPath, LOCK_CONTENT)
-    return ResultAsync.fromPromise(
-      fs.promises.writeFile(lockFilePath, "locked"),
-      (error) => new SiteCheckerError(`${error}`)
+    return this.createLogsFolder(repo).andThen(() =>
+      ResultAsync.fromPromise(
+        fs.promises.writeFile(lockFilePath, "locked"),
+        (error) => new SiteCheckerError(`${error}`)
+      )
     )
   }
 
@@ -375,91 +400,107 @@ export default class RepoCheckerService {
           fileName,
           viewablePageInCms,
         ] of mapOfMdFilesAndViewableLinkInCms) {
-          const file = fs.readFileSync(path.join(repoPath, fileName), "utf8")
-
-          const filePermalink = file
-            .split("---")
-            ?.at(1)
-            ?.split("permalink: ")
-            ?.at(1)
-            ?.split("\n")
-            ?.at(0)
-
-          if (!filePermalink) {
-            continue
-          }
-          const normalisedPermalink = this.normalisePermalink(filePermalink)
-
-          // we are only parsing out the front matter
-          const fileContent = file.split("---")?.slice(2).join("---")
-          if (!fileContent) {
-            continue
-          }
           findErrors.push(
             ResultAsync.fromPromise(
-              Promise.resolve(marked.parse(fileContent)),
-              (err) => new SiteCheckerError(`${err}`)
-            ).andThen((html) => {
-              const dom = new JSDOM(html)
-              const anchorTags = dom.window.document.querySelectorAll("a")
-              forEach(anchorTags, (tag) => {
-                const href = tag.getAttribute("href")
-                const text = tag.textContent
+              fs.promises.readFile(path.join(repoPath, fileName), "utf8"),
+              (error) =>
+                new SiteCheckerError(
+                  `SiteCheckerError: error reading file ${fileName}: ${error}`
+                )
+            )
+              .andThen((file) => {
+                const filePermalink = file
+                  .split("---")
+                  ?.at(1)
+                  ?.split("permalink: ")
+                  ?.at(1)
+                  ?.split("\n")
+                  ?.at(0)
 
-                if (!text) {
-                  // while rendered in the dom, unlikely to be
-                  // noticed by end citizen.
-                  return
+                if (!filePermalink) {
+                  return errAsync("No permalink found in front matter")
                 }
-                if (!tag.hasAttribute("href")) {
-                  const error: RepoError = {
-                    type: RepoErrorTypes.BROKEN_LINK,
-                    linkToAsset: "",
-                    viewablePageInCms,
-                    viewablePageInStaging: path.join(normalisedPermalink),
-                    linkedText: text,
-                  }
-                  errors.push(error)
-                }
-                if (!href) {
-                  // could be intentional linking to self
-                  // eg. <a href>Back to top</a>
-                  return
-                }
+                const normalisedPermalink = this.normalisePermalink(
+                  filePermalink
+                )
 
-                if (!this.hasValidReference(setOfAllMediaAndPagesPath, href)) {
-                  const error: RepoError = {
-                    type: RepoErrorTypes.BROKEN_LINK,
-                    linkToAsset: href,
-                    viewablePageInCms,
-                    viewablePageInStaging: path.join(normalisedPermalink),
-                    linkedText: text,
-                  }
-                  errors.push(error)
+                // we are only parsing out the front matter
+                const fileContent = file.split("---")?.slice(2).join("---")
+                if (!fileContent) {
+                  return errAsync("No file content found")
                 }
+                return okAsync({ fileContent, normalisedPermalink })
               })
-              const imgTags = dom.window.document.querySelectorAll("img")
-              forEach(imgTags, (tag) => {
-                const src = tag.getAttribute("src")
-                if (!src) {
-                  // while rendered in the dom, unlikely to be
-                  // noticed by end citizen.
-                  return
-                }
+              .andThen(({ fileContent, normalisedPermalink }) =>
+                ResultAsync.fromPromise(
+                  Promise.resolve(marked.parse(fileContent)),
+                  (err) => new SiteCheckerError(`${err}`)
+                ).andThen((html) => {
+                  const dom = new JSDOM(html)
+                  const anchorTags = dom.window.document.querySelectorAll("a")
+                  forEach(anchorTags, (tag) => {
+                    const href = tag.getAttribute("href")
+                    const text = tag.textContent
 
-                //! todo: include check for post bundled files https://github.com/isomerpages/isomerpages-template/tree/staging/assets/img
-                if (!this.hasValidReference(setOfAllMediaAndPagesPath, src)) {
-                  const error: RepoError = {
-                    type: RepoErrorTypes.BROKEN_IMAGE,
-                    linkToAsset: src,
-                    viewablePageInCms,
-                    viewablePageInStaging: path.join(normalisedPermalink),
-                  }
-                  errors.push(error)
-                }
-              })
-              return ok(undefined)
-            })
+                    if (!text) {
+                      // while rendered in the dom, unlikely to be
+                      // noticed by end citizen.
+                      return
+                    }
+                    if (!tag.hasAttribute("href")) {
+                      const error: RepoError = {
+                        type: RepoErrorTypes.BROKEN_LINK,
+                        linkToAsset: "",
+                        viewablePageInCms,
+                        viewablePageInStaging: path.join(normalisedPermalink),
+                        linkedText: text,
+                      }
+                      errors.push(error)
+                    }
+                    if (!href) {
+                      // could be intentional linking to self
+                      // eg. <a href>Back to top</a>
+                      return
+                    }
+
+                    if (
+                      !this.hasValidReference(setOfAllMediaAndPagesPath, href)
+                    ) {
+                      const error: RepoError = {
+                        type: RepoErrorTypes.BROKEN_LINK,
+                        linkToAsset: href,
+                        viewablePageInCms,
+                        viewablePageInStaging: path.join(normalisedPermalink),
+                        linkedText: text,
+                      }
+                      errors.push(error)
+                    }
+                  })
+                  const imgTags = dom.window.document.querySelectorAll("img")
+                  forEach(imgTags, (tag) => {
+                    const src = tag.getAttribute("src")
+                    if (!src) {
+                      // while rendered in the dom, unlikely to be
+                      // noticed by end citizen.
+                      return
+                    }
+
+                    //! todo: include check for post bundled files https://github.com/isomerpages/isomerpages-template/tree/staging/assets/img
+                    if (
+                      !this.hasValidReference(setOfAllMediaAndPagesPath, src)
+                    ) {
+                      const error: RepoError = {
+                        type: RepoErrorTypes.BROKEN_IMAGE,
+                        linkToAsset: src,
+                        viewablePageInCms,
+                        viewablePageInStaging: path.join(normalisedPermalink),
+                      }
+                      errors.push(error)
+                    }
+                  })
+                  return ok(undefined)
+                })
+              )
           )
         }
         logger.info(`Site checker for repo ${repo} completed successfully!`)
@@ -493,52 +534,83 @@ export default class RepoCheckerService {
     return false
   }
 
-  reporter(repo: string, errors: RepoError[]): ResultAsync<RepoError[], never> {
-    const folderPath = path.join(SITE_CHECKER_REPO_PATH, repo)
-    if (!fs.existsSync(folderPath)) {
-      fs.mkdirSync(folderPath, { recursive: true })
-    }
-    const filePath = path.join(SITE_CHECKER_REPO_PATH, repo, REPO_LOG)
-    const stringifiedErrors = this.convertToCSV(errors)
-    if (!fs.existsSync(filePath)) {
-      fs.appendFileSync(filePath, stringifiedErrors)
-    } else {
-      fs.writeFileSync(filePath, stringifiedErrors)
-    }
-
-    const isProd = config.get("env") === "prod"
-    if (!isProd) {
-      return okAsync(errors)
-    }
-
-    const gitOperations:
-      | Response<CommitResult>
-      | Response<PushResult> = this.git
-      .cwd({ path: SITE_CHECKER_REPO_PATH, root: false })
-      .checkout("main")
-      .fetch()
-      .merge(["origin/main"])
-      .add(["."])
-      .commit(`Site checker logs added for ${repo}`)
-      .push()
-
-    // pushing since there is no real time requirement for user
-    return ResultAsync.fromPromise<CommitResult | PushResult, SiteCheckerError>(
-      gitOperations,
-      (error) => new SiteCheckerError(`${error}`)
-    )
-      .map(() => errors)
-      .orElse(() => {
-        /**
-         * Actually committing the repo to remote is not a critical operation, and done for observability.
-         * If it fails, we can still return the broken links report to the user.
-         * We also do not want to log the actual error as it could cause other alarms to go off.
-         */
-        logger.info(
-          `SiteCheckerInfo: Error pushing logs for ${repo} to remote isomer-site-checker repo`
+  reporter(
+    repo: string,
+    errors: RepoError[]
+  ): ResultAsync<RepoError[], SiteCheckerError> {
+    return this.createLogsFolder(repo).andThen(() => {
+      const filePath = path.join(SITE_CHECKER_REPO_PATH, repo, REPO_LOG)
+      const stringifiedErrors = this.convertToCSV(errors)
+      return ResultAsync.fromPromise<fs.Stats, false>(
+        fs.promises.stat(filePath),
+        () => false
+      )
+        .andThen(() =>
+          ResultAsync.fromPromise(
+            fs.promises.appendFile(filePath, stringifiedErrors),
+            (error) => {
+              logger.error(
+                `SiteCheckerError: Error appending to log file for ${repo}: ${error}`
+              )
+              return new SiteCheckerError(
+                `Error appending to log file for ${repo}: ${error}`
+              )
+            }
+          )
         )
-        return ok(errors)
-      })
+        .orElse((error) => {
+          if (error === false) {
+            return ResultAsync.fromPromise(
+              fs.promises.writeFile(filePath, stringifiedErrors),
+              (writeFileError) => {
+                logger.error(
+                  `SiteCheckerError: Error creating log file for ${repo} :${writeFileError}`
+                )
+                return new SiteCheckerError(
+                  `Error creating log file for ${repo} :${writeFileError}`
+                )
+              }
+            )
+          }
+
+          return errAsync(error)
+        })
+        .andThen(() => {
+          const isProd = config.get("env") === "prod"
+          if (!isProd) {
+            return okAsync(errors)
+          }
+
+          const gitOperations:
+            | Response<CommitResult>
+            | Response<PushResult> = this.git
+            .cwd({ path: SITE_CHECKER_REPO_PATH, root: false })
+            .checkout("main")
+            .fetch()
+            .merge(["origin/main"])
+            .add(["."])
+            .commit(`Site checker logs added for ${repo}`)
+            .push()
+
+          // pushing since there is no real time requirement for user
+          return ResultAsync.fromPromise<
+            CommitResult | PushResult,
+            SiteCheckerError
+          >(gitOperations, (error) => new SiteCheckerError(`${error}`))
+            .map(() => errors)
+            .orElse(() => {
+              /**
+               * Actually committing the repo to remote is not a critical operation, and done for observability.
+               * If it fails, we can still return the broken links report to the user.
+               * We also do not want to log the actual error as it could cause other alarms to go off.
+               */
+              logger.info(
+                `SiteCheckerInfo: Error pushing logs for ${repo} to remote isomer-site-checker repo`
+              )
+              return ok(errors)
+            })
+        })
+    })
   }
 
   // adapted from https://stackoverflow.com/questions/56427009/how-to-return-papa-parsed-csv-via-promise-async-await
@@ -566,37 +638,38 @@ export default class RepoCheckerService {
     repo: string
   ): ResultAsync<BrokenLinkErrorDto, SiteCheckerError> => {
     const filePath = path.join(SITE_CHECKER_REPO_PATH, repo, REPO_LOG)
-    if (!fs.existsSync(filePath)) {
-      logger.error(`SiteCheckerError: Folder does not exist for ${repo}`)
-      return errAsync(new SiteCheckerError(`Folder does not exist for ${repo}`))
-    }
 
-    return this.isCurrentlyErrored(repo).andThen((isError) => {
-      if (isError) {
-        return errAsync(new SiteCheckerError(`Error checking repo ${repo}`))
-      }
+    return ResultAsync.fromPromise(
+      fs.promises.stat(filePath),
+      () => new SiteCheckerError(`Folder does not exist for ${repo}`)
+    ).andThen(() =>
+      this.isCurrentlyErrored(repo).andThen((isError) => {
+        if (isError) {
+          return errAsync(new SiteCheckerError(`Error checking repo ${repo}`))
+        }
 
-      return this.isCurrentlyLocked(repo)
-        .andThen(() => okAsync<BrokenLinkErrorDto>({ status: "loading" }))
-        .orElse(() =>
-          ResultAsync.fromPromise(
-            this.generateRepoErrorsFromCsv(repo),
-            (error) => {
-              logger.error(
-                `SiteCheckerError: Error reading csv for repo ${repo}: ${error}`
-              )
-              return new SiteCheckerError(
-                `Error reading csv for repo ${repo}: ${error}`
-              )
-            }
-          ).andThen((errors) =>
-            okAsync<BrokenLinkErrorDto>({
-              errors,
-              status: "success",
-            })
+        return this.isCurrentlyLocked(repo)
+          .andThen(() => okAsync<BrokenLinkErrorDto>({ status: "loading" }))
+          .orElse(() =>
+            ResultAsync.fromPromise(
+              this.generateRepoErrorsFromCsv(repo),
+              (error) => {
+                logger.error(
+                  `SiteCheckerError: Error reading csv for repo ${repo}: ${error}`
+                )
+                return new SiteCheckerError(
+                  `Error reading csv for repo ${repo}: ${error}`
+                )
+              }
+            ).andThen((errors) =>
+              okAsync<BrokenLinkErrorDto>({
+                errors,
+                status: "success",
+              })
+            )
           )
-        )
-    })
+      })
+    )
   }
 
   /**
@@ -806,18 +879,16 @@ export default class RepoCheckerService {
   }
 
   outputHumanReadableErrors(repoName: string) {
-    const csvData = fs.readFileSync(
-      path.join(SITE_CHECKER_REPO_PATH, repoName, REPO_LOG),
-      "utf8"
+    return ResultAsync.fromPromise(
+      this.generateRepoErrorsFromCsv(repoName),
+      (err) => {
+        logger.error(`SiteCheckerError: Error reading errors from csv: ${err}`)
+        return new SiteCheckerError(`Error reading errors from csv: ${err}`)
+      }
     )
-
-    const report: string[] = []
-
-    Papa.parse(csvData, {
-      header: true,
-      complete(results) {
-        results.data.forEach((row) => {
-          if (!isRepoError(row)) return
+      .andThen((errors) => {
+        const report: string[] = []
+        errors.forEach((row) => {
           if (row.type === "broken-image") {
             report.push(`Broken image: ${row.linkToAsset}`)
             report.push(`Edit page: ${row.viewablePageInCms}`)
@@ -843,14 +914,25 @@ export default class RepoCheckerService {
             report.push("\n")
           }
         })
-      },
-    })
 
-    // write report to file
-    fs.writeFileSync(
-      path.join(SITE_CHECKER_REPO_PATH, repoName, "report.txt"),
-      report.join("\n")
-    )
+        return ok(report)
+      })
+      .andThen((report) =>
+        ResultAsync.fromPromise(
+          fs.promises.writeFile(
+            path.join(SITE_CHECKER_REPO_PATH, repoName, "report.txt"),
+            report.join("\n")
+          ),
+          (err) => {
+            logger.error(
+              `SiteCheckerError: Error writing report to file: ${err}`
+            )
+            return new SiteCheckerError(
+              `SiteCheckerError: Error writing report to file: ${err}`
+            )
+          }
+        )
+      )
   }
 
   traverseDirectory(

--- a/src/services/utilServices/MailClient.ts
+++ b/src/services/utilServices/MailClient.ts
@@ -51,13 +51,14 @@ class MailClient {
     form.append("body", body)
     form.append("recipient", recipient)
     form.append("reply_to", "noreply@isomer.gov.sg")
-    attachments?.forEach((attachment) => {
-      form.append(
-        "attachments",
-        fs.readFileSync(attachment),
-        path.basename(attachment)
+    if (attachments) {
+      await Promise.all(
+        attachments?.map(async (attachment) => {
+          const content = await fs.promises.readFile(attachment)
+          form.append("attachments", content, path.basename(attachment))
+        })
       )
-    })
+    }
 
     try {
       const sendMailResponse = await axios.post<MailData>(sendEndpoint, form, {

--- a/src/utils/fs-utils.ts
+++ b/src/utils/fs-utils.ts
@@ -1,0 +1,13 @@
+/* eslint-disable import/prefer-default-export */
+import * as fs from "fs/promises"
+
+export async function doesDirectoryExist(path: string): Promise<boolean> {
+  let result = false
+  try {
+    const stat = await fs.stat(path)
+    result = stat.isDirectory()
+  } catch (e) {
+    result = false
+  }
+  return result
+}


### PR DESCRIPTION
## Problem

We have quite a number of blocking I/O calls that has lead to unwanted CPU spikes in the event pool thread. 

This PR scrapes any existence of I/O calls and ensures that there is no lingering sync fs calls made from node. 


## Solution
use `fs.promises` instead

Looking at the spike after running the site checker
### NOTE: initial spike in event loop delay is due to the startup push to staging environment, this is not due to the site checker calls that were made
![Screenshot 2024-03-19 at 2 30 02 PM](https://github.com/isomerpages/isomercms-backend/assets/42832651/10604267-a702-4764-9ba4-e428987a8317)



![Screenshot 2024-03-19 at 1 30 03 PM](https://github.com/isomerpages/isomercms-backend/assets/42832651/fd9432b0-c83d-4a34-9c56-3e62d5d23a37)

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:


when running the site repair form:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

- [ ] Run the following command from the command line: 
```
grep -rE '(accessSync|appendFileSync|chmodSync|chownSync|closeSync|copyFileSync|cpSync|existsSync|fchmodSync|fchownSync|fdatasyncSync|fstatSync|fsyncSync|ftruncateSync|futimesSync|lchmodSync|lchownSync|lutimesSync|linkSync|lstatSync|mkdirSync|mkdtempSync|opendirSync|openSync|readdirSync|readFileSync|readlinkSync|readSync|readvSync|realpathSync|renameSync|rmdirSync|rmSync|statSync|statfsSync|symlinkSync|truncateSync|unlinkSync|utimesSync|writeFileSync|writeSync|writevSync)\b' src 
```

the only results should be from the `GitFileSystemService.spec.ts` which is fine since this test file runs locally and not in prod line

- [ ] Submit a form [here](https://form.gov.sg/65e4a3d2c25a061b046f3f01) for a repo in staging efs, and assert that the attachments are sent properly

- [ ] submit the site create form 


## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details
    - [ ] added env var to 1PW + SSM script (`fetch_ssm_parameters.sh`)

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details