### PR TITLE
ISOM-942: add user info to traces

### DIFF
--- a/src/middleware/traceUser.ts
+++ b/src/middleware/traceUser.ts
@@ -14,7 +14,8 @@ function isUserSession(session: Session): session is UserSession {
     "userInfo" in session &&
     typeof session.userInfo === "object" &&
     session.userInfo &&
-    "isomerUserId" in session.userInfo
+    "isomerUserId" in session.userInfo &&
+    "email" in session.userInfo
   )
 }
 

--- a/src/middleware/traceUser.ts
+++ b/src/middleware/traceUser.ts
@@ -1,0 +1,21 @@
+import tracer from "@utils/tracer"
+
+import { RequestHandlerWithGrowthbook } from "@root/types"
+
+// eslint-disable-next-line import/prefer-default-export
+export const traceUserMiddleware: RequestHandlerWithGrowthbook<
+  never,
+  unknown,
+  unknown,
+  never
+> = async (req, res, next) => {
+  if (req.session?.userInfo?.isomerUserId) {
+    tracer.setUser({
+      id: req.session.userInfo.isomerUserId,
+      session_id: req.session.id,
+
+      // Could consider adding the entire userInfo object if we are comfortable having that data in DD traces
+    })
+  }
+  next()
+}

--- a/src/middleware/traceUser.ts
+++ b/src/middleware/traceUser.ts
@@ -1,15 +1,30 @@
+import { NextFunction, Request, Response } from "express"
+import { Session } from "express-session"
+
 import tracer from "@utils/tracer"
 
-import { RequestHandlerWithGrowthbook } from "@root/types"
+import { SessionData } from "@root/types/express/session"
+
+type UserSession = Session & SessionData
+
+function isUserSession(session: Session): session is UserSession {
+  return !!(
+    session &&
+    "id" in session &&
+    "userInfo" in session &&
+    typeof session.userInfo === "object" &&
+    session.userInfo &&
+    "isomerUserId" in session.userInfo
+  )
+}
 
 // eslint-disable-next-line import/prefer-default-export
-export const traceUserMiddleware: RequestHandlerWithGrowthbook<
-  never,
-  unknown,
-  unknown,
-  never
-> = async (req, res, next) => {
-  if (req.session?.userInfo?.isomerUserId) {
+export const traceUserMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (isUserSession(req.session)) {
     tracer.setUser({
       id: req.session.userInfo.isomerUserId,
       session_id: req.session.id,

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,7 +47,7 @@ import {
   getAuthorizationMiddleware,
 } from "@root/middleware"
 import { statsMiddleware } from "@root/middleware/stats"
-import { traceUser } from "@root/middleware/traceUser"
+import { traceUserMiddleware } from "@root/middleware/traceUser"
 import { BaseDirectoryService } from "@root/services/directoryServices/BaseDirectoryService"
 import { CollectionPageService } from "@root/services/fileServices/MdPageServices/CollectionPageService"
 import { ContactUsPageService } from "@root/services/fileServices/MdPageServices/ContactUsPageService"
@@ -372,7 +372,7 @@ app.use(
 )
 
 app.use(sessionMiddleware)
-app.use(traceUser)
+app.use(traceUserMiddleware)
 
 // Health endpoint
 app.use("/v2/ping", (req, res, next) => res.status(200).send("Ok"))

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,6 +47,7 @@ import {
   getAuthorizationMiddleware,
 } from "@root/middleware"
 import { statsMiddleware } from "@root/middleware/stats"
+import { traceUser } from "@root/middleware/traceUser"
 import { BaseDirectoryService } from "@root/services/directoryServices/BaseDirectoryService"
 import { CollectionPageService } from "@root/services/fileServices/MdPageServices/CollectionPageService"
 import { ContactUsPageService } from "@root/services/fileServices/MdPageServices/ContactUsPageService"
@@ -371,6 +372,7 @@ app.use(
 )
 
 app.use(sessionMiddleware)
+app.use(traceUser)
 
 // Health endpoint
 app.use("/v2/ping", (req, res, next) => res.status(200).send("Ok"))


### PR DESCRIPTION
## Problem

We do not have the user information in traces. Since DataDog offers [an API](https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md#user-identification) to track the user, we should use the capability.


## Solution

Use the [dd-trace setUser() API ](https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md#user-identification) to populate user id in traces.

This is done in a middleware that will run right after the session middleware, so we can report whatever user is in session.


### Question

Should we track the user email and github id in traces as well? (basically the entire content of the session's UserInfo object ?) Working with emails make its faster for us to identify people, but is that a privacy concern? (potentially not since we also have a lot of emails in logs?)


### Results

Verified working on staging:
[Sample trace here](https://ogp.datadoghq.com/apm/trace/6897147640340843683?colorBy=service&env=staging&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=7613602567414186727&spanViewType=metadata&timeHint=1713260101003.0051)
![image](https://github.com/isomerpages/isomercms-backend/assets/935223/8a91b330-93c2-4bab-99c2-9b514a3b79a2)

Traces and spans can be filtered by show the user id and session id:
[Sample search here](https://ogp.datadoghq.com/apm/traces?query=%40_top_level%3A1%20env%3Astaging%20service%3Aisomer%20%40usr.id%3A119&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40usr.id%2C%40usr.session_id&fromUser=false&graphType=flamegraph&historicalData=false&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanType=service-entry&traceQuery=&view=spans&start=1713259340314&end=1713260240314&paused=false)
![image](https://github.com/isomerpages/isomercms-backend/assets/935223/1edcd6fd-ec06-4f0e-8c61-595839d93abd)


