### PR TITLE
Feat: Optimize canSendEmailOtp

### DIFF
--- a/src/services/identity/UsersService.ts
+++ b/src/services/identity/UsersService.ts
@@ -156,12 +156,17 @@ class UsersService {
   async canSendEmailOtp(email: string) {
     const normalizedEmail = email.toLowerCase()
 
-    // raw query because ORMs suck!
-    // why: we want to leverage the DB to see if a single record exists that whitelists the input
+    // Raw query for readability because it uses 2 "unusual" query patterns
+    // - a CASE WHEN in the WHERE clause
+    // - a where condition of the form 'input like cell' (with a concat() call thrown in), as opposed to the more common 'cell like input'
+    //
+    // Why? We want to leverage the DB to see if a single record exists that whitelists the input
     // we do not want to download the whole table locally to filter in local code
+    //
     // query logic:
     // - if whitelist entry is a full email (something before the @), then do exact match
     // - if whitelist entry is a domain (no @, or starting with @), then do suffix match
+    //
     // Limit 1 is added to allow the query to exit early on first match
     const records = (await this.sequelize.query(
       `

--- a/src/services/identity/UsersService.ts
+++ b/src/services/identity/UsersService.ts
@@ -168,7 +168,7 @@ class UsersService {
         SELECT email
         FROM whitelist
         WHERE
-          (expiry is NULL OR expiry >= NOW())
+          (expiry is NULL OR expiry > NOW())
           AND
           CASE WHEN email ~ '^.+@'
             THEN email = :email

--- a/src/services/identity/UsersService.ts
+++ b/src/services/identity/UsersService.ts
@@ -159,7 +159,7 @@ class UsersService {
     // raw query because ORMs suck!
     const records = (await this.sequelize.query(
       `
-        SELECT 1 AS found
+        SELECT email AS found
         FROM whitelist
         WHERE
           (expiry is NULL OR expiry >= NOW())
@@ -170,9 +170,21 @@ class UsersService {
         replacements: { email: normalizedEmail },
         type: QueryTypes.SELECT,
       }
-    )) as { found: 1 }[]
+    )) as { email: string }[]
 
-    return records.length >= 1
+    if (records.length >= 1) {
+      logger.info({
+        message: "Email valid for OTP by whitelist",
+        meta: {
+          email,
+          whitelistEntry: records[0].email,
+        },
+      })
+
+      return true
+    }
+
+    return false
   }
 
   async sendEmailOtp(email: string) {

--- a/src/services/identity/__tests__/UsersService.spec.ts
+++ b/src/services/identity/__tests__/UsersService.spec.ts
@@ -32,6 +32,7 @@ const MockRepository = {
 
 const MockSequelize = {
   transaction: jest.fn((closure) => closure("transaction")),
+  query: jest.fn(),
 }
 
 const MockWhitelist = {
@@ -120,71 +121,31 @@ describe("User Service", () => {
     expect(actual.githubId).toBe(mockGithubId)
   })
 
-  it("should allow whitelisted emails", async () => {
-    // Arrange
-    const expected = true
-    const mockWhitelistEntry = {
-      email: ".gov.sg",
-    }
-    MockWhitelist.findAll.mockResolvedValueOnce([mockWhitelistEntry])
+  describe("canSendEmailOtp", () => {
+    it("should return true when the db query returns a record", async () => {
+      // Arrange
+      const expected = true
+      MockSequelize.query.mockResolvedValueOnce([{ found: 1 }])
 
-    // Act
-    const actual = await UsersService.canSendEmailOtp(mockEmail)
+      // Act
+      const actual = await UsersService.canSendEmailOtp(mockEmail)
 
-    // Assert
-    expect(actual).toBe(expected)
-  })
-  it("should not allow partial match of whitelisted emails", async () => {
-    // Arrange
-    const expected = false
-    // NOTE: This ends with gov.sg not .gov.sg (lacks a dot after the @)
-    const emailWithoutDot = "user@gov.sg"
-    const mockWhitelistEntry = {
-      email: ".gov.sg",
-    }
-    MockWhitelist.findAll.mockResolvedValueOnce([mockWhitelistEntry])
+      // Assert
+      expect(actual).toBe(expected)
+    })
 
-    // Act
-    const actual = await UsersService.canSendEmailOtp(emailWithoutDot)
+    it("should return false when the db query returns no record", async () => {
+      // Arrange
+      const expected = false
+      // NOTE: This ends with gov.sg not .gov.sg (lacks a dot after the @)
+      const emailWithoutDot = "user@gov.sg"
+      MockSequelize.query.mockResolvedValueOnce([])
 
-    // Assert
-    expect(actual).toBe(expected)
-  })
+      // Act
+      const actual = await UsersService.canSendEmailOtp(emailWithoutDot)
 
-  it("should allow not .gov.sg emails when whitelist does not contain .gov.sg", async () => {
-    // Arrange
-    const expected = false
-    const mockWhitelistEntries = [
-      {
-        email: "@accenture.com",
-      },
-      {
-        email: ".edu.sg",
-      },
-    ]
-    MockWhitelist.findAll.mockResolvedValueOnce(mockWhitelistEntries)
-
-    // Act
-    const actual = await UsersService.canSendEmailOtp(mockEmail)
-
-    // Assert
-    expect(actual).toBe(expected)
-  })
-
-  it("should not allow suffix match if the whitelist entry is a full email", async () => {
-    // Arrange
-    const expected = false
-    const mockWhitelistEntries = [
-      {
-        email: "foo@accenture.com",
-      },
-    ]
-    MockWhitelist.findAll.mockResolvedValueOnce(mockWhitelistEntries)
-
-    // Act
-    const actual = await UsersService.canSendEmailOtp("bar.foo@accenture.com")
-
-    // Assert
-    expect(actual).toBe(expected)
+      // Assert
+      expect(actual).toBe(expected)
+    })
   })
 })

--- a/src/services/identity/__tests__/UsersService.spec.ts
+++ b/src/services/identity/__tests__/UsersService.spec.ts
@@ -125,7 +125,7 @@ describe("User Service", () => {
     it("should return true when the db query returns a record", async () => {
       // Arrange
       const expected = true
-      MockSequelize.query.mockResolvedValueOnce([{ found: 1 }])
+      MockSequelize.query.mockResolvedValueOnce([{ email: ".gov.sg" }])
 
       // Act
       const actual = await UsersService.canSendEmailOtp(mockEmail)


### PR DESCRIPTION
## Problem

`UserService.canSendEmailOtp()` uses a whitelist to determine if emails are allowed to receive OTPs.

The whitelist contains
1) domains that the input can be matched against by suffix match
2) full email that the input can be matched again with exact match

At the moment the code basically download the full content of the whitelist table, and does a filter and check in code locally. 

It would be much better to leverage the query capability of the DB, to ask if a whitelist entry exists and get a small yes/no type result.
 

## Solution

Replace app-level code filtering by a single DB query.

The DB query will return: either:
* the first whitelist entry that matches
* nothing if there is no match

The PR will log the whitelist match, so we can verify if anything is wrong.


### Behaviour and Results

#### Old query (for reference)
[Sample trace](https://ogp.datadoghq.com/apm/trace/6688008335714158923?colorBy=service&env=staging&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=3260853590528579031&spanViewType=metadata&timeHint=1713259938105)
![image](https://github.com/isomerpages/isomercms-backend/assets/935223/bfc57c45-a39d-4f14-bc28-dc500ba0ae54)



[Sample trace for success](https://ogp.datadoghq.com/apm/trace/9058953070850640436?colorBy=service&env=staging&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=4403824909672225076&spanViewType=metadata&timeHint=1712978730516&view=spans)
![image](https://github.com/isomerpages/isomercms-backend/assets/935223/eaae45ed-5f3f-4239-bf14-399cf04c6b7e)
![image](https://github.com/isomerpages/isomercms-backend/assets/935223/85a9aa8f-3aa4-4541-99a9-f106bdfdb99a)
![image](https://github.com/isomerpages/isomercms-backend/assets/935223/190476b0-caff-4cdb-90ab-1106d527d88a)


[Sample trace for failure](https://ogp.datadoghq.com/apm/trace/460028362167627232?colorBy=service&env=staging&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=779548380314975616&spanViewType=metadata&timeHint=1712979224210.0051&view=spans)
![image](https://github.com/isomerpages/isomercms-backend/assets/935223/c0cad195-58df-4dcd-b124-e1ae7db06686)
![image](https://github.com/isomerpages/isomercms-backend/assets/935223/071d3e2b-5f4e-4029-b74d-548d75f42530)



### Performance

This particularly is not very heavy, returning most of the time in less than 2 milliseconds (link to [performance tracking graph here](https://ogp.datadoghq.com/dashboard/8tj-6k5-p2v/isomer-cm-s?fromUser=false&refresh_mode=paused&view=spans&from_ts=1713088170314&to_ts=1713260970314&live=false&tile_focus=3522012591074081)). The purpose of the PR is not to get a great performance gain but instead to 1) correct a bad pattern of fetching a large resultset to do filtering in code when that could be done in the query itself; 2) show that we can use raw queries to implement efficient queries.

But so concretely:

When no whitelist entry matches, the new query does a full table scan and returns nothing.

The previous query also did a full table scan to find active whitelist rows, but also incurred the transport cost to return the data, whether or not there was a whitelist match.

The new query is slightly heavier on the DB because it makes it do more work, but at the size of the whitelist table, it's negligible. The network transit time of the resulset should still be a net benefit in total time spent.

Overall, we expect the raw query time to be equivalent, and this can hopefully be visualized after release in [this tracker in the isomer dashboard](https://ogp.datadoghq.com/dashboard/8tj-6k5-p2v/isomer-cm-s?fromUser=false&refresh_mode=paused&view=spans&from_ts=1713088787609&to_ts=1713261587609&live=false&tile_focus=7015368340178734).


### Important note:

With the whitelisting filtering logic done in the query rather than code, the unit tests are not representative of the behaviour any more. Great care should be spent on reviewing/testing the query, and ideally we should have synthetic tests that validate the behaviour as e2e tests (some happy path tests and some expected failure mode).


## Tests

Note the traces for the query will be at [this link](https://ogp.datadoghq.com/apm/traces?query=%40_top_level%3A1%20service%3Aisomer-postgres%20env%3Astaging%20%40db.statement%3A%22SELECT%20email%20FROM%20whitelist%20WHERE%20%28%20expiry%20is%20%3F%20OR%20expiry%20%3E%3D%20NOW%20%28%20%29%20%29%20AND%20CASE%20WHEN%20email%20~%20%3F%20THEN%20email%20%3D%20%3F%20ELSE%20%3F%20LIKE%20CONCAT%20%28%20%3F%20email%20%29%20END%20LIMIT%20%3F%22&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=flamegraph&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanType=service-entry&traceQuery=&view=spans&start=1711772720605&end=1712982320605&paused=false).

- [ ] Try to get an OTP for your ogp email address -> should succeed. 
    * Locate trace for `isomer-postgres` with the new whitelist search query, check the log for the match (e.g. `Email valid for OTP by whitelist`)
- [ ] Try to get an OTP for `badguy.jeneszh@gmail.com` -> should appear to succeed but not send an email
    * Locate trace for `isomer-postgres` with the new whitelist search query, check the log for the error (e.g. `Error occurred when attempting to login user <email>`)


