### PR TITLE
fix(tags): update tagging for dd

### DIFF
--- a/.aws/deploy/backend-task-definition.prod.json
+++ b/.aws/deploy/backend-task-definition.prod.json
@@ -238,11 +238,11 @@
         },
         {
           "name": "DD_SERVICE",
-          "value": "isomer-infra"
+          "value": "isomer"
         },
         {
           "name": "DD_TAGS",
-          "value": "service:isomer-infra"
+          "value": "service:isomer"
         },
         {
           "name": "DD_AGENT_MAJOR_VERSION",
@@ -263,7 +263,7 @@
       ],
       "dockerLabels": {
         "com.datadoghq.tags.env": "production",
-        "com.datadoghq.tags.service": "isomer-infra",
+        "com.datadoghq.tags.service": "isomer",
         "com.datadoghq.tags.version": "7"
       },
       "mountPoints": [],

--- a/.aws/deploy/backend-task-definition.prod.json
+++ b/.aws/deploy/backend-task-definition.prod.json
@@ -234,15 +234,15 @@
         },
         {
           "name": "DD_ENV",
-          "value": "prod"
+          "value": "production"
         },
         {
           "name": "DD_SERVICE",
-          "value": "isomer"
+          "value": "isomer-infra"
         },
         {
           "name": "DD_TAGS",
-          "value": "service:isomer"
+          "value": "service:isomer-infra"
         },
         {
           "name": "DD_AGENT_MAJOR_VERSION",
@@ -262,7 +262,7 @@
         }
       ],
       "dockerLabels": {
-        "com.datadoghq.tags.env": "prod",
+        "com.datadoghq.tags.env": "production",
         "com.datadoghq.tags.service": "isomer-infra",
         "com.datadoghq.tags.version": "7"
       },

--- a/.aws/deploy/backend-task-definition.staging.json
+++ b/.aws/deploy/backend-task-definition.staging.json
@@ -247,11 +247,11 @@
         },
         {
           "name": "DD_SERVICE",
-          "value": "isomer"
+          "value": "isomer-infra"
         },
         {
           "name": "DD_TAGS",
-          "value": "service:isomer"
+          "value": "service:isomer-infra"
         },
         {
           "name": "DD_AGENT_MAJOR_VERSION",

--- a/.aws/deploy/backend-task-definition.staging.json
+++ b/.aws/deploy/backend-task-definition.staging.json
@@ -247,11 +247,11 @@
         },
         {
           "name": "DD_SERVICE",
-          "value": "isomer-infra"
+          "value": "isomer"
         },
         {
           "name": "DD_TAGS",
-          "value": "service:isomer-infra"
+          "value": "service:isomer"
         },
         {
           "name": "DD_AGENT_MAJOR_VERSION",
@@ -272,7 +272,7 @@
       ],
       "dockerLabels": {
         "com.datadoghq.tags.env": "staging",
-        "com.datadoghq.tags.service": "isomer-infra",
+        "com.datadoghq.tags.service": "isomer",
         "com.datadoghq.tags.version": "7"
       },
       "mountPoints": [],


### PR DESCRIPTION
## Problem
previously, we updated env tags for `production` to `prod` but turns out it's being used in more than a few places. just change back to `production` + tag properly on docker labels also

## Solution
1. change container/run-time tags to `production` 
2. update docker labels