### PR TITLE
fix: only release the lock after the handler is done

### DIFF
--- a/src/middleware/routeHandler.ts
+++ b/src/middleware/routeHandler.ts
@@ -108,16 +108,19 @@ export const attachWriteRouteHandlerWrapper: RouteWrapper<{
     return
   }
 
-  Promise.resolve(routeHandler(req, res, next)).catch(async (err: Error) => {
-    await unlock(siteName)
-    next(err)
-  })
-
-  try {
-    await unlock(siteName)
-  } catch (err) {
-    next(err)
-  }
+  Promise.resolve(routeHandler(req, res, next)).then(
+    async () => {
+      try {
+        await unlock(siteName)
+      } catch (err) {
+        next(err)
+      }
+    },
+    async (err) => {
+      await unlock(siteName)
+      next(err)
+    }
+  )
 }
 
 export const attachRollbackRouteHandlerWrapper: RouteWrapper<


### PR DESCRIPTION
## Problem

For write routes, the site lock is released too early, which makes the lock useless

This is a sibling PR to https://github.com/isomerpages/isomercms-backend/pull/1256, which introduced the same fix for the rollback routes.

## Solution

Only release the lock AFTER the action for the handler is completed. 

Notes:
1. For this to work (same a rollback routes), there is an assumption that ALL write route handlers are async and resolve when their job is done, but that is NOT enforced from typings. The handler is of type `RequestHandler` which is not specified to return a `Promise`, it returns `void`.
2. The handling of the express flow still looks wrong and should be discussed. When the handler is successful, and the lock fails to release, does it really make sense to call `next(err)`? The query was handled successfully, and failure to release the lock could be retried or just logged (and tracked!)

