### PR TITLE
fix: external links in top level nav

### DIFF
--- a/src/validators/RequestSchema.js
+++ b/src/validators/RequestSchema.js
@@ -382,6 +382,7 @@ const UpdateNavigationRequestSchema = Joi.object().keys({
                 })
               ),
               false_collection: Joi.boolean(),
+              external: Joi.boolean(),
             })
             .oxor("url", "collection", "resource_room")
             .oxor("sublinks", "collection")


### PR DESCRIPTION
## Problem

This PR adds an additional allowance for legacy nav bars to have an `external` field for top level navs (e.g. 
```
- title: News
    url: https://www.mlaw.gov.sg/news/
    external: true
```

Related to https://github.com/isomerpages/isomercms-backend/pull/1250