### PR TITLE
fix(server): server should die if unable to connect to db

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -487,5 +487,5 @@ sequelize
 
     // If we cannot connect to the db, report an error using status code
     // And gracefully shut down the application since we can't serve client
-    process.exitCode = 1
+    process.exit(1)
   })


### PR DESCRIPTION
## Problem

something in me wanted to check if we indeed exit if we fail to connect to db, and the answer is... no 


[node.js](https://nodejs.org/docs/latest-v18.x/api/process.html#processexitcode_1) states that 
> A number which will be the process exit code, when the process either exits gracefully, or is exited via process.exit() without specifying a code.

so it does not actually do the exiting, which leads to silent failures 

