### PR TITLE
fix: reduce log size to just last commit

### DIFF
--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -421,6 +421,12 @@ export default class GitFileSystemService {
   ): ResultAsync<LogResult<DefaultLogFields>, GitFileSystemError> {
     const efsVolPath = this.getEfsVolPathFromBranch(branchName)
 
+    if (!Number.isInteger(maxCount) || maxCount < 1) {
+      return errAsync(
+        new GitFileSystemError(`Invalid maxCount value supplied: ${maxCount}`)
+      )
+    }
+
     return ResultAsync.fromPromise(
       this.git
         .cwd({ path: `${efsVolPath}/${repoName}`, root: false })

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -417,18 +417,14 @@ export default class GitFileSystemService {
   getGitLog(
     repoName: string,
     branchName: string,
-    maxCount?: number
+    maxCount = 1
   ): ResultAsync<LogResult<DefaultLogFields>, GitFileSystemError> {
     const efsVolPath = this.getEfsVolPathFromBranch(branchName)
-
-    const logArgs = [branchName]
-
-    if (maxCount) logArgs.unshift(`--max-count=${maxCount}`)
 
     return ResultAsync.fromPromise(
       this.git
         .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
-        .log(logArgs),
+        .log([`--max-count=${maxCount}`, branchName]),
 
       (error) => {
         logger.error(
@@ -1736,8 +1732,7 @@ export default class GitFileSystemService {
       .andThen((isBranchLocallyPresent) =>
         this.getGitLog(
           repoName,
-          isBranchLocallyPresent ? branchName : `origin/${branchName}`,
-          1
+          isBranchLocallyPresent ? branchName : `origin/${branchName}`
         )
       )
       .andThen((logSummary) => {

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -809,6 +809,34 @@ describe("GitFileSystemService", () => {
 
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
     })
+
+    it("should return GitFileSystemError if maxCount is supplied as a float", async () => {
+      const result = await GitFileSystemService.getGitLog(
+        "fake-repo",
+        "fake-commit-sha",
+        1.1 // float value
+      )
+
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
+    })
+
+    it("should return GitFileSystemError if a maxCount less than 1 is supplied", async () => {
+      const result1 = await GitFileSystemService.getGitLog(
+        "fake-repo",
+        "fake-commit-sha",
+        0
+      )
+
+      expect(result1._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
+
+      const result2 = await GitFileSystemService.getGitLog(
+        "fake-repo",
+        "fake-commit-sha",
+        -1
+      )
+
+      expect(result2._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
+    })
   })
 
   describe("rollback", () => {


### PR DESCRIPTION
## Problem

To get the last commit, we issue a full `git log` command which can returns and parse thousands of lines and commits. 

Some sites have a HUGE amount of commits (e.g. `nlb-biblioasia` which has over 50k commits!)

```bash
git log | grep 'commit ' | wc -l
```


## Solution

Use the arg `--max-count=1` to restrict resultset to just one commit when fetching the last commit 😑 🤷 



## Benchmark

Assuming you have `nlb-biblioasia` locally (peer of your isomercms checkout), run this script to show the difference between the 2

```javascript
const SimpleGit = require("simple-git")
const git = SimpleGit()
const ITERATIONS = 20;

async function run() {
    // prime FS cache if needed
    await git.cwd('../nlb-biblioasia').log(['staging']);

    let startTs, latest;

    startTs = Date.now();

    for (let idx=ITERATIONS; idx--; ) {
        latest = (await git.cwd('../nlb-biblioasia').log(['staging'])).latest;
    }

    console.log('unfiltered:', Date.now() - startTs);
    console.log(latest)
    console.log('====================')

    startTs = Date.now();

    for (let idx=ITERATIONS; idx--; ) {
        latest = (await git.cwd('../nlb-biblioasia').log(['--max-count=1', 'staging'])).latest;
    }

    console.log('last only:', Date.now() - startTs);
    console.log(latest)
    console.log('====================')
}

run();
```

Result
```
unfiltered: 12699
{
  hash: 'ef9c558be46df2f0c03174eeb1209f53d14ff34c',
  date: '2024-03-25T01:17:25+00:00',
  message: '{"message":"Update file: Memory, History, Art: Yip Yew Chong’s “I Paint my Singapore”.md","userId":"341","fileName":"Memory, History, Art: Yip Yew Chong’s “I Paint my Singapore”.md"}',
  refs: 'HEAD -> staging, origin/staging, origin/HEAD',
  body: '',
  author_name: 'Isomer Admin',
  author_email: 'admin@isomer.gov.sg'
}
====================
last only: 164
{
  hash: 'ef9c558be46df2f0c03174eeb1209f53d14ff34c',
  date: '2024-03-25T01:17:25+00:00',
  message: '{"message":"Update file: Memory, History, Art: Yip Yew Chong’s “I Paint my Singapore”.md","userId":"341","fileName":"Memory, History, Art: Yip Yew Chong’s “I Paint my Singapore”.md"}',
  refs: 'HEAD -> staging, origin/staging, origin/HEAD',
  body: '',
  author_name: 'Isomer Admin',
  author_email: 'admin@isomer.gov.sg'
}
====================
```

On that site, fetching just the last commit is nearly 100x faster 😑 🎉 

