### PR TITLE
fix(navbar): allow ext links

### DIFF
--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -378,8 +378,10 @@ const UpdateNavigationRequestSchema = Joi.object().keys({
                 Joi.object().keys({
                   title: Joi.string().required(),
                   url: Joi.string().required(),
+                  external: Joi.boolean(),
                 })
               ),
+              false_collection: Joi.boolean(),
             })
             .oxor("url", "collection", "resource_room")
             .oxor("sublinks", "collection")


### PR DESCRIPTION
## Problem

currently we have some agencies that use external links for their navbar. this brings back the backward compat with those agencies. 

for more context, refer [here](https://opengovproducts.slack.com/archives/CK68JNFHR/p1711596585315799) 

@seaerchin am adding another key, looks ugly but is affecting prod sites as of right now. let me know if you have concerns regarding this
