### PR TITLE
Improve APM spans (no more "<anonymous>"!)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@opengovsg/sgid-client": "^2.0.0",
         "@types/dompurify": "^3.0.5",
         "@types/node": "^20.11.13",
-        "auto-bind": "^4.0.0",
+        "auto-bind": "4.0.0",
         "aws-lambda": "^1.0.7",
         "aws-sdk": "^2.1565.0",
         "axios": "^1.6.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@opengovsg/sgid-client": "^2.0.0",
     "@types/dompurify": "^3.0.5",
     "@types/node": "^20.11.13",
-    "auto-bind": "^4.0.0",
+    "auto-bind": "4.0.0",
     "aws-lambda": "^1.0.7",
     "aws-sdk": "^2.1565.0",
     "axios": "^1.6.5",

--- a/patches/auto-bind+4.0.0.patch
+++ b/patches/auto-bind+4.0.0.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/auto-bind/index.js b/node_modules/auto-bind/index.js
+index c4487af..200e1b9 100644
+--- a/node_modules/auto-bind/index.js
++++ b/node_modules/auto-bind/index.js
+@@ -35,7 +35,18 @@ module.exports = (self, {include, exclude} = {}) => {
+ 
+ 		const descriptor = Reflect.getOwnPropertyDescriptor(object, key);
+ 		if (descriptor && typeof descriptor.value === 'function') {
++			const originalName = self[key].name
++
+ 			self[key] = self[key].bind(self);
++
++			// after binding the method names will be "bound methodName"
++			// We reset the name to the original to drop the bound
++			// OR, we set the name to the method key if the method was anonymous
++			// Note that alternatively, we could conditionally set the name ONLY for anonymous function
++			Object.defineProperty(self[key], "name", {
++				value: originalName || key,
++				writable: false,
++			})
+ 		}
+ 	}
+ 

--- a/src/middleware/routeHandler.ts
+++ b/src/middleware/routeHandler.ts
@@ -83,11 +83,16 @@ const nameRouteHandlerWrapper = <
   Params = Record<string, unknown>,
   Locals extends Record<string, unknown> = Record<string, unknown>
 >(
-  func: RequestHandler<Params, ResBody, ReqBody, ReqQuery, Locals>,
-  name: string
+  wrapper: RequestHandler<Params, ResBody, ReqBody, ReqQuery, Locals>,
+  original: { name: string }
 ): RequestHandler<Params, ResBody, ReqBody, ReqQuery, Locals> => {
-  Object.defineProperty(func, "name", { value: name, writable: false })
-  return func
+  if (original.name) {
+    Object.defineProperty(wrapper, "name", {
+      value: original.name,
+      writable: false,
+    })
+  }
+  return wrapper
 }
 
 // Used when there are no write API calls to the repo on GitHub
@@ -96,7 +101,7 @@ export const attachReadRouteHandlerWrapper: RouteWrapper = (routeHandler) =>
     Promise.resolve(routeHandler(req, res, next)).catch((err: Error) => {
       next(err)
     })
-  }, routeHandler.name)
+  }, routeHandler)
 
 // Used when there are write API calls to the repo on GitHub
 export const attachWriteRouteHandlerWrapper: RouteWrapper<{
@@ -135,7 +140,7 @@ export const attachWriteRouteHandlerWrapper: RouteWrapper<{
         next(err)
       }
     )
-  }, routeHandler.name)
+  }, routeHandler)
 
 export const attachRollbackRouteHandlerWrapper: RouteWrapper<
   {
@@ -340,4 +345,4 @@ export const attachRollbackRouteHandlerWrapper: RouteWrapper<
         next(err)
       }
     )
-  }, routeHandler.name)
+  }, routeHandler)


### PR DESCRIPTION
## Problem

We have a lot of spans in APM traces which are `<anonymous>`. While not a deal breaker to get value out of APM, it is annoying.

