### PR TITLE
feat: optimise local diff

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -35,7 +35,7 @@ export E2E_TEST_SECRET="test"
 export E2E_TEST_GH_TOKEN="test"
 
 # Database
-export DB_URI="postgres://isomer:password@localhost:54321/isomercms_test"
+export DB_URI="postgres://isomer:password@127.0.0.1:54321/isomercms_test"
 export DB_MIN_POOL="1"
 export DB_MAX_POOL="10"
 export DB_ENABLE_LOGGING="true"

--- a/src/fixtures/review.ts
+++ b/src/fixtures/review.ts
@@ -47,6 +47,9 @@ export const MOCK_LATEST_LOG_ONE = {
   body: "body",
   author_name: "name",
   author_email: "email",
+  diff: {
+    files: [{ file: MOCK_COMMIT_FILEPATH_ONE + MOCK_COMMIT_FILENAME_ONE }],
+  },
 }
 
 export const MOCK_LATEST_LOG_TWO = {
@@ -57,6 +60,13 @@ export const MOCK_LATEST_LOG_TWO = {
   body: "body",
   author_name: "name",
   author_email: "email",
+  diff: {
+    files: [{ file: MOCK_COMMIT_FILEPATH_TWO + MOCK_COMMIT_FILENAME_TWO }],
+  },
+}
+
+export const MOCK_LATEST_LOGS = {
+  all: [MOCK_LATEST_LOG_ONE, MOCK_LATEST_LOG_TWO],
 }
 
 export const MOCK_FILENAME_TO_LATEST_LOG_MAP = {

--- a/src/services/db/GitFileSystemService.ts
+++ b/src/services/db/GitFileSystemService.ts
@@ -396,7 +396,7 @@ export default class GitFileSystemService {
       return ResultAsync.fromPromise(
         this.git
           .cwd({ path: `${efsVolPath}/${repoName}`, root: false })
-          .diff(["master..staging", "--name-only"]),
+          .raw(["diff-tree", "-r", "--name-only", "master..staging"]),
         (error) => {
           logger.error(
             `Error when getting diff files between master and staging: ${error}, when trying to access ${efsVolPath}/${repoName}`

--- a/src/services/db/RepoService.ts
+++ b/src/services/db/RepoService.ts
@@ -58,8 +58,8 @@ export default class RepoService extends GitHubService {
     return this.gitFileSystemService.getFilesChanged(siteName)
   }
 
-  getLatestLocalCommitOfPath(repoName: string, path: string) {
-    return this.gitFileSystemService.getLatestCommitOfPath(repoName, path)
+  getCommitsBetweenMasterAndStaging(siteName: string) {
+    return this.gitFileSystemService.getCommitsBetweenMasterAndStaging(siteName)
   }
 
   getCommitDiff(siteName: string, base?: string, head?: string) {

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -777,49 +777,6 @@ describe("GitFileSystemService", () => {
     })
   })
 
-  describe("getLatestLocalCommitOfPath", () => {
-    it("should return the latest commit for a valid path", async () => {
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        log: jest.fn().mockResolvedValueOnce({
-          latest: MOCK_LATEST_LOG_ONE,
-        }),
-      })
-
-      const result = await GitFileSystemService.getLatestCommitOfPath(
-        "fake-repo",
-        "fake-dir/fake-file"
-      )
-
-      expect(result._unsafeUnwrap()).toEqual(MOCK_LATEST_LOG_ONE)
-    })
-
-    it("should return GitFileSystemError if an error occurred when getting the git log", async () => {
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        log: jest.fn().mockRejectedValueOnce(new GitError()),
-      })
-
-      const result = await GitFileSystemService.getLatestCommitOfPath(
-        "fake-repo",
-        "fake-dir/fake-file"
-      )
-
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
-    })
-
-    it("should return GitFileSystemError if there were no commits found", async () => {
-      MockSimpleGit.cwd.mockReturnValueOnce({
-        log: jest.fn().mockResolvedValueOnce({ latest: null }),
-      })
-
-      const result = await GitFileSystemService.getLatestCommitOfPath(
-        "fake-repo",
-        "fake-dir/fake-file"
-      )
-
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(GitFileSystemError)
-    })
-  })
-
   describe("getGitLog", () => {
     it("should return the Git log for a valid branch", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({

--- a/src/services/db/__tests__/GitFileSystemService.spec.ts
+++ b/src/services/db/__tests__/GitFileSystemService.spec.ts
@@ -753,7 +753,7 @@ describe("GitFileSystemService", () => {
 
     it("should return the files changed and defensively try creating local branches", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
-        diff: jest
+        raw: jest
           .fn()
           .mockResolvedValueOnce("fake-dir/fake-file\nanother-fake-file\n"),
       })
@@ -768,7 +768,7 @@ describe("GitFileSystemService", () => {
 
     it("should return GitFileSystemError if an error occurred when getting the git diff", async () => {
       MockSimpleGit.cwd.mockReturnValueOnce({
-        diff: jest.fn().mockRejectedValueOnce(new GitError()),
+        raw: jest.fn().mockRejectedValueOnce(new GitError()),
       })
 
       const actual = await GitFileSystemService.getFilesChanged("fake-repo")

--- a/src/services/review/__tests__/ReviewRequestService.spec.ts
+++ b/src/services/review/__tests__/ReviewRequestService.spec.ts
@@ -54,10 +54,12 @@ import {
   MOCK_FILENAME_TO_LATEST_LOG_MAP,
   MOCK_REVIEW_REQUEST_META,
   MOCK_REVIEW_REQUEST_COMMENT,
+  MOCK_LATEST_LOGS,
 } from "@root/fixtures/review"
 import {
   mockEmail,
   mockGrowthBook,
+  mockIsomerUserId,
   mockUserWithSiteSessionData,
   mockUserWithSiteSessionDataAndGrowthBook,
 } from "@root/fixtures/sessionData"
@@ -90,7 +92,7 @@ const MockReviewApi = {
   getCommitDiff: jest.fn(),
   getPullRequest: jest.fn(),
   getFilesChanged: jest.fn(),
-  getLatestLocalCommitOfPath: jest.fn(),
+  getCommitsBetweenMasterAndStaging: jest.fn(),
   fastForwardMaster: jest.fn(),
 }
 
@@ -178,11 +180,11 @@ describe("ReviewRequestService", () => {
       MockReviewApi.getFilesChanged.mockReturnValue(
         okAsync(MOCK_PULL_REQUEST_FILES_CHANGED)
       )
-      MockReviewApi.getLatestLocalCommitOfPath = jest.fn(
-        (repoName: string, path: string) =>
-          okAsync(MOCK_FILENAME_TO_LATEST_LOG_MAP[path])
+      MockReviewApi.getCommitsBetweenMasterAndStaging = jest.fn(() =>
+        okAsync(MOCK_LATEST_LOGS)
       )
       MockUsersRepository.findByPk.mockResolvedValue({
+        id: mockIsomerUserId,
         email: mockEmail,
       })
       MockPageService.parsePageName.mockReturnValue(okAsync("mock page name"))
@@ -229,7 +231,9 @@ describe("ReviewRequestService", () => {
       // Assert
       expect(actual).toEqual(expected)
       expect(MockReviewApi.getFilesChanged).toHaveBeenCalled()
-      expect(MockReviewApi.getLatestLocalCommitOfPath).toHaveBeenCalledTimes(2)
+      expect(
+        MockReviewApi.getCommitsBetweenMasterAndStaging
+      ).toHaveBeenCalledTimes(1)
       expect(MockPageService.retrieveStagingPermalink).toHaveBeenCalled()
     })
 
@@ -247,7 +251,9 @@ describe("ReviewRequestService", () => {
       // Assert
       expect(actual).toEqual(expected)
       expect(MockReviewApi.getFilesChanged).toHaveBeenCalled()
-      expect(MockReviewApi.getLatestLocalCommitOfPath).not.toHaveBeenCalled()
+      expect(
+        MockReviewApi.getCommitsBetweenMasterAndStaging
+      ).not.toHaveBeenCalled()
       expect(MockPageService.retrieveStagingPermalink).not.toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
## Problem
Closes https://linear.app/ogp/issue/ISOM-833/benchmark-impact-of-local-git-diff-on-cpu-usage
Local diff was implemented a while back but kept behind a feature flag.
Feature flag has not been enabled in production due to concerns about performance especially for larger diffs.

## Solution
### Understanding bottlenecks via Datadog
**Everything below is in the context of motac2 with ~444 files changed in one RR**
[Trace for unoptimised implementation](https://ogp.datadoghq.com/apm/traces?query=%40_top_level%3A1%20env%3Astaging%20service%3A%2Aisomer%2A%20resource_name%3A%2Acompare%2A&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=flamegraph&historicalData=false&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanID=3675313136803532925&spanType=service-entry&spanViewType=errors&timeHint=1714031343944&trace=90028220631642002043675313136803532925&traceID=9002822063164200204&traceQuery=&view=spans&start=1714051891906&end=1714052791906&paused=false)
Significant bottlenecks (in order of priority):
1. `getFilesChanged` 27s / 40s or ~66%
2. calling `getLatestCommitOfPath` for every single file changed
    - called in parallel but still each call is about 10s / 40s or 25%
3. querying `Users` for every commit to get `email` (@timotheeg had already fixed this for the GitHub diff flow), actually doesn't add much to latency

### Optimisations
1. Refactor `getFilesChanged` to call `git diff-tree -r --name-only master..staging`
    - this change alone cuts the 27s to ~70ms
2. Refactor the entire flow. Like @timotheeg  mentioned, writing "clean" and "elegant" code in the original implementation - mapping over the filenames and performing the operations on that individual level - is not always the best when it comes to efficiency. Additionally, there is extra network cost from interacting with EFS many times.
    - instead `getCommitsBetweenMasterAndStaging` once
    - loop over these commits, constructing a `filenameToLogMap`. At the same time, get unique `userIds` from commit messages to dedupe queries
    - query DB for the unique users and construct a `userIdToUserMap`
    - finally use the two maps to construct the full response for each filename - minimal changes here just that it no longer needs to query DB and get latest commit from EFS for every single filename, as the two data structures are sufficient.

### Final flame graph after optimisations:
Bottleneck is now the many parallel reads on EFS. Out of scope for this PR and its also current behaviour for GitHub flow.
TLDR: reads are needed to get the permalink from frontmatter, which is then used to construct the `stagingUrl`

https://github.com/isomerpages/isomercms-backend/assets/77665182/44d530aa-da0c-4a94-88a1-b24978d13cdf



**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)


## Tests
Copied over tests from https://github.com/isomerpages/isomercms-backend/pull/1172
- [ ] Toggle feature flag `is_local_diff_enabled` for account being tested https://app.growthbook.io/features/is_local_diff_enabled
- [ ] Create a page
- [ ] Edit a page
- [ ] Delete a page
- [ ] Move a page
- [ ] Try to create an RR and check that the diff shown is correct for all files (this tests that /compare works)
- [ ] After creating the RR, navigate to the RR page and check that the diff shown is correct (this tests that /listFullReviewRequest works)
- [ ] Approve and publish the RR
- [ ] Check that diff is empty now (tests that master has been fastforwarded)
- [ ] Finally, last sanity check that the diff still works after making another edit


