### PR TITLE
chore: index notifications table

### DIFF
--- a/src/database/migrations/20240405132731-add-notification-indexes.js
+++ b/src/database/migrations/20240405132731-add-notification-indexes.js
@@ -1,44 +1,24 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    queryInterface.sequelize.transaction((t) =>
-      Promise.all([
-        queryInterface.addIndex(
-          "notifications", // name of Source model
-          ["site_id", "user_id"],
-          {
-            transaction: t,
-          }
-        ),
-        queryInterface.addIndex(
-          "notifications", // name of Source model
-          ["user_id"],
-          {
-            transaction: t,
-          }
-        ),
-      ])
+    await queryInterface.addIndex(
+      "notifications", // name of Source model
+      ["site_id", "user_id"]
+    )
+    await queryInterface.addIndex(
+      "notifications", // name of Source model
+      ["user_id"]
     )
   },
 
   async down(queryInterface, Sequelize) {
-    queryInterface.sequelize.transaction((t) =>
-      Promise.all([
-        queryInterface.removeIndex(
-          "notifications", // name of Source model
-          ["site_id", "user_id"],
-          {
-            transaction: t,
-          }
-        ),
-        queryInterface.removeIndex(
-          "notifications", // name of Source model
-          ["user_id"],
-          {
-            transaction: t,
-          }
-        ),
-      ])
+    await queryInterface.removeIndex(
+      "notifications", // name of Source model
+      ["site_id", "user_id"]
+    )
+    await queryInterface.removeIndex(
+      "notifications", // name of Source model
+      ["user_id"]
     )
   },
 }

--- a/src/database/migrations/20240405132731-add-notification-indexes.js
+++ b/src/database/migrations/20240405132731-add-notification-indexes.js
@@ -1,0 +1,44 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    queryInterface.sequelize.transaction((t) =>
+      Promise.all([
+        queryInterface.addIndex(
+          "notifications", // name of Source model
+          ["site_id", "user_id"],
+          {
+            transaction: t,
+          }
+        ),
+        queryInterface.addIndex(
+          "notifications", // name of Source model
+          ["user_id"],
+          {
+            transaction: t,
+          }
+        ),
+      ])
+    )
+  },
+
+  async down(queryInterface, Sequelize) {
+    queryInterface.sequelize.transaction((t) =>
+      Promise.all([
+        queryInterface.removeIndex(
+          "notifications", // name of Source model
+          ["site_id", "user_id"],
+          {
+            transaction: t,
+          }
+        ),
+        queryInterface.removeIndex(
+          "notifications", // name of Source model
+          ["user_id"],
+          {
+            transaction: t,
+          }
+        ),
+      ])
+    )
+  },
+}


### PR DESCRIPTION
## Problem

Our notifications table is large, and we run frequent SELECT queries on it, but postgres does not automatically index foreign key columns, so WHERE clauses on these columns will require a full table scan, which results in inefficient db queries. This PR adds indexes to the foreign keys in the notifications table to speed up our queries.

Note that `site_id` is only indexed with `user_id`, since we never filter by `site_id` alone.

## Deploy Notes

- Run migration on staging and master before merge