### PR TITLE
chore(growthbook): handle refreshes at module level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/client-dynamodb": "^3.521.0",
         "@aws-sdk/client-secrets-manager": "^3.389.0",
         "@aws-sdk/lib-dynamodb": "^3.521.0",
-        "@growthbook/growthbook": "^0.34.0",
+        "@growthbook/growthbook": "^0.36.0",
         "@octokit/plugin-retry": "^6.0.0",
         "@octokit/rest": "^18.12.0",
         "@opengovsg/formsg-sdk": "^0.11.0",
@@ -2956,9 +2956,9 @@
       "optional": true
     },
     "node_modules/@growthbook/growthbook": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@growthbook/growthbook/-/growthbook-0.34.0.tgz",
-      "integrity": "sha512-3K5JL8QftX7y77EpieYg9anXVYb6+ZafTsrNCWp0HOdmtf4lxHOzCUYwuYDaS3bvmaeIUWJ5hYcOTc6WhNbfJw==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@growthbook/growthbook/-/growthbook-0.36.0.tgz",
+      "integrity": "sha512-5u1x34H7pg5zS5db3UZ1Pn5hL/jj1EOWdUuz5tSIDUfW49TOWtxtrOAx0Qu1B+UmrIcZKE5XJr6TmWdmdOK12g==",
       "dependencies": {
         "dom-mutator": "^0.6.0"
       },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@aws-sdk/client-dynamodb": "^3.521.0",
     "@aws-sdk/client-secrets-manager": "^3.389.0",
     "@aws-sdk/lib-dynamodb": "^3.521.0",
-    "@growthbook/growthbook": "^0.34.0",
+    "@growthbook/growthbook": "^0.36.0",
     "@octokit/plugin-retry": "^6.0.0",
     "@octokit/rest": "^18.12.0",
     "@opengovsg/formsg-sdk": "^0.11.0",

--- a/src/middleware/featureFlag.ts
+++ b/src/middleware/featureFlag.ts
@@ -1,17 +1,21 @@
 import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
-import config from "@root/config/config"
+import { config } from "@root/config/config"
 import logger from "@root/logger/logger"
 import { RequestHandlerWithGrowthbook } from "@root/types"
 import { getNewGrowthbookInstance } from "@root/utils/growthbook-utils"
 
 // Keep one GrowthBook instance at module level
 // The instance will handle internal cache refreshes via a SSE connection
-const gb = getNewGrowthbookInstance(config.get("growthbook.clientKey"))
+const gb = getNewGrowthbookInstance({
+  clientKey: config.get("growthbook.clientKey"),
+  subscribeToChanges: true,
+})
 
-gb.loadFeatures({ autoRefresh: true }).catch((e: unknown) => {
-  logger.error(
-    `Failed to load features from GrowthBook at startup: ${JSON.stringify(e)}`
-  )
+gb.loadFeatures().catch((e: unknown) => {
+  logger.error({
+    error: e,
+    message: "Failed to load features from GrowthBook at startup",
+  })
 })
 
 // eslint-disable-next-line import/prefer-default-export
@@ -22,7 +26,10 @@ export const featureFlagMiddleware: RequestHandlerWithGrowthbook<
   never,
   { userWithSiteSessionData: UserWithSiteSessionData }
 > = async (req, res, next) => {
-  req.growthbook = getNewGrowthbookInstance(config.get("growthbook.clientKey"))
+  req.growthbook = getNewGrowthbookInstance({
+    clientKey: config.get("growthbook.clientKey"),
+    subscribeToChanges: false, // request-level instances should have immutable flag values
+  })
 
   // Clean up at the end of the request
   res.on("close", () => {
@@ -33,9 +40,10 @@ export const featureFlagMiddleware: RequestHandlerWithGrowthbook<
   req.growthbook
     .loadFeatures()
     .catch((e: unknown) => {
-      logger.error(
-        `Failed to load features from GrowthBook: ${JSON.stringify(e)}`
-      )
+      logger.error({
+        error: e,
+        message: "Failed to load features from GrowthBook",
+      })
     })
     .then(() => next())
 }

--- a/src/utils/growthbook-utils.ts
+++ b/src/utils/growthbook-utils.ts
@@ -1,15 +1,22 @@
 import { GrowthBook, setPolyfills } from "@growthbook/growthbook"
 
-import config from "@root/config/config"
+import { config } from "@root/config/config"
 import { FEATURE_FLAGS } from "@root/constants/featureFlags"
 import { FeatureFlags, CloudmersiveConfigType } from "@root/types/featureFlags"
 
 const GROWTHBOOK_API_HOST = "https://cdn.growthbook.io"
 
-export const getNewGrowthbookInstance = (clientKey: string) =>
+export const getNewGrowthbookInstance = ({
+  clientKey,
+  subscribeToChanges,
+}: {
+  clientKey: string
+  subscribeToChanges: boolean
+}) =>
   new GrowthBook<FeatureFlags>({
     apiHost: GROWTHBOOK_API_HOST,
     clientKey,
+    subscribeToChanges,
     enableDevMode: config.get("env") === "dev",
   })
 


### PR DESCRIPTION
## Problem

Using `autorefresh:true` in `growthbook.loadFeatures()` is an anti pattern.

`autorefresh:true` [translates to a subscribe on the instance](https://github.com/growthbook/growthbook/blob/v2.0.0/packages/sdk-js/src/GrowthBook.ts#L115-L122), which means the flags may be updated during the lifetime of a request.

In recent version of growthbook, `autorefresh:true` [has been deprecated](https://github.com/growthbook/growthbook/blob/v2.8.0/packages/sdk-js/src/GrowthBook.ts#L155-L158) in favour of a more explicit constructor setting `subscribeToChanges:true`, with a documented behaviour warning for middlewares [in documentation](https://docs.growthbook.io/lib/js#nodejs):
```
    // Important: make sure this is set to `false`, otherwise features may change in the middle of a request
    subscribeToChanges: false,
```

In addition, when the first request which loads the featureflag is in a middleware (typically the health endpoint at deployment), then the SSE call is created in context of the request, creating abnormally huge traces lasting days with thousands of spans. [Example here](https://ogp.datadoghq.com/apm/trace/8277262834568158153?colorBy=service&env=production&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=3383986745756776406&spanViewType=metadata&timeHint=1709470545168.802&view=spans) or [here](https://ogp.datadoghq.com/apm/trace/65f0f2f9000000007add984d58603d36?colorBy=service&env=production&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=7021684506432005181&spanViewType=metadata&timeHint=1710289657428.0059&view=spans)

![image](https://github.com/isomerpages/isomercms-backend/assets/935223/10ebc5dd-dc1b-4d05-b847-b5a5c4076a23)


## Solution

1. Upgrade growthbook to 0.36 to have have the new `subscribeToChanges` property available
2. Create a growthbook instance at startup time
3. load the feature immediately and subscribe to changes
4. Make the growthbook instances created in middleware NOT use `subscribeToChanges:true`


Bonus: Simplify the promise chain just a bit

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)


## Tests

* Load the cms and verify functionality gated by feature flag still exists (TODO: find a specific feature flag to test on)

