### PR TITLE
Improve APM spans (no more <anonymous>)

### DIFF
--- a/src/middleware/routeHandler.ts
+++ b/src/middleware/routeHandler.ts
@@ -88,7 +88,7 @@ const nameRouteHandlerWrapper = <
 ): RequestHandler<Params, ResBody, ReqBody, ReqQuery, Locals> => {
   if (original.name) {
     Object.defineProperty(wrapper, "name", {
-      value: original.name,
+      value: original.name.replace(/^bound /, ""),
       writable: false,
     })
   }

--- a/src/middleware/routeHandler.ts
+++ b/src/middleware/routeHandler.ts
@@ -83,11 +83,16 @@ const nameRouteHandlerWrapper = <
   Params = Record<string, unknown>,
   Locals extends Record<string, unknown> = Record<string, unknown>
 >(
-  func: RequestHandler<Params, ResBody, ReqBody, ReqQuery, Locals>,
-  name: string
+  wrapper: RequestHandler<Params, ResBody, ReqBody, ReqQuery, Locals>,
+  original: { name: string }
 ): RequestHandler<Params, ResBody, ReqBody, ReqQuery, Locals> => {
-  Object.defineProperty(func, "name", { value: name, writable: false })
-  return func
+  if (original.name) {
+    Object.defineProperty(wrapper, "name", {
+      value: original.name,
+      writable: false,
+    })
+  }
+  return wrapper
 }
 
 // Used when there are no write API calls to the repo on GitHub
@@ -96,7 +101,7 @@ export const attachReadRouteHandlerWrapper: RouteWrapper = (routeHandler) =>
     Promise.resolve(routeHandler(req, res, next)).catch((err: Error) => {
       next(err)
     })
-  }, routeHandler.name)
+  }, routeHandler)
 
 // Used when there are write API calls to the repo on GitHub
 export const attachWriteRouteHandlerWrapper: RouteWrapper<{
@@ -135,7 +140,7 @@ export const attachWriteRouteHandlerWrapper: RouteWrapper<{
         next(err)
       }
     )
-  }, routeHandler.name)
+  }, routeHandler)
 
 export const attachRollbackRouteHandlerWrapper: RouteWrapper<
   {
@@ -340,4 +345,4 @@ export const attachRollbackRouteHandlerWrapper: RouteWrapper<
         next(err)
       }
     )
-  }, routeHandler.name)
+  }, routeHandler)

--- a/src/routes/formsg/formsgSiteCreation.ts
+++ b/src/routes/formsg/formsgSiteCreation.ts
@@ -11,6 +11,7 @@ import { BadRequestError } from "@errors/BadRequestError"
 import { getField } from "@utils/formsg-utils"
 
 import { attachFormSGHandler } from "@root/middleware"
+import { nameAnonymousMethods } from "@root/utils/apm-utils"
 import GitFileSystemService from "@services/db/GitFileSystemService"
 import UsersService from "@services/identity/UsersService"
 import InfraService from "@services/infra/InfraService"
@@ -45,6 +46,7 @@ export class FormsgSiteCreateRouter {
     this.infraService = infraService
     this.gitFileSystemService = gitFileSystemService
     // We need to bind all methods because we don't invoke them from the class directly
+    nameAnonymousMethods(this)
     autoBind(this)
   }
 

--- a/src/routes/formsg/formsgSiteLaunch.ts
+++ b/src/routes/formsg/formsgSiteLaunch.ts
@@ -27,6 +27,7 @@ import {
 import TRUSTED_AMPLIFY_CAA_RECORDS from "@root/types/caaAmplify"
 import { isErrnoException } from "@root/types/nodeError"
 import { SiteLaunchResult } from "@root/types/siteLaunch"
+import { nameAnonymousMethods } from "@root/utils/apm-utils"
 import UsersService from "@services/identity/UsersService"
 import InfraService from "@services/infra/InfraService"
 
@@ -150,6 +151,7 @@ export class FormsgSiteLaunchRouter {
     this.usersService = usersService
     this.infraService = infraService
     // We need to bind all methods because we don't invoke them from the class directly
+    nameAnonymousMethods(this)
     autoBind(this)
   }
 

--- a/src/routes/v2/authenticated/collaborators.ts
+++ b/src/routes/v2/authenticated/collaborators.ts
@@ -13,6 +13,7 @@ import { attachSiteHandler } from "@root/middleware"
 import { RouteCheckerMiddleware } from "@root/middleware/routeChecker"
 import { RequestHandler } from "@root/types"
 import { UserDto } from "@root/types/dto/review"
+import { nameAnonymousMethods } from "@root/utils/apm-utils"
 import { CreateCollaboratorRequestSchema } from "@root/validators/RequestSchema"
 import CollaboratorsService from "@services/identity/CollaboratorsService"
 
@@ -33,6 +34,7 @@ export class CollaboratorsRouter {
   }: CollaboratorsRouterProps) {
     this.collaboratorsService = collaboratorsService
     this.authorizationMiddleware = authorizationMiddleware
+    nameAnonymousMethods(this)
     autoBind(this)
   }
 

