### PR TITLE
fix(task def): update log groups for support + role for prod

### DIFF
--- a/.aws/deploy/support-task-definition.prod.json
+++ b/.aws/deploy/support-task-definition.prod.json
@@ -196,7 +196,7 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/aws/elasticbeanstalk/cms-backend-staging-node18/var/log/web.stdout.log",
+          "awslogs-group": "/aws/elasticbeanstalk/cms-backend-prod-node18/var/log/web.stdout.log",
           "awslogs-region": "ap-southeast-1",
           "awslogs-stream-prefix": "ecs"
         }
@@ -274,7 +274,7 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "isomer-infra-staging/ecs/dd-agent",
+          "awslogs-group": "prod-support/ecs/dd-agent",
           "awslogs-region": "ap-southeast-1",
           "awslogs-stream-prefix": "ecs"
         }
@@ -297,8 +297,8 @@
     "operatingSystemFamily": "LINUX"
   },
   "requiresCompatibilities": ["FARGATE"],
-  "taskRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/stg-support-ecs-task-role",
-  "executionRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/stg-support-ecs-task-exec-role",
+  "taskRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/prod-support-ecs-task-role",
+  "executionRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/prod-support-ecs-task-exec-role",
   "cpu": "1024",
   "memory": "2048"
 }

--- a/.aws/deploy/support-task-definition.staging.json
+++ b/.aws/deploy/support-task-definition.staging.json
@@ -283,7 +283,7 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "isomer-infra-staging/ecs/dd-agent",
+          "awslogs-group": "stg-support/ecs/dd-agent",
           "awslogs-region": "ap-southeast-1",
           "awslogs-stream-prefix": "ecs"
         }


### PR DESCRIPTION
## Problem
There was an error with the production deployment - the task role specified in the task definition is the `staging` task role and leads to the `support` service not having sufficient perms in `prod`. 

## Solution
1. update task role to `prod` 
2. update dd log group for `support` for both staging + prod to avoid conflicts with existing `backend` log group. (note that this is dd internals and not app stuff - we don't need this but just for clarity)