### PR TITLE
fix(mergify): update as snyk now uses isomeradmin

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -14,7 +14,7 @@ pull_request_rules:
 
   - name: Approve and merge Snyk.io upgrades
     conditions:
-      - author=snyk-bot
+      - author=isomeradmin
       - check-success~=lint
       - check-success~=test
       - title~=^\[Snyk\]]


### PR DESCRIPTION
## Problem
Previously we used `snyk-bot` but now it is `isomeradmin`

## Solution
Change `author` to `isomeradmin`