### PR TITLE
fix: off-by-one error for month number

### DIFF
--- a/src/routes/formsg/formsgSiteAuditLogs.ts
+++ b/src/routes/formsg/formsgSiteAuditLogs.ts
@@ -81,14 +81,15 @@ export class FormsgSiteAuditLogsRouter {
       const endDateObject = new Date()
       endDateObject.setDate(0)
 
-      startDate = `${startDateObject.getFullYear()}-${startDateObject
-        .getMonth()
+      const startDateMonth = (startDateObject.getMonth() + 1)
         .toString()
-        .padStart(2, "0")}-01`
-      endDate = `${endDateObject.getFullYear()}-${endDateObject
-        .getMonth()
+        .padStart(2, "0")
+      const endDateMonth = (endDateObject.getMonth() + 1)
         .toString()
-        .padStart(2, "0")}-${endDateObject.getDate()}`
+        .padStart(2, "0")
+
+      startDate = `${startDateObject.getFullYear()}-${startDateMonth}-01`
+      endDate = `${endDateObject.getFullYear()}-${endDateMonth}-${endDateObject.getDate()}`
     } else {
       const startDateField = getField(responses, LOGS_TIMEFRAME_START_FIELD)
       const endDateField = getField(responses, LOGS_TIMEFRAME_END_FIELD)


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The month number has an off-by-one error as it is zero-indexed, which means for April, `getMonth()` will return `3` instead of `4`.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Fix the off-by-one error so that invalid dates (such as `2024-02-31` is not being produced erroneously).

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Use the form for staging (find in 1PW) to request for the site audit logs
- [ ] Request for logs for the previous calendar month for a site that exists on staging (and you are either an Isomer Admin or collaborator of)
- [ ] Verify that the commits in the audit logs only show those in the previous calendar month (i.e. March)

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*