### PR TITLE
fix: remove unnecessary join and site retrieval

### DIFF
--- a/src/services/identity/NotificationsService.ts
+++ b/src/services/identity/NotificationsService.ts
@@ -228,6 +228,7 @@ class NotificationsService {
     const recentTargetNotification = await this.repository.findOne({
       where: {
         user_id: siteMember.userId,
+        site_id: siteMember.siteId,
         type: notificationType,
         created_at: {
           [Op.gte]: getNotificationExpiryDate(notificationType),
@@ -235,16 +236,6 @@ class NotificationsService {
         link,
         source_username: notificationSourceUsername,
       },
-      include: [
-        {
-          model: Site,
-          as: "site",
-          required: true,
-          where: {
-            id: siteMember.siteId,
-          },
-        },
-      ],
     })
 
     if (recentTargetNotification) {


### PR DESCRIPTION
## Problem

Creating a review request can create a lot of notification, where the prelim search is very expensive. See [sample trace here](https://ogp.datadoghq.com/apm/trace/1838468539673357242?colorBy=service&env=production&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=4348314207189470064&spanViewType=metadata&timeHint=1712136769385&view=spans), screenshotted below for reference:

![image](https://github.com/isomerpages/isomercms-backend/assets/935223/16dd7d11-5438-462e-bc1f-45e5f815fbeb)


The search query does an unnecessary join on the site table. The join is not needed since the site id is already known.

TODO: Remove unnecessary join

Note that even on much smaller traces, not at peak time (~9pm), the pattern of having the selects take much longer than the insert/updates hold. Here is [another sample trace](https://ogp.datadoghq.com/apm/trace/8161601024562039339?colorBy=service&env=production&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=5033923360487192116&spanViewType=metadata&timeHint=1712148829754&view=spans) for reference.


## Solution

Remove the unnecessary join!

The change is fully backward compatible.