![image](https://github.com/isomerpages/isomercms-backend/assets/935223/5c92b2ca-f877-49a9-8f1e-acf4b7619942)

The anonymous functions are due to the way some methods are declared in classes, which is done to be able to specify types.

e.g. in [`ReviewsRouter`](https://github.com/isomerpages/isomercms-backend/blob/develop/src/routes/v2/authenticated/review.ts#L92-L100), the assignment syntax creates anonymous methods
```typescript
  compareDiff: RequestHandler<
    { siteName: string },
    { items: EditedItemDto[] } | ResponseErrorBody,
    unknown,
    unknown,
    { userWithSiteSessionData: UserWithSiteSessionData }
  > = async (req, res) => {
    // ... 
  }
```
while in `collectionPages`, this style of named method works:
```typescript
  async updateCollectionPage(req, res, next) {
    // ...
  }
```

TODO: We should ensure that all methods we use as express route handlers are named to have nice usable traces



## Solution

⚠️⚠️⚠️ FOR DISCUSSION ⚠️⚠️⚠️

Disclaimer: I practically never patch dependencies - I swear!!! 😅 It is just a coincidence that autobind does nearly exactly what we need in this case, minus setting the method name!. Patching autobind is the smallest amount of work and change that gets the result we want. Still patching is "dirty", we can consider a larger changeset to make our own function naming system - @kishore03109 your input would be very much appreciated! 🙏 

So interestingly, we already run a utility in most of our classes to update all instance methods: `auto-bind`! `autobind` does exactly what we need to do in term of finding the methods, but it does not set the name of the method when it is an anonymous functions.

`autobind` is used in the following files:

```bash
$ git grep 'autoBind(this)'

src/middleware/authentication.ts:    autoBind(this)
src/middleware/authorization.ts:    autoBind(this)
src/middleware/notificationOnEditHandler.ts:    autoBind(this)
src/middleware/stats.ts:    autoBind(this)
src/routes/formsg/formsgSiteCreation.ts:    autoBind(this)
src/routes/formsg/formsgSiteLaunch.ts:    autoBind(this)
src/routes/v2/auth.js:    autoBind(this)
src/routes/v2/authenticated/collaborators.ts:    autoBind(this)
src/routes/v2/authenticated/netlifyToml.js:    autoBind(this)
src/routes/v2/authenticated/notifications.ts:    autoBind(this)
src/routes/v2/authenticated/review.ts:    autoBind(this)
src/routes/v2/authenticated/sites.ts:    autoBind(this)
src/routes/v2/authenticated/users.ts:    autoBind(this)
src/routes/v2/authenticatedSites/collectionPages.js:    autoBind(this)
src/routes/v2/authenticatedSites/collections.js:    autoBind(this)
src/routes/v2/authenticatedSites/contactUs.js:    autoBind(this)
src/routes/v2/authenticatedSites/homepage.js:    autoBind(this)
src/routes/v2/authenticatedSites/media.ts:    autoBind(this)
src/routes/v2/authenticatedSites/navigation.js:    autoBind(this)
src/routes/v2/authenticatedSites/repoManagement.ts:    autoBind(this)
src/routes/v2/authenticatedSites/resourceCategories.js:    autoBind(this)
src/routes/v2/authenticatedSites/resourcePages.js:    autoBind(this)
src/routes/v2/authenticatedSites/resourceRoom.js:    autoBind(this)
src/routes/v2/authenticatedSites/settings.js:    autoBind(this)
src/routes/v2/authenticatedSites/unlinkedPages.js:    autoBind(this)
src/routes/v2/sgidAuth.ts:    autoBind(this)
src/services/configServices/SettingsService.js:    autoBind(this)
src/services/infra/DynamoDBClient.ts:    autoBind(this)
src/services/infra/DynamoDBService.ts:    autoBind(this)
```

While we could embark on a large changeset to either update all the files to change the method declaration, or perform our own iterations to give names to anonymous function. We can patch auto-bind to add the function naming for us.


This PR:
- patch autobind to give a name to all functions that are being bound (the code also drops the prefix "bound " from the name
- refactors `routeHandler.nameRouteHandlerWrapper()` to have a more explicit signature and behaviour


## Tests
- [ ] Load the CMS and perform some actions, all happy paths should work
- [ ] Find a span for a Review compare, and verify the span name is `compareDiff` (**NOT** `<anonymous>`)

