### PR TITLE
refactor(UserService): simplify login by using findOrCreate()

### DIFF
--- a/src/services/identity/UsersService.ts
+++ b/src/services/identity/UsersService.ts
@@ -136,30 +136,19 @@ class UsersService {
   }
 
   async login(githubId: string): Promise<User> {
-    const loginUpdate = { lastLoggedIn: new Date() }
-    const [user, created] = await this.repository.findOrCreate({
-      where: { githubId },
-      defaults: loginUpdate,
+    const [user] = await this.repository.upsert({
+      githubId,
+      lastLoggedIn: new Date(),
     })
-
-    if (!created) {
-      await user.update(loginUpdate)
-    }
 
     return user
   }
 
   async loginWithEmail(email: string): Promise<User> {
-    const parsedEmail = email.toLowerCase()
-    const loginUpdate = { lastLoggedIn: new Date() }
-    const [user, created] = await this.repository.findOrCreate({
-      where: { email: parsedEmail },
-      defaults: loginUpdate,
+    const [user] = await this.repository.upsert({
+      email: email.toLowerCase(),
+      lastLoggedIn: new Date(),
     })
-
-    if (!created) {
-      await user.update(loginUpdate)
-    }
 
     return user
   }

--- a/src/services/identity/UsersService.ts
+++ b/src/services/identity/UsersService.ts
@@ -136,28 +136,32 @@ class UsersService {
   }
 
   async login(githubId: string): Promise<User> {
-    return this.sequelize.transaction<User>(async (transaction) => {
-      const [user] = await this.repository.findOrCreate({
-        where: { githubId },
-        transaction,
-      })
-      user.lastLoggedIn = new Date()
-
-      return user.save({ transaction })
+    const loginUpdate = { lastLoggedIn: new Date() }
+    const [user, created] = await this.repository.findOrCreate({
+      where: { githubId },
+      defaults: loginUpdate,
     })
+
+    if (!created) {
+      await user.update(loginUpdate)
+    }
+
+    return user
   }
 
   async loginWithEmail(email: string): Promise<User> {
     const parsedEmail = email.toLowerCase()
-    return this.sequelize.transaction<User>(async (transaction) => {
-      const [user] = await this.repository.findOrCreate({
-        where: { email: parsedEmail },
-        transaction,
-      })
-      user.lastLoggedIn = new Date()
-
-      return user.save({ transaction })
+    const loginUpdate = { lastLoggedIn: new Date() }
+    const [user, created] = await this.repository.findOrCreate({
+      where: { email: parsedEmail },
+      defaults: loginUpdate,
     })
+
+    if (!created) {
+      await user.update(loginUpdate)
+    }
+
+    return user
   }
 
   async canSendEmailOtp(email: string) {

--- a/src/services/identity/UsersService.ts
+++ b/src/services/identity/UsersService.ts
@@ -137,20 +137,12 @@ class UsersService {
 
   async login(githubId: string): Promise<User> {
     return this.sequelize.transaction<User>(async (transaction) => {
-      // NOTE: The service's findOrCreate is not being used here as this requires an explicit transaction
-      let user = await this.repository.findOne({
+      const [user] = await this.repository.findOrCreate({
         where: { githubId },
         transaction,
       })
-
-      if (!user) {
-        user = await this.repository.create({
-          githubId,
-          transaction,
-        })
-      }
-
       user.lastLoggedIn = new Date()
+
       return user.save({ transaction })
     })
   }
@@ -158,7 +150,6 @@ class UsersService {
   async loginWithEmail(email: string): Promise<User> {
     const parsedEmail = email.toLowerCase()
     return this.sequelize.transaction<User>(async (transaction) => {
-      // NOTE: The service's findOrCreate is not being used here as this requires an explicit transaction
       const [user] = await this.repository.findOrCreate({
         where: { email: parsedEmail },
         transaction,

--- a/src/services/identity/__tests__/UsersService.spec.ts
+++ b/src/services/identity/__tests__/UsersService.spec.ts
@@ -26,6 +26,7 @@ const MockRepository = {
   findOne: jest.fn(),
   update: jest.fn(),
   create: jest.fn(),
+  findOrCreate: jest.fn(),
 }
 
 const MockSequelize = {
@@ -99,52 +100,28 @@ describe("User Service", () => {
     })
   })
 
-  it("should return the result of calling the underlying `findOne` method on the db model when the user exists and set the lastLoggedIn", async () => {
+  it("should call `findOrCreate` on the db model and set the lastLoggedIn", async () => {
     // Arrange
     const mockDbUser = {
       save: jest.fn().mockReturnThis(),
       githubId: mockGithubId,
     }
-    MockRepository.findOne.mockResolvedValue(mockDbUser)
+    MockRepository.findOrCreate.mockResolvedValue([mockDbUser])
 
     // Act
     const actual = await UsersService.login(mockGithubId)
 
     // Assert
-    expect(actual.lastLoggedIn).toBeDefined()
-    expect(actual.githubId).toBe(mockGithubId)
-    expect(MockRepository.create).not.toBeCalled()
-    expect(MockRepository.findOne).toBeCalledWith({
+    expect(MockSequelize.transaction).toBeCalled()
+    expect(MockRepository.findOrCreate).toBeCalledWith({
       where: { githubId: mockGithubId },
       transaction: "transaction",
     })
-    expect(MockSequelize.transaction).toBeCalled()
-  })
-
-  it("should call both `findOne` and `create` on the db model when the user does not exist and set the lastLoggedIn", async () => {
-    // Arrange
-    const mockDbUser = {
-      save: jest.fn().mockReturnThis(),
-      githubId: mockGithubId,
-    }
-    MockRepository.findOne.mockResolvedValue(null)
-    MockRepository.create.mockResolvedValue(mockDbUser)
-
-    // Act
-    const actual = await UsersService.login(mockGithubId)
-
-    // Assert
     expect(actual.lastLoggedIn).toBeDefined()
     expect(actual.githubId).toBe(mockGithubId)
-    expect(MockRepository.create).toBeCalledWith({
-      githubId: mockGithubId,
+    expect(actual.save).toBeCalledWith({
       transaction: "transaction",
     })
-    expect(MockRepository.findOne).toBeCalledWith({
-      where: { githubId: mockGithubId },
-      transaction: "transaction",
-    })
-    expect(MockSequelize.transaction).toBeCalled()
   })
 
   it("should allow whitelisted emails", async () => {

--- a/src/services/identity/__tests__/UsersService.spec.ts
+++ b/src/services/identity/__tests__/UsersService.spec.ts
@@ -102,12 +102,11 @@ describe("User Service", () => {
 
   it("should call `findOrCreate` on the db model and set the lastLoggedIn", async () => {
     // Arrange
-    const testTime = Date.now()
     const mockDbUser = {
       update: jest.fn().mockReturnThis(),
       githubId: mockGithubId,
     }
-    MockRepository.findOrCreate.mockResolvedValue([mockDbUser])
+    MockRepository.findOrCreate.mockResolvedValue([mockDbUser, true])
 
     // Act
     const actual = await UsersService.login(mockGithubId)
@@ -117,8 +116,29 @@ describe("User Service", () => {
       where: { githubId: mockGithubId },
       defaults: { lastLoggedIn: expect.any(Date) },
     })
-    expect(actual.lastLoggedIn).toBeDefined()
-    expect(actual.lastLoggedIn.getTime()).toBeGreaterThanOrEqual(testTime)
+    expect(actual.update).not.toHaveBeenCalled()
+    expect(actual.githubId).toBe(mockGithubId)
+  })
+
+  it("should update the user with lastLoggedIn when not creating it", async () => {
+    // Arrange
+    const mockDbUser = {
+      update: jest.fn().mockReturnThis(),
+      githubId: mockGithubId,
+    }
+    MockRepository.findOrCreate.mockResolvedValue([mockDbUser, false])
+
+    // Act
+    const actual = await UsersService.login(mockGithubId)
+
+    // Assert
+    expect(MockRepository.findOrCreate).toBeCalledWith({
+      where: { githubId: mockGithubId },
+      defaults: { lastLoggedIn: expect.any(Date) },
+    })
+    expect(actual.update).toHaveBeenCalledWith({
+      lastLoggedIn: expect.any(Date),
+    })
     expect(actual.githubId).toBe(mockGithubId)
   })
 

--- a/src/services/identity/__tests__/UsersService.spec.ts
+++ b/src/services/identity/__tests__/UsersService.spec.ts
@@ -27,6 +27,7 @@ const MockRepository = {
   update: jest.fn(),
   create: jest.fn(),
   findOrCreate: jest.fn(),
+  upsert: jest.fn(),
 }
 
 const MockSequelize = {
@@ -100,43 +101,20 @@ describe("User Service", () => {
     })
   })
 
-  it("should call `findOrCreate` on the db model and set the lastLoggedIn", async () => {
+  it("should call `upsert` on the db model and set the lastLoggedIn", async () => {
     // Arrange
+    const startTime = Date.now()
     const mockDbUser = {
-      update: jest.fn().mockReturnThis(),
       githubId: mockGithubId,
     }
-    MockRepository.findOrCreate.mockResolvedValue([mockDbUser, true])
+    MockRepository.upsert.mockResolvedValue([mockDbUser])
 
     // Act
     const actual = await UsersService.login(mockGithubId)
 
     // Assert
-    expect(MockRepository.findOrCreate).toBeCalledWith({
-      where: { githubId: mockGithubId },
-      defaults: { lastLoggedIn: expect.any(Date) },
-    })
-    expect(actual.update).not.toHaveBeenCalled()
-    expect(actual.githubId).toBe(mockGithubId)
-  })
-
-  it("should update the user with lastLoggedIn when not creating it", async () => {
-    // Arrange
-    const mockDbUser = {
-      update: jest.fn().mockReturnThis(),
+    expect(MockRepository.upsert).toBeCalledWith({
       githubId: mockGithubId,
-    }
-    MockRepository.findOrCreate.mockResolvedValue([mockDbUser, false])
-
-    // Act
-    const actual = await UsersService.login(mockGithubId)
-
-    // Assert
-    expect(MockRepository.findOrCreate).toBeCalledWith({
-      where: { githubId: mockGithubId },
-      defaults: { lastLoggedIn: expect.any(Date) },
-    })
-    expect(actual.update).toHaveBeenCalledWith({
       lastLoggedIn: expect.any(Date),
     })
     expect(actual.githubId).toBe(mockGithubId)

--- a/src/services/identity/__tests__/UsersService.spec.ts
+++ b/src/services/identity/__tests__/UsersService.spec.ts
@@ -102,8 +102,9 @@ describe("User Service", () => {
 
   it("should call `findOrCreate` on the db model and set the lastLoggedIn", async () => {
     // Arrange
+    const testTime = Date.now()
     const mockDbUser = {
-      save: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
       githubId: mockGithubId,
     }
     MockRepository.findOrCreate.mockResolvedValue([mockDbUser])
@@ -112,16 +113,13 @@ describe("User Service", () => {
     const actual = await UsersService.login(mockGithubId)
 
     // Assert
-    expect(MockSequelize.transaction).toBeCalled()
     expect(MockRepository.findOrCreate).toBeCalledWith({
       where: { githubId: mockGithubId },
-      transaction: "transaction",
+      defaults: { lastLoggedIn: expect.any(Date) },
     })
     expect(actual.lastLoggedIn).toBeDefined()
+    expect(actual.lastLoggedIn.getTime()).toBeGreaterThanOrEqual(testTime)
     expect(actual.githubId).toBe(mockGithubId)
-    expect(actual.save).toBeCalledWith({
-      transaction: "transaction",
-    })
   })
 
   it("should allow whitelisted emails", async () => {


### PR DESCRIPTION
## Problem

Incorrect comments on not being able to use `findOrCreate()` with a transaction.

(Also I think the old code for create might have been incorrect, because the first argument to `create()` must be an object, not a string (?) 🤔 

While `.findOrCreate()` does in fact accept a transaction (see [API documentation](https://sequelize.org/api/v6/class/src/model.js~model#static-method-findOrCreate)), I think the update to `lastLoggedIn` doesn't need to be in the transaction. Even if there is a conflict with multiple writes overwriting each other, the updates would be so close by that's the inaccuracy is not business critical.

Because of that, we can simplify the code by using the default transaction behaviour of `.findOrCreate()`, instead of providing our own transaction.


## Solution

1. Use `.findOrCreate()` in both `login` and `loginWithEmail`
2. Move the update to `lastLoggedIn` out of transaction
3. Update the tests

`.findOrCreate()` does provide its own transaction, [documentation](https://sequelize.org/api/v6/class/src/model.js~model#static-method-findOrCreate) states

> If no transaction is passed in the options object, a new transaction will be created internally, to prevent the race condition where a matching row is created by another connection after the find but before the insert call. 


Verified on staging ([sample trace here](https://ogp.datadoghq.com/apm/trace/6810154304698742342?colorBy=service&env=staging&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=5390287072878530279&spanViewType=metadata&timeHint=1712797446427&view=spans)):
![image](https://github.com/isomerpages/isomercms-backend/assets/935223/e0322c58-2380-47fd-9142-2fb4ab207fa6)


## Tests

- [x] Login successfully via email
- [ ] Login successfully via github
