### PR TITLE
fix(lock): fix early release of lock

### DIFF
--- a/src/middleware/routeHandler.ts
+++ b/src/middleware/routeHandler.ts
@@ -245,15 +245,15 @@ export const attachRollbackRouteHandlerWrapper: RouteWrapper<
     }
   }
 
-  Promise.resolve(routeHandler(req, res, next))
-    .then(async () => {
+  Promise.resolve(routeHandler(req, res, next)).then(
+    async () => {
       try {
         await unlock(siteName)
       } catch (err) {
         next(err)
       }
-    })
-    .catch(async (err: Error) => {
+    },
+    async (err: Error) => {
       try {
         if (shouldUseGitFileSystem) {
           await backOff(
@@ -320,5 +320,6 @@ export const attachRollbackRouteHandlerWrapper: RouteWrapper<
       }
       await unlock(siteName)
       next(err)
-    })
+    }
+  )
 }


### PR DESCRIPTION
## Problem

Currently, we are releasing the lock before the promise gets resolved, which then leads to the lock becoming effectively useless as it does not guarantee that each mutation on the repo is isolated from one another. This would prob lead to more users complaining that there are concurrent editors, but there might be further optimisations that could be done to reduce the frequency of this. 


## Solution

dont release lock early

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)


## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
![Screenshot 2024-04-01 at 7 37 00 AM](https://github.com/isomerpages/isomercms-backend/assets/42832651/10a233fb-9b0d-46a8-ba4b-24bdc647fcfc)

**AFTER**:

<!-- [insert screenshot here] -->
![Screenshot 2024-04-01 at 7 39 11 AM](https://github.com/isomerpages/isomercms-backend/assets/42832651/796d7f2c-6942-4593-9412-87ee1f36106f)

## Tests

[ ] Go into any site and perform CRUD operations on a page level for a repo in efs.

