### PR TITLE
fix(dockerfile): add dig to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /opt/isomercms-backend
 RUN apk update && \
   apk add --no-cache bash && \
   apk add git && \
-  apk add openssh-client
+  apk add openssh-client && \ 
+  apk add bind-tools
 
 RUN adduser -u 900 webapp -D -h /home/webapp -s /bin/sh
 USER webapp


### PR DESCRIPTION
## Problem
https://www.notion.so/opengov/2024-03-27-careers-gov-sg-misconfiguration-15469dbae95942588574db9d8e819177?pvs=4#c009bcd4e261452289d0d74463b37cb9

https://linear.app/ogp/issue/ISOM-881/add-dig-to-image-for-backend

## Solution
add `bind-tools` (`dig` + `nslookup` is part of this)

## Tests 
- [ ] `ecs exec` into staging
- [ ] run `dig www.google.com` 

## Images 
<img width="647" alt="Screenshot 2024-03-27 at 10 36 32 PM" src="https://github.com/isomerpages/isomercms-backend/assets/44049504/a09be492-1cee-458b-8b96-7f9e5a97d37c">
