### PR TITLE
ISOM-951: Better cloudmersive logging

### DIFF
--- a/src/services/fileServices/MdPageServices/MediaFileService.js
+++ b/src/services/fileServices/MdPageServices/MediaFileService.js
@@ -36,7 +36,12 @@ class MediaFileService {
     const cmConfig = isCloudmersiveEnabled(sessionData.growthbook)
     if (cmConfig.is_enabled) {
       const virusScanRes = await scanFileForVirus(fileBuffer, cmConfig.timeout)
-      logger.info(`File scan result: ${virusScanRes.CleanResult}`)
+      logger.info({
+        message: "File scan result",
+        meta: {
+          virusScanRes,
+        },
+      })
       if (!virusScanRes || !virusScanRes.CleanResult) {
         throw new BadRequestError("File did not pass virus scan")
       }

--- a/src/utils/file-upload-utils.js
+++ b/src/utils/file-upload-utils.js
@@ -44,11 +44,16 @@ const scanFileForVirus = (fileBuffer, timeout) => {
     defaultCloudmersiveClient.timeout = timeout
   }
   return new Promise((success, failure) => {
-    apiInstance.scanFile(fileBuffer, (error, data) => {
+    apiInstance.scanFile(fileBuffer, (error, data, response) => {
       if (error) {
-        logger.error(
-          `Error when calling Cloudmersive Virus Scan API: ${error.message}`
-        )
+        logger.error({
+          message: "Error when calling Cloudmersive Virus Scan API",
+          error,
+          meta: {
+            data,
+            headers: response?.headers,
+          },
+        })
         failure(error)
       } else {
         logger.info("Cloudmersive Virus Scan API called successfully")


### PR DESCRIPTION
## Problem

CloudMersiove is supposed to return 200 for all scan calls, and the response body will indicate if the media contains viruses or not. 

Unfortunately, we see instances where CloudMersive returns a 400, which means it is OUR error, since we are the one who make the call (it's not a client error). Our app correctly returns 500 when this happens because the 400 responses are not expected.

Unfortunately, our logging for CloudMersive errors only contains the http status message like so:

> Error when calling Cloudmersive Virus Scan API: Bad Request

Which is not enough information for us to troubleshoot what about the request is wrong (e.g. a rate limit error? a body error? etc.)

[Sample trace here](https://ogp.datadoghq.com/apm/trace/8271674638636057839?colorBy=service&env=production&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=4797913757591720371&spanViewType=logs&timeHint=1712285893885)
![image](https://github.com/isomerpages/isomercms-backend/assets/935223/ef29ead9-b307-4816-a8f1-b1dd8cc26165)
![image](https://github.com/isomerpages/isomercms-backend/assets/935223/17b957f4-116a-4457-9c67-fbccc4295e2f)


## Solution

Improve cloudmersive logs so we can (hopefully) understand the error better, and we can also have some data about the typical viruses (if any) that CM finds for us.

Documentation is unfortunately sparse (see [here](https://www.npmjs.com/package/cloudmersive-virus-api-client#getting-started)), but we can see that we should have access to the `response` object, which should allow us see everything we need about the response (e.g. headers, body). 

This PR only includes non functional changes: it's just extra logging.