--- a/src/routes/v2/authenticated/notifications.ts
+++ b/src/routes/v2/authenticated/notifications.ts
@@ -10,6 +10,7 @@ import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import { attachSiteHandler } from "@root/middleware"
 import { AuthorizationMiddleware } from "@root/middleware/authorization"
 import { RequestHandler } from "@root/types"
+import { nameAnonymousMethods } from "@root/utils/apm-utils"
 import NotificationsService, {
   NotificationResponse,
 } from "@services/identity/NotificationsService"
@@ -31,6 +32,7 @@ export class NotificationsRouter {
   }: NotificationsRouterProps) {
     this.notificationsService = notificationsService
     this.authorizationMiddleware = authorizationMiddleware
+    nameAnonymousMethods(this)
     autoBind(this)
   }
 

--- a/src/routes/v2/authenticated/review.ts
+++ b/src/routes/v2/authenticated/review.ts
@@ -31,6 +31,7 @@ import {
   BlobDiffDto,
   EditedItemDto,
 } from "@root/types/dto/review"
+import { nameAnonymousMethods } from "@root/utils/apm-utils"
 import {
   CreateCommentSchema,
   CreateReviewRequestSchema,
@@ -66,6 +67,7 @@ export class ReviewsRouter {
     this.notificationsService = notificationsService
     this.githubService = githubService
 
+    nameAnonymousMethods(this)
     autoBind(this)
   }
 

--- a/src/routes/v2/authenticated/sites.ts
+++ b/src/routes/v2/authenticated/sites.ts
@@ -21,6 +21,7 @@ import { RepositoryData } from "@root/types/repoInfo"
 import { BrokenLinkErrorDto } from "@root/types/siteChecker"
 import { SiteInfo, SiteLaunchDto } from "@root/types/siteInfo"
 import { StagingBuildStatus } from "@root/types/stagingBuildStatus"
+import { nameAnonymousMethods } from "@root/utils/apm-utils"
 import {
   GetPreviewInfoSchema,
   LaunchSiteSchema,
@@ -60,6 +61,7 @@ export class SitesRouter {
     this.infraService = infraService
     this.repoCheckerService = repoCheckerService
     // We need to bind all methods because we don't invoke them from the class directly
+    nameAnonymousMethods(this)
     autoBind(this)
   }
 

--- a/src/routes/v2/authenticated/users.ts
+++ b/src/routes/v2/authenticated/users.ts
@@ -13,6 +13,7 @@ import UserSessionData from "@classes/UserSessionData"
 
 import DatabaseError from "@root/errors/DatabaseError"
 import { isError, RequestHandler } from "@root/types"
+import { nameAnonymousMethods } from "@root/utils/apm-utils"
 import {
   VerifyEmailOtpSchema,
   VerifyMobileNumberOtpSchema,
@@ -29,6 +30,7 @@ export class UsersRouter {
 
   constructor({ usersService }: UsersRouterProps) {
     this.usersService = usersService
+    nameAnonymousMethods(this)
     autoBind(this)
   }
 

--- a/src/routes/v2/authenticatedSites/media.ts
+++ b/src/routes/v2/authenticatedSites/media.ts
@@ -17,6 +17,7 @@ import type {
   MediaFileOutput,
   RequestHandler,
 } from "@root/types"
+import { nameAnonymousMethods } from "@root/utils/apm-utils"
 import {
   CreateMediaDirectoryRequestSchema,
   CreateMediaFileRequestSchema,
@@ -44,6 +45,7 @@ export class MediaRouter {
     this.mediaFileService = mediaFileService
     this.mediaDirectoryService = mediaDirectoryService
     // We need to bind all methods because we don't invoke them from the class directly
+    nameAnonymousMethods(this)
     autoBind(this)
   }
 

--- a/src/routes/v2/authenticatedSites/repoManagement.ts
+++ b/src/routes/v2/authenticatedSites/repoManagement.ts
@@ -11,6 +11,7 @@ import UserWithSiteSessionData from "@root/classes/UserWithSiteSessionData"
 import GitFileSystemError from "@root/errors/GitFileSystemError"
 import { attachSiteHandler } from "@root/middleware"
 import type { RequestHandler } from "@root/types"
+import { nameAnonymousMethods } from "@root/utils/apm-utils"
 import { ResetRepoSchema } from "@root/validators/RequestSchema"
 import RepoManagementService from "@services/admin/RepoManagementService"
 
@@ -30,6 +31,7 @@ export class RepoManagementRouter {
   }: RepoManagementRouterProps) {
     this.repoManagementService = repoManagementService
     this.authorizationMiddleware = authorizationMiddleware
+    nameAnonymousMethods(this)
     autoBind(this)
   }
 

--- a/src/routes/v2/sgidAuth.ts
+++ b/src/routes/v2/sgidAuth.ts
@@ -19,6 +19,7 @@ import {
 import { RequestHandler } from "@root/types"
 import { ResponseErrorBody } from "@root/types/dto/error"
 import { isPublicOfficerData, PublicOfficerData } from "@root/types/sgid"
+import { nameAnonymousMethods } from "@root/utils/apm-utils"
 import { isSecure } from "@root/utils/auth-utils"
 import { EmailSchema } from "@root/validators/RequestSchema"
 import UsersService from "@services/identity/UsersService"
@@ -42,6 +43,7 @@ export class SgidAuthRouter {
   constructor({ usersService, sgidAuthService }: SgidAuthRouterProps) {
     this.usersService = usersService
     this.sgidAuthService = sgidAuthService
+    nameAnonymousMethods(this)
     autoBind(this)
   }
 

--- a/src/utils/apm-utils.ts
+++ b/src/utils/apm-utils.ts
@@ -1,0 +1,28 @@
+/* eslint-disable import/prefer-default-export */
+/**
+ * A function to set the name of anonymous methods on an object, all the way into the prototype chain
+ * This is useful to be reported in APM traces and spans
+ * This is an unconventional thing to do, so we have to disable a couple of eslint rules
+ */
+export const nameAnonymousMethods = <SelfType extends { [key: string]: any }>(
+  self: SelfType
+): SelfType => {
+  /* eslint-disable no-restricted-syntax */
+  /* eslint-disable no-continue */
+  for (const methodName in self) {
+    if (methodName === "constructor") continue
+
+    const method = self[methodName]
+    if (typeof method !== "function") continue
+    if (method.name) continue
+
+    Object.defineProperty(method, "name", {
+      value: methodName,
+      writable: false,
+    })
+  }
+  /* eslint-enable no-restricted-syntax */
+  /* eslint-enable no-continue */
+
+  return self
+}

--- a/src/utils/apm-utils.ts
+++ b/src/utils/apm-utils.ts
@@ -21,8 +21,5 @@ export const nameAnonymousMethods = <SelfType extends { [key: string]: any }>(
       writable: false,
     })
   }
-  /* eslint-enable no-restricted-syntax */
-  /* eslint-enable no-continue */
-
   return self
 }


### PR DESCRIPTION
## Problem

We have a lot of spans in APM traces which are `<anonymous>`. While not a deal breaker to get value out of APM, it is annoying.

![image](https://github.com/isomerpages/isomercms-backend/assets/935223/5c92b2ca-f877-49a9-8f1e-acf4b7619942)

The anonymous functions are due to the way some methods are declared in classes, which is done to be able to specify types.

e.g. in [`ReviewsRouter.ts`](https://github.com/isomerpages/isomercms-backend/blob/develop/src/routes/v2/authenticated/review.ts#L92-L100), the assignment syntax creates anonymous methods
```typescript
  compareDiff: RequestHandler<
    { siteName: string },
    { items: EditedItemDto[] } | ResponseErrorBody,
    unknown,
    unknown,
    { userWithSiteSessionData: UserWithSiteSessionData }
  > = async (req, res) => {
    // ... 
  }
```
while in [`collectionPages.js`](https://github.com/isomerpages/isomercms-backend/blob/develop/src/routes/v2/authenticatedSites/collectionPages.js), this style of named method works:
```typescript
  async updateCollectionPage(req, res, next) {
    // ...
  }
```

Note: The first style of method declaration (assignment) does **NOT** create methods on the class' prototype. The methods are created on the instance themselves at construction (and so just FYI the call to `autoBind(this)` are actually useless for classes which only use that style of declaration)


TODO: We should ensure that all methods we use as express route handlers are named to have nice usable traces



## Solution

* Provide a utility `nameAnonymousMethods()` to ensure all methods of an instance and its class are named (invoked at construction)
* Update all router classes (ts files) to ensure all methods are named

Updating the Router classes was done via the script below, which was then cleaned up on commit by eslint/prettier:
```bash
grep 'autoBind(this)' $(git grep Router | grep class | grep Router | cut -d: -f1) | cut -d: -f1 | grep -v -E '.js$' | while read f; do
  echo 'import { nameAnonymousMethods } from "@root/utils/apm-utils"' > temp;
  sed -E -e 's/autoBind\(this\)/nameAnonymousMethods(this);autoBind(this)/' "${f}" >> temp;
  mv temp "${f}";
done
```

Verified on staging:
![image](https://github.com/isomerpages/isomercms-backend/assets/935223/a834d33f-a0b2-4ba7-b319-d64ef5ca8972)


## Tests
- [x] Load the CMS and perform some actions, all happy paths should work
- [x] Find a span for a Review compare, and verify the span name is `compareDiff` (**NOT** `<anonymous>`)

