### PR TITLE
chore: change error handler to use logger.error

### DIFF
--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -31,7 +31,7 @@ function errorHandler(err, req, res, next) {
 
   // Error handling for custom errors
   if (err.isIsomerError) {
-    logger.info(errMsg)
+    logger.error(errMsg)
     if (err.isV2Err) {
       return res.status(err.status).json({
         error: IsomerError.toExternalRepresentation(err),
@@ -47,7 +47,7 @@ function errorHandler(err, req, res, next) {
   }
   if (err.name === "PayloadTooLargeError") {
     // Error thrown by large payload is done by express
-    logger.info(errMsg)
+    logger.error(errMsg)
     return res.status(413).json({
       error: {
         name: err.name,
@@ -56,7 +56,7 @@ function errorHandler(err, req, res, next) {
       },
     })
   }
-  logger.info(`Unrecognized internal server error: ${errMsg}`)
+  logger.error(`Unrecognized internal server error: ${errMsg}`)
   return res.status(500).json({
     error: {
       code: 500,


### PR DESCRIPTION
## Problem

Resolves ISOM-916. Previously, our catch-all error handler was using `logger.info`, which meant that unrecognised/unhandled errors were being tagged as info in datadog. This PR modifies them to use `logger.error` instead.

## Tests

- [ ] Visit the workspace of a-test-v4 (https://staging-cms.isomer.gov.sg/sites/a-test-v4/workspace)
- [ ] Click on the `YAML error` page, which should bring you to an error page
- [ ] Verify on DD that the error message is logged as an error

