### PR TITLE
chore(package): use npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "source .env && docker compose -f docker-compose.dev.yml up",
     "test:docker": "docker run -d -p 54321:5432 --name postgres -e POSTGRES_USER=isomer -e POSTGRES_PASSWORD=password -e POSTGRES_DB=isomercms_test postgres:latest",
     "test": "source .env.test && jest --runInBand",
-    "release": "npm version $npm_config_isomer_update && git push --tags",
+    "release": "bash scripts/release_prep.sh",
     "lint": "npx eslint .",
     "lint-fix": "eslint --ignore-path .gitignore . --fix",
     "format": "npx prettier --check .",


### PR DESCRIPTION
## Problem
previously we were using `bash` to run the release script, which might not be obvious. this changes the release script to be invoked via `npm`

## Solution
alias old command to script