### PR TITLE
fix(canSendEmailOtp): use a query to find whitelist match, rather than fetching the whole table

### DIFF
--- a/src/services/identity/UsersService.ts
+++ b/src/services/identity/UsersService.ts
@@ -154,7 +154,7 @@ class UsersService {
   }
 
   async canSendEmailOtp(email: string) {
-    const parsedEmail = email.toLowerCase()
+    const normalizedEmail = email.toLowerCase()
     const whitelistEntries = await this.whitelist.findAll({
       attributes: ["email"],
       where: {
@@ -165,8 +165,15 @@ class UsersService {
     })
     const whitelistDomains = whitelistEntries.map((entry) => entry.email)
     const hasMatchDomain =
-      whitelistDomains.filter((domain) => parsedEmail.endsWith(domain)).length >
-      0
+      whitelistDomains.filter((domain) => {
+        // if domain is really just a domain (does not include a @ OR starts with a @), we can do a prefix match
+        if (/^@|^[^@]+$/.test(domain)) {
+          return normalizedEmail.endsWith(domain)
+        }
+
+        return normalizedEmail === domain
+        // otherwise we can ONLY do an exact match
+      }).length > 0
     return hasMatchDomain
   }
 

--- a/src/services/identity/__tests__/UsersService.spec.ts
+++ b/src/services/identity/__tests__/UsersService.spec.ts
@@ -170,4 +170,21 @@ describe("User Service", () => {
     // Assert
     expect(actual).toBe(expected)
   })
+
+  it("should not allow suffix match if the whitelist entry is a full email", async () => {
+    // Arrange
+    const expected = false
+    const mockWhitelistEntries = [
+      {
+        email: "foo@accenture.com",
+      },
+    ]
+    MockWhitelist.findAll.mockResolvedValueOnce(mockWhitelistEntries)
+
+    // Act
+    const actual = await UsersService.canSendEmailOtp("bar.foo@accenture.com")
+
+    // Assert
+    expect(actual).toBe(expected)
+  })
 })


### PR DESCRIPTION
## Problem

We have a whitelist of domains and specific allowed emails in DB. Before we allow a OTP to be sent to an email, we check against the whitelist if the input email is allowed.

The way this is done is to fetch the entire table content (with a slight filter for expiry) and do a match in code 😑 

It would be much more efficient to use the database query capabilities to run the match on the DB directly. We can expect that to be both faster and transfer much less data.

## Solution

Run a raw efficient query to return an easy yes/no state on whether an email matches an entry in the whitelist.

We can not use the ORM capability because we are not matching a cell value to some input. Instead we are matching the input against the cell value with a `endsWith` behaviour. This is done by using the `<input> like concat ('%', field)` syntax.

As we want the query to exit as early as possible (any match is enough), we run the query to return 1 on match and limit 1. 

While DB engine do not offer guarantees of early exit, in principle, this can exit on the first match found and is thus as efficient as it can be made. 

For email which do not match, there will be a full traversal of the table, which is about the same as the previous code, which was also doing a full table scan.

We return the whitelist entry that matched so we can log and verify


