### PR TITLE
fix: name auth routers

### DIFF
--- a/src/middleware/authorization.ts
+++ b/src/middleware/authorization.ts
@@ -5,6 +5,7 @@ import { ForbiddenError } from "@errors/ForbiddenError"
 import UserWithSiteSessionData from "@classes/UserWithSiteSessionData"
 
 import { RequestHandler } from "@root/types"
+import { nameAnonymousMethods } from "@root/utils/apm-utils"
 import AuthorizationMiddlewareService from "@services/middlewareServices/AuthorizationMiddlewareService"
 
 export class AuthorizationMiddleware {
@@ -18,6 +19,7 @@ export class AuthorizationMiddleware {
     this.authorizationMiddlewareService = authorizationMiddlewareService
     // We need to bind all methods because we don't invoke them from the class directly
     autoBind(this)
+    nameAnonymousMethods(this)
   }
 
   // Allows access only to users using email login


### PR DESCRIPTION
## Problem

The Auth middlewares are not named correctly:

Example trace:
![image](https://github.com/isomerpages/isomercms-backend/assets/935223/d93a902a-1005-4f53-8536-d57415e81b94)


[Trace link for reference](https://ogp.datadoghq.com/apm/trace/3862022928270485881?colorBy=service&env=production&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=6340181816854815641&spanViewType=metadata&timeHint=1712392136957&view=spans)

## Solution

Use the method namer introduced in [this PR](https://github.com/isomerpages/isomercms-backend/pull/1267)
