### PR TITLE
ISOM-824 feat: don't fetch redundant author info from db

### DIFF
--- a/src/services/infra/StatsService.ts
+++ b/src/services/infra/StatsService.ts
@@ -24,7 +24,7 @@ const getNpsVariant = (rating: number): NpsVariant => {
 }
 
 export class StatsService {
-  private readonly statsD: StatsD
+  readonly statsD: StatsD
 
   private readonly usersRepo: ModelStatic<User>
 

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -25,6 +25,7 @@ import PageParseError from "@root/errors/PageParseError"
 import PlaceholderParseError from "@root/errors/PlaceholderParseError"
 import RequestNotFoundError from "@root/errors/RequestNotFoundError"
 import logger from "@root/logger/logger"
+import { statsService } from "@root/services/infra/StatsService"
 import {
   BaseEditedItemDto,
   CommentItem,
@@ -457,13 +458,11 @@ export default class ReviewRequestService {
       )
     )
 
-    logger.info({
-      message: "computeShaMappings(): author query optimisation results",
-      meta: {
-        numCommits: commits.length,
-        numUniqueValidAuthors: validAuthorIds.size,
-      },
-    })
+    statsService.statsD.increment("review_requests.commits", commits.length)
+    statsService.statsD.increment(
+      "review_requests.commits.users",
+      validAuthorIds.size
+    )
 
     commits.forEach(({ commit, sha }, idx) => {
       const authorId = commitAuthorIds[idx]
@@ -490,13 +489,11 @@ export default class ReviewRequestService {
       await Promise.all(userIds.map((userId) => this.users.findByPk(userId)))
     )
 
-    logger.info({
-      message: "computeCommentData(): author query optimisation results",
-      meta: {
-        numComments: comments.length,
-        numUniqueValidUsers: userIds.length,
-      },
-    })
+    statsService.statsD.increment("review_requests.comments", comments.length)
+    statsService.statsD.increment(
+      "review_requests.comments.users",
+      userIds.length
+    )
 
     const mappings = comments.map(({ userId, message, createdAt }) => {
       const createdTime = new Date(createdAt)

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -459,11 +459,11 @@ export default class ReviewRequestService {
 
     commits.forEach(({ commit, sha }, idx) => {
       const authorId = commitAuthorIds[idx]
+      const author = authorId ? authorsById[authorId] : null
       const lastChangedTime = new Date(commit.author.date).getTime()
 
       mappings[sha] = {
-        author:
-          (authorId && authorsById[authorId]?.email) || commit.author.name,
+        author: author?.email || commit.author.name,
         unixTime: lastChangedTime,
       }
     })

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -454,7 +454,7 @@ export default class ReviewRequestService {
     const authorsById = zipObject(
       allAuthorIds,
       await Promise.all(
-        allAuthorIds.map(async (authorId) => this.users.findByPk(authorId))
+        allAuthorIds.map((authorId) => this.users.findByPk(authorId))
       )
     )
 

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -457,6 +457,14 @@ export default class ReviewRequestService {
       )
     )
 
+    logger.info({
+      message: "computeShaMappings(): author query optimisation results",
+      meta: {
+        numCommits: commits.length,
+        numUniqueValidAuthors: validAuthorIds.size,
+      },
+    })
+
     commits.forEach(({ commit, sha }, idx) => {
       const authorId = commitAuthorIds[idx]
       const author = authorId ? authorsById[authorId] : null

--- a/src/services/review/ReviewRequestService.ts
+++ b/src/services/review/ReviewRequestService.ts
@@ -483,7 +483,9 @@ export default class ReviewRequestService {
     viewedTime: Date | null
   ) => {
     // retrieve the comment users while minimizing the number of DB query
-    const userIds = [...new Set(comments.map(({ userId }) => userId))]
+    const userIds = [
+      ...new Set(comments.map(({ userId }) => userId).filter(_.identity)),
+    ]
     const userByIds = zipObject(
       userIds,
       await Promise.all(userIds.map((userId) => this.users.findByPk(userId)))

--- a/src/services/review/__tests__/ReviewRequestService.spec.ts
+++ b/src/services/review/__tests__/ReviewRequestService.spec.ts
@@ -1313,10 +1313,34 @@ describe("ReviewRequestService", () => {
         sha: "234",
         url: "",
         commit: {
+          message: JSON.stringify({ userId: 2 }),
+          url: "",
+          author: {
+            ...MOCK_GITHUB_COMMIT_AUTHOR_TWO,
+            date: new Date().toISOString(),
+          },
+        },
+      },
+      {
+        sha: "345",
+        url: "",
+        commit: {
           message: JSON.stringify({ userId: 1 }),
           url: "",
           author: {
             ...MOCK_GITHUB_COMMIT_AUTHOR_ONE,
+            date: new Date().toISOString(),
+          },
+        },
+      },
+      {
+        sha: "456",
+        url: "",
+        commit: {
+          message: JSON.stringify({ userId: 2 }),
+          url: "",
+          author: {
+            ...MOCK_GITHUB_COMMIT_AUTHOR_TWO,
             date: new Date().toISOString(),
           },
         },
@@ -1331,20 +1355,29 @@ describe("ReviewRequestService", () => {
           unixTime: new Date(mockCommits[0].commit.author.date).getTime(),
         },
         "234": {
+          author: MOCK_GITHUB_COMMIT_AUTHOR_TWO.email,
+          unixTime: new Date(mockCommits[1].commit.author.date).getTime(),
+        },
+        "345": {
           author: MOCK_GITHUB_COMMIT_AUTHOR_ONE.email,
-          unixTime: new Date(mockCommits[0].commit.author.date).getTime(),
+          unixTime: new Date(mockCommits[2].commit.author.date).getTime(),
+        },
+        "456": {
+          author: MOCK_GITHUB_COMMIT_AUTHOR_TWO.email,
+          unixTime: new Date(mockCommits[3].commit.author.date).getTime(),
         },
       }
-      MockUsersRepository.findByPk.mockResolvedValue(
-        MOCK_GITHUB_COMMIT_AUTHOR_ONE
-      )
+
+      MockUsersRepository.findByPk
+        .mockResolvedValueOnce(MOCK_GITHUB_COMMIT_AUTHOR_ONE)
+        .mockResolvedValueOnce(MOCK_GITHUB_COMMIT_AUTHOR_TWO)
 
       // Act
       const actual = await ReviewRequestService.computeShaMappings(mockCommits)
 
       // Assert
       expect(actual).toEqual(expected)
-      expect(MockUsersRepository.findByPk).toHaveBeenCalledTimes(1)
+      expect(MockUsersRepository.findByPk).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/src/services/review/__tests__/ReviewRequestService.spec.ts
+++ b/src/services/review/__tests__/ReviewRequestService.spec.ts
@@ -257,7 +257,7 @@ describe("ReviewRequestService", () => {
       // Arrange
       const mockComments: GithubCommentData[] = [
         MOCK_GITHUB_COMMENT_DATA_ONE,
-        MOCK_GITHUB_COMMENT_DATA_TWO,
+        MOCK_GITHUB_COMMENT_DATA_TWO, // same user id -_-
       ]
       const mockViewedTime = new Date("2022-09-23T00:00:00Z")
       const expected = [
@@ -268,17 +268,14 @@ describe("ReviewRequestService", () => {
           isRead: true,
         },
         {
-          user: MOCK_GITHUB_EMAIL_ADDRESS_TWO,
+          user: MOCK_GITHUB_EMAIL_ADDRESS_ONE,
           message: MOCK_GITHUB_COMMENT_TWO,
           createdAt: new Date(MOCK_GITHUB_DATE_TWO).getTime(),
           isRead: false,
         },
       ]
-      MockUsersRepository.findByPk.mockResolvedValueOnce(
+      MockUsersRepository.findByPk.mockResolvedValue(
         MOCK_GITHUB_COMMIT_AUTHOR_ONE
-      )
-      MockUsersRepository.findByPk.mockResolvedValueOnce(
-        MOCK_GITHUB_COMMIT_AUTHOR_TWO
       )
 
       // Act
@@ -289,14 +286,14 @@ describe("ReviewRequestService", () => {
 
       // Assert
       expect(actual).toEqual(expected)
-      expect(MockUsersRepository.findByPk).toHaveBeenCalledTimes(2)
+      expect(MockUsersRepository.findByPk).toHaveBeenCalledTimes(1)
     })
 
     it("should return the correct comment objects with viewedTime being null", async () => {
       // Arrange
       const mockComments: GithubCommentData[] = [
         MOCK_GITHUB_COMMENT_DATA_ONE,
-        MOCK_GITHUB_COMMENT_DATA_TWO,
+        MOCK_GITHUB_COMMENT_DATA_TWO, // same user id -_-
       ]
       const expected = [
         {
@@ -306,17 +303,14 @@ describe("ReviewRequestService", () => {
           isRead: false,
         },
         {
-          user: MOCK_GITHUB_EMAIL_ADDRESS_TWO,
+          user: MOCK_GITHUB_EMAIL_ADDRESS_ONE,
           message: MOCK_GITHUB_COMMENT_TWO,
           createdAt: new Date(MOCK_GITHUB_DATE_TWO).getTime(),
           isRead: false,
         },
       ]
-      MockUsersRepository.findByPk.mockResolvedValueOnce(
+      MockUsersRepository.findByPk.mockResolvedValue(
         MOCK_GITHUB_COMMIT_AUTHOR_ONE
-      )
-      MockUsersRepository.findByPk.mockResolvedValueOnce(
-        MOCK_GITHUB_COMMIT_AUTHOR_TWO
       )
 
       // Act
@@ -327,14 +321,14 @@ describe("ReviewRequestService", () => {
 
       // Assert
       expect(actual).toEqual(expected)
-      expect(MockUsersRepository.findByPk).toHaveBeenCalledTimes(2)
+      expect(MockUsersRepository.findByPk).toHaveBeenCalledTimes(1)
     })
 
     it("should return empty email string if user is not found", async () => {
       // Arrange
       const mockComments: GithubCommentData[] = [
         MOCK_GITHUB_COMMENT_DATA_ONE,
-        MOCK_GITHUB_COMMENT_DATA_TWO,
+        MOCK_GITHUB_COMMENT_DATA_TWO, // same user if -_-
       ]
       const expected = [
         {
@@ -350,8 +344,7 @@ describe("ReviewRequestService", () => {
           isRead: false,
         },
       ]
-      MockUsersRepository.findByPk.mockResolvedValueOnce(null)
-      MockUsersRepository.findByPk.mockResolvedValueOnce(null)
+      MockUsersRepository.findByPk.mockResolvedValue(null)
 
       // Act
       const actual = await ReviewRequestService.computeCommentData(
@@ -361,7 +354,7 @@ describe("ReviewRequestService", () => {
 
       // Assert
       expect(actual).toEqual(expected)
-      expect(MockUsersRepository.findByPk).toHaveBeenCalledTimes(2)
+      expect(MockUsersRepository.findByPk).toHaveBeenCalledTimes(1)
     })
 
     it("should return empty array if there are no comments", async () => {
@@ -512,7 +505,7 @@ describe("ReviewRequestService", () => {
         MOCK_REVIEW_REQUEST_ONE.reviewMeta.pullRequestNumber
       )
       expect(SpyReviewRequestService.computeCommentData).toHaveBeenCalled()
-      expect(MockUsersRepository.findByPk).toHaveBeenCalledTimes(2)
+      expect(MockUsersRepository.findByPk).toHaveBeenCalledTimes(1)
     })
 
     it("should return an array of basic review request objects with a mix of read and unread comments", async () => {
@@ -553,11 +546,8 @@ describe("ReviewRequestService", () => {
       MockReviewRequestViewRepository.findOne.mockResolvedValueOnce(
         MOCK_REVIEW_REQUEST_VIEW_ONE
       )
-      MockUsersRepository.findByPk.mockResolvedValueOnce({
+      MockUsersRepository.findByPk.mockResolvedValue({
         email: MOCK_IDENTITY_EMAIL_ONE,
-      })
-      MockUsersRepository.findByPk.mockResolvedValueOnce({
-        email: MOCK_IDENTITY_EMAIL_TWO,
       })
       MockReviewCommentApi.getCommentsForReviewRequest([
         MOCK_REVIEW_REQUEST_COMMENT,
@@ -587,7 +577,7 @@ describe("ReviewRequestService", () => {
         MOCK_REVIEW_REQUEST_ONE.reviewMeta.pullRequestNumber
       )
       expect(SpyReviewRequestService.computeCommentData).toHaveBeenCalled()
-      expect(MockUsersRepository.findByPk).toHaveBeenCalledTimes(2)
+      expect(MockUsersRepository.findByPk).toHaveBeenCalledTimes(1)
     })
 
     it("should return an array of basic review request objects with no comments", async () => {
@@ -1244,7 +1234,7 @@ describe("ReviewRequestService", () => {
       // Arrange
       const mockComments: GithubCommentData[] = [
         MOCK_GITHUB_COMMENT_DATA_ONE,
-        MOCK_GITHUB_COMMENT_DATA_TWO,
+        MOCK_GITHUB_COMMENT_DATA_TWO, // same user id -_-
       ]
       const expected = [
         {
@@ -1254,7 +1244,7 @@ describe("ReviewRequestService", () => {
           isRead: true,
         },
         {
-          user: MOCK_GITHUB_EMAIL_ADDRESS_TWO,
+          user: MOCK_GITHUB_EMAIL_ADDRESS_ONE,
           message: MOCK_GITHUB_COMMENT_TWO,
           createdAt: new Date(MOCK_GITHUB_DATE_TWO).getTime(),
           isRead: false,
@@ -1267,11 +1257,8 @@ describe("ReviewRequestService", () => {
       MockReviewRequestViewRepository.findOne.mockResolvedValueOnce(
         MOCK_REVIEW_REQUEST_VIEW_ONE
       )
-      MockUsersRepository.findByPk.mockResolvedValueOnce(
+      MockUsersRepository.findByPk.mockResolvedValue(
         MOCK_GITHUB_COMMIT_AUTHOR_ONE
-      )
-      MockUsersRepository.findByPk.mockResolvedValueOnce(
-        MOCK_GITHUB_COMMIT_AUTHOR_TWO
       )
 
       // Act


### PR DESCRIPTION
## Problem

`computeShaMappings()` does one query `this.users.findByPk(userId)` for each author of all commits on the review. All the DB queries are issued in parallel. For large changeset with many commits, we expect the set of authors to be less than the number of commits, and so the process sometimes issues many redundant queries in parallel.

![image](https://github.com/isomerpages/isomercms-backend/assets/935223/7eb8a766-8804-4d6d-af20-bf5a7454ed87)
![image](https://github.com/isomerpages/isomercms-backend/assets/935223/5bbbef69-e673-4e85-98fc-e121d3c8251e)

Goal: reduce the number of queries to the minimum required.


## Solution

* From the list of commits, identify the sets of unique authors
* Fetch author data in parallel as before on that minimized set
* Generate the mappings from the author data

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

TODO:
- [x] Log the gains the PR does (i.e. how many query we are making versus how many commits there were.

## Notes:
* ~~The same inefficient process of blindly retrieving user details (possibly with redundant calls) exist for `computeCommentData()`, the same fix should be done there as well.~~ DONE!
* We could investigate having a LRU cache for userId => userDetails that can be used to drop some queries entirely


