### PR TITLE
feat(dd): add source code linkage

### DIFF
--- a/.aws/deploy/backend-task-definition.staging.json
+++ b/.aws/deploy/backend-task-definition.staging.json
@@ -10,7 +10,17 @@
         }
       ],
       "essential": true,
-      "environment": [{ "name": "ENV_TYPE", "value": "STAGING" }],
+      "environment": [
+        { "name": "ENV_TYPE", "value": "STAGING" },
+        {
+          "name": "DD_GIT_COMMIT_SHA",
+          "value": "<DD_COMMIT_SHA>"
+        },
+        {
+          "name": "DD_GIT_REPOSITORY_URL",
+          "value": "github.com/isomerpages/isomercms-backend"
+        }
+      ],
       "mountPoints": [
         {
           "sourceVolume": "ggs-efs",
@@ -264,14 +274,6 @@
         {
           "name": "DD_TRACE_STARTUP_LOGS",
           "value": "true"
-        },
-        {
-          "name": "DD_GIT_COMMIT_SHA",
-          "value": "<DD_COMMIT_SHA>"
-        },
-        {
-          "name": "DD_GIT_REPOSITORY_URL",
-          "value": "github.com/isomerpages/isomercms-backend"
         },
         {
           "name": "DD_API_KEY",

--- a/.aws/deploy/backend-task-definition.staging.json
+++ b/.aws/deploy/backend-task-definition.staging.json
@@ -266,6 +266,14 @@
           "value": "true"
         },
         {
+          "name": "DD_GIT_COMMIT_SHA",
+          "value": "<DD_COMMIT_SHA>"
+        },
+        {
+          "name": "DD_GIT_REPOSITORY_URL",
+          "value": "github.com/isomerpages/isomercms-backend"
+        },
+        {
           "name": "DD_API_KEY",
           "value": "<DD_API_KEY>"
         }

--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -114,6 +114,7 @@ jobs:
             sed -i 's/<AWS_ACCOUNT_ID>/${{ secrets.AWS_ACCOUNT_ID }}/g' ${{ inputs.task-definition-path }}
             sed -i 's/<EFS_FILE_SYSTEM_ID>/${{ secrets.EFS_FILE_SYSTEM_ID }}/g' ${{ inputs.task-definition-path }}
             sed -i 's/<DD_API_KEY>/${{ secrets.DD_API_KEY }}/g' ${{ inputs.task-definition-path }}
+            sed -i 's/<DD_COMMIT_SHA>/${{ github.sha }}/g' ${{ inputs.task-definition-path }}
       
       - name: Replace variables in appspec
         run: |


### PR DESCRIPTION
## Problem
https://linear.app/ogp/issue/ISOM-884/add-github-source-code-linkage-on-dd

Closes ISOM-884

## Solution
1. add required env vars into the task def **on the app container**
    a. tried adding on dd container initially - didn't work
3. inject the required env vars via `sed` during the workflow

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

## Tests
- check the page [here](https://linear.app/ogp/issue/ISOM-884/add-github-source-code-linkage-on-dd) post deployment of this PR to staging. 
- the linkage should be **green** for `service:isomer, env:staging, version:0.77`

<img width="983" alt="Screenshot 2024-04-08 at 10 32 35 PM" src="https://github.com/isomerpages/isomercms-backend/assets/44049504/47ebad1a-98e7-44ef-8cd5-2244b099057f">
