### PR TITLE
fix: revert log group to isomer-infra

### DIFF
--- a/.aws/deploy/support-task-definition.prod.json
+++ b/.aws/deploy/support-task-definition.prod.json
@@ -274,7 +274,7 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "prod-support/ecs/dd-agent",
+          "awslogs-group": "isomer-infra-prod/ecs/dd-agent",
           "awslogs-region": "ap-southeast-1",
           "awslogs-stream-prefix": "ecs"
         }

--- a/.aws/deploy/support-task-definition.staging.json
+++ b/.aws/deploy/support-task-definition.staging.json
@@ -283,7 +283,7 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "stg-support/ecs/dd-agent",
+          "awslogs-group": "isomer-infra-staging/ecs/dd-agent",
           "awslogs-region": "ap-southeast-1",
           "awslogs-stream-prefix": "ecs"
         }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The log group was previously renamed to `prod-support/ecs/dd-agent` and `stg-support/ecs/dd-agent` for prod and staging respectively, but these log groups were not yet created via Pulumi, causing the deployments for the support service to fail.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Bug Fixes**:

- Temporarily revert the log group back to the old log group (which already existed) until the new log group is correctly created on isomer-infra.

## Tests

<!-- What tests should be run to confirm functionality? -->

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*