### PR TITLE
ci(sidecar): add deploy files for prod

### DIFF
--- a/.aws/deploy/backend-task-definition.prod.json
+++ b/.aws/deploy/backend-task-definition.prod.json
@@ -252,7 +252,7 @@
         },
         {
           "name": "DD_TAGS",
-          "value": "service:isomer"
+          "value": "team:isomer,service:isomer"
         },
         {
           "name": "DD_AGENT_MAJOR_VERSION",

--- a/.aws/deploy/backend-task-definition.staging.json
+++ b/.aws/deploy/backend-task-definition.staging.json
@@ -251,7 +251,7 @@
         },
         {
           "name": "DD_TAGS",
-          "value": "service:isomer"
+          "value": "team:isomer,service:isomer"
         },
         {
           "name": "DD_AGENT_MAJOR_VERSION",

--- a/.aws/deploy/support-task-definition.prod.json
+++ b/.aws/deploy/support-task-definition.prod.json
@@ -13,7 +13,7 @@
       "environment": [
         { "name": "ENV_TYPE", "value": "PROD" },
         { "name": "DD_SERVICE", "value": "isomer-support" },
-        { "name": "DD_TAGS", "value": "team:isomer" }
+        { "name": "DD_TAGS", "value": "team:isomer,service:isomer-support" }
       ],
       "mountPoints": [
         {
@@ -244,7 +244,7 @@
         },
         {
           "name": "DD_TAGS",
-          "value": "team:isomer"
+          "value": "team:isomer,service:isomer-support"
         },
         {
           "name": "DD_AGENT_MAJOR_VERSION",

--- a/.aws/deploy/support-task-definition.prod.json
+++ b/.aws/deploy/support-task-definition.prod.json
@@ -1,0 +1,304 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "support",
+      "portMappings": [
+        {
+          "containerPort": 8082,
+          "hostPort": 8082,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,
+      "environment": [
+        { "name": "ENV_TYPE", "value": "PROD" },
+        { "name": "DD_SERVICE", "value": "isomer-support" },
+        { "name": "DD_TAGS", "value": "team:isomer" }
+      ],
+      "mountPoints": [
+        {
+          "sourceVolume": "ggs-efs",
+          "containerPath": "/efs",
+          "readOnly": false
+        }
+      ],
+      "linuxParameters": {
+        "initProcessEnabled": true
+      },
+      "volumesFrom": [],
+      "secrets": [
+        {
+          "name": "AUTH_TOKEN_EXPIRY_DURATION_IN_MILLISECONDS",
+          "valueFrom": "PROD_AUTH_TOKEN_EXPIRY_DURATION_IN_MILLISECONDS"
+        },
+        {
+          "name": "AWS_BACKEND_EB_ENV_NAME",
+          "valueFrom": "PROD_AWS_BACKEND_EB_ENV_NAME"
+        },
+        { "name": "AWS_REGION", "valueFrom": "PROD_AWS_REGION" },
+        { "name": "CLIENT_ID", "valueFrom": "PROD_CLIENT_ID" },
+        { "name": "CLIENT_SECRET", "valueFrom": "PROD_CLIENT_SECRET" },
+        {
+          "name": "CLOUDMERSIVE_API_KEY",
+          "valueFrom": "PROD_CLOUDMERSIVE_API_KEY"
+        },
+        { "name": "COOKIE_DOMAIN", "valueFrom": "PROD_COOKIE_DOMAIN" },
+        { "name": "DB_ACQUIRE", "valueFrom": "PROD_DB_ACQUIRE" },
+        { "name": "DB_MAX_POOL", "valueFrom": "PROD_DB_MAX_POOL" },
+        { "name": "DB_MIN_POOL", "valueFrom": "PROD_DB_MIN_POOL" },
+        { "name": "DB_TIMEOUT", "valueFrom": "PROD_DB_TIMEOUT" },
+        { "name": "DB_URI", "valueFrom": "PROD_DB_URI" },
+        {
+          "name": "DD_AGENT_MAJOR_VERSION",
+          "valueFrom": "PROD_DD_AGENT_MAJOR_VERSION"
+        },
+        { "name": "DD_ENV", "valueFrom": "PROD_DD_ENV" },
+        { "name": "DD_LOGS_INJECTION", "valueFrom": "PROD_DD_LOGS_INJECTION" },
+        {
+          "name": "DD_TRACE_STARTUP_LOGS",
+          "valueFrom": "PROD_DD_TRACE_STARTUP_LOGS"
+        },
+        { "name": "E2E_TEST_GH_TOKEN", "valueFrom": "PROD_E2E_TEST_GH_TOKEN" },
+        { "name": "E2E_TEST_REPO", "valueFrom": "PROD_E2E_TEST_REPO" },
+        { "name": "E2E_TEST_SECRET", "valueFrom": "PROD_E2E_TEST_SECRET" },
+        { "name": "EFS_VOL_PATH", "valueFrom": "PROD_EFS_VOL_PATH" },
+        { "name": "ENCRYPTION_SECRET", "valueFrom": "PROD_ENCRYPTION_SECRET" },
+        {
+          "name": "FF_DEPRECATE_SITE_QUEUES",
+          "valueFrom": "PROD_FF_DEPRECATE_SITE_QUEUES"
+        },
+        { "name": "FRONTEND_URL", "valueFrom": "PROD_FRONTEND_URL" },
+        {
+          "name": "GGS_REPAIR_FORM_KEY",
+          "valueFrom": "PROD_GGS_REPAIR_FORM_KEY"
+        },
+        {
+          "name": "GGS_EXPERIMENTAL_TRACKING_SITES",
+          "valueFrom": "PROD_GGS_EXPERIMENTAL_TRACKING_SITES"
+        },
+        {
+          "name": "GITHUB_BUILD_ORG_NAME",
+          "valueFrom": "PROD_GITHUB_BUILD_ORG_NAME"
+        },
+        {
+          "name": "GITHUB_BUILD_REPO_NAME",
+          "valueFrom": "PROD_GITHUB_BUILD_REPO_NAME"
+        },
+        { "name": "GITHUB_ORG_NAME", "valueFrom": "PROD_GITHUB_ORG_NAME" },
+        {
+          "name": "GROWTHBOOK_CLIENT_KEY",
+          "valueFrom": "PROD_GROWTHBOOK_CLIENT_KEY"
+        },
+        {
+          "name": "INCOMING_QUEUE_URL",
+          "valueFrom": "PROD_INCOMING_QUEUE_URL"
+        },
+        {
+          "name": "ISOMERPAGES_REPO_PAGE_COUNT",
+          "valueFrom": "PROD_ISOMERPAGES_REPO_PAGE_COUNT"
+        },
+        { "name": "JWT_SECRET", "valueFrom": "PROD_JWT_SECRET" },
+        {
+          "name": "MAX_NUM_OTP_ATTEMPTS",
+          "valueFrom": "PROD_MAX_NUM_OTP_ATTEMPTS"
+        },
+        {
+          "name": "MOCK_AMPLIFY_DOMAIN_ASSOCIATION_CALLS",
+          "valueFrom": "PROD_MOCK_AMPLIFY_DOMAIN_ASSOCIATION_CALLS"
+        },
+        { "name": "MUTEX_TABLE_NAME", "valueFrom": "PROD_MUTEX_TABLE_NAME" },
+        {
+          "name": "NETLIFY_ACCESS_TOKEN",
+          "valueFrom": "PROD_NETLIFY_ACCESS_TOKEN"
+        },
+        { "name": "NODE_ENV", "valueFrom": "PROD_NODE_ENV" },
+        { "name": "OTP_EXPIRY", "valueFrom": "PROD_OTP_EXPIRY" },
+        { "name": "OTP_SECRET", "valueFrom": "PROD_OTP_SECRET" },
+        {
+          "name": "OUTGOING_QUEUE_URL",
+          "valueFrom": "PROD_OUTGOING_QUEUE_URL"
+        },
+        { "name": "POSTMAN_API_KEY", "valueFrom": "PROD_POSTMAN_API_KEY" },
+        {
+          "name": "POSTMAN_SMS_CRED_NAME",
+          "valueFrom": "PROD_POSTMAN_SMS_CRED_NAME"
+        },
+        {
+          "name": "REDIRECT_URI",
+          "valueFrom": "PROD_REDIRECT_URI"
+        },
+        {
+          "name": "SESSION_SECRET",
+          "valueFrom": "PROD_SESSION_SECRET"
+        },
+        { "name": "SGID_CLIENT_ID", "valueFrom": "PROD_SGID_CLIENT_ID" },
+        {
+          "name": "SGID_CLIENT_SECRET",
+          "valueFrom": "PROD_SGID_CLIENT_SECRET"
+        },
+        {
+          "name": "SGID_REDIRECT_URI",
+          "valueFrom": "PROD_SGID_REDIRECT_URI"
+        },
+        {
+          "name": "SGID_PRIVATE_KEY",
+          "valueFrom": "PROD_SGID_PRIVATE_KEY"
+        },
+        {
+          "name": "SITE_CLONE_FORM_KEY",
+          "valueFrom": "PROD_SITE_CLONE_FORM_KEY"
+        },
+        {
+          "name": "SITE_CREATE_FORM_KEY",
+          "valueFrom": "PROD_SITE_CREATE_FORM_KEY"
+        },
+        {
+          "name": "SITE_LAUNCH_DYNAMO_DB_TABLE_NAME",
+          "valueFrom": "PROD_SITE_LAUNCH_DYNAMO_DB_TABLE_NAME"
+        },
+        {
+          "name": "SITE_LAUNCH_FORM_KEY",
+          "valueFrom": "PROD_SITE_LAUNCH_FORM_KEY"
+        },
+        {
+          "name": "SITE_PASSWORD_SECRET_KEY",
+          "valueFrom": "PROD_SITE_PASSWORD_SECRET_KEY"
+        },
+        {
+          "name": "PROD_SSH_PUBLIC_KEY",
+          "valueFrom": "PROD_SSH_PUBLIC_KEY"
+        },
+        {
+          "name": "PROD_SSH_PRIVATE_KEY",
+          "valueFrom": "PROD_SSH_PRIVATE_KEY"
+        },
+        {
+          "name": "STEP_FUNCTIONS_ARN",
+          "valueFrom": "PROD_STEP_FUNCTIONS_ARN"
+        },
+        {
+          "name": "SYSTEM_GITHUB_TOKEN",
+          "valueFrom": "PROD_SYSTEM_GITHUB_TOKEN"
+        },
+        {
+          "name": "UPTIME_ROBOT_API_KEY",
+          "valueFrom": "PROD_UPTIME_ROBOT_API_KEY"
+        },
+        {
+          "name": "SITE_CHECKER_FORM_KEY",
+          "valueFrom": "PROD_SITE_CHECKER_FORM_KEY"
+        },
+        {
+          "name": "SITE_AUDIT_LOGS_FORM_KEY",
+          "valueFrom": "PROD_SITE_AUDIT_LOGS_FORM_KEY"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/aws/elasticbeanstalk/cms-backend-staging-node18/var/log/web.stdout.log",
+          "awslogs-region": "ap-southeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    },
+    {
+      "name": "dd-agent",
+      "image": "public.ecr.aws/datadog/agent:latest",
+      "portMappings": [
+        {
+          "containerPort": 8126,
+          "hostPort": 8126,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,
+      "environment": [
+        {
+          "name": "TZ",
+          "value": "Asia/Singapore"
+        },
+        {
+          "name": "DD_APM_NON_LOCAL_TRAFFIC",
+          "value": "true"
+        },
+        {
+          "name": "ECS_FARGATE",
+          "value": "true"
+        },
+        {
+          "name": "DD_APM_ENABLED",
+          "value": "true"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "datadoghq.com"
+        },
+        {
+          "name": "DD_ENV",
+          "value": "production"
+        },
+        {
+          "name": "DD_SERVICE",
+          "value": "isomer-support"
+        },
+        {
+          "name": "DD_TAGS",
+          "value": "team:isomer"
+        },
+        {
+          "name": "DD_AGENT_MAJOR_VERSION",
+          "value": "7"
+        },
+        {
+          "name": "DD_LOGS_INJECTION",
+          "value": "true"
+        },
+        {
+          "name": "DD_TRACE_STARTUP_LOGS",
+          "value": "true"
+        },
+        {
+          "name": "DD_API_KEY",
+          "value": "<DD_API_KEY>"
+        }
+      ],
+      "dockerLabels": {
+        "com.datadoghq.tags.env": "production",
+        "com.datadoghq.tags.service": "isomer-support",
+        "com.datadoghq.tags.version": "7"
+      },
+      "mountPoints": [],
+      "volumesFrom": [],
+      "secrets": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "isomer-infra-staging/ecs/dd-agent",
+          "awslogs-region": "ap-southeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ],
+  "family": "isomer-infra",
+  "networkMode": "awsvpc",
+  "volumes": [
+    {
+      "name": "ggs-efs",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "<EFS_FILE_SYSTEM_ID>",
+        "rootDirectory": "/"
+      }
+    }
+  ],
+  "placementConstraints": [],
+  "runtimePlatform": {
+    "operatingSystemFamily": "LINUX"
+  },
+  "requiresCompatibilities": ["FARGATE"],
+  "taskRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/stg-support-ecs-task-role",
+  "executionRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/stg-support-ecs-task-exec-role",
+  "cpu": "1024",
+  "memory": "2048"
+}

--- a/.aws/deploy/support-task-definition.staging.json
+++ b/.aws/deploy/support-task-definition.staging.json
@@ -13,7 +13,7 @@
       "environment": [
         { "name": "ENV_TYPE", "value": "STAGING" },
         { "name": "DD_SERVICE", "value": "isomer-support" },
-        { "name": "DD_TAGS", "value": "team:isomer" }
+        { "name": "DD_TAGS", "value": "team:isomer,service:isomer-support" }
       ],
       "mountPoints": [
         {
@@ -253,7 +253,7 @@
         },
         {
           "name": "DD_TAGS",
-          "value": "team:isomer"
+          "value": "team:isomer,service:isomer-support"
         },
         {
           "name": "DD_AGENT_MAJOR_VERSION",

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -8,8 +8,8 @@ on:
   workflow_call: 
 
 jobs:
-  deploy:
-    name: Deploy
+  deploy-app:
+    name: Deploy app to production
     uses: ./.github/workflows/aws_deploy.yml
     with:
       aws-region: "ap-southeast-1"
@@ -18,12 +18,37 @@ jobs:
       ecs-cluster-name: "isomer-prod-ecs"
       ecs-web-service-name: "isomer-prod-ecs-service"
       ecs-container-name: "backend"
+      ecs-container-port: 8081
       environment: "prod"
       shortEnv: "prod"
       task-definition-path: ".aws/deploy/backend-task-definition.prod.json" 
       codedeploy-application: "isomer-prod-ecs-app"
       codedeploy-deployment-group: "isomer-prod-ecs-dg"
+      path-to-dockerfile: "Dockerfile"
 
+    secrets: 
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      EFS_FILE_SYSTEM_ID: ${{ secrets.PROD_EFS_FILE_SYSTEM_ID }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+
+  deploy-support: 
+    name: Deploy support to staging
+    uses: ./.github/workflows/aws_deploy.yml
+    with:
+      aws-region: "ap-southeast-1"
+      cicd-role: "arn:aws:iam::095733531422:role/isomer-infra-github-oidc-role-16ea937"
+      ecr-repository: "isomer-infra-prod-ecr"
+      ecs-cluster-name: "isomer-prod-ecs"
+      ecs-web-service-name: "prod-support-ecs-service"
+      ecs-container-name: "support"
+      ecs-container-port: 8082
+      environment: "prod"
+      shortEnv: "prod"
+      task-definition-path: ".aws/deploy/support-task-definition.prod.json" 
+      codedeploy-application: "prod-support-ecs-app"
+      codedeploy-deployment-group: "prod-support-ecs-dg"
+      path-to-dockerfile: "support/Dockerfile"
+      
     secrets: 
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       EFS_FILE_SYSTEM_ID: ${{ secrets.PROD_EFS_FILE_SYSTEM_ID }}


### PR DESCRIPTION
**NOTE: DO NOT MERGE, PENDING INFRA DEPLOY**

## Problem
This adds in the missing deployment files for our support ecs service **on production**. this is raised as a separate PR so we can go through these 2 files in excruciating detail. the base PR is #1269.

For reviewers, please help to crosscheck against what i did below for env vars + deployment workflow to make sure i haven't missed anything

## Solution
- create a new task definition for `support` for deployment to production. 
- update our existing `deploy_prod` workflow to have a step to deploy the support ecs service.

for verification, these are the steps that i took: 
**task def**
- copied over the existing `support-task-def` for `staging` to `production` 
- thereafter, i **deleted** the `secrets` section and replaced it with the one for `backend-task-def` (sans `DD_SERVICE/DD_TAGS`, which are done via `env` on the task def)
- replaced remaining `stg/staging` references with `prod/production`; referenced `backend-task-def` for the correct version (short or long) 
**deploy_prod**
- copied over the existing `deploy-support` workflow
- updated values (simple replacement cos this is deterministic via `pulumi`)

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5) - should be fully back-compat, this should consume form webhook just fine

## Tests
See base PR! 