### PR TITLE
fix(sitelaunch): do not throw for no dig results

### DIFF
--- a/support/routes/v2/formsg/formsgSiteLaunch.ts
+++ b/support/routes/v2/formsg/formsgSiteLaunch.ts
@@ -252,6 +252,7 @@ export class FormsgSiteLaunchRouter {
         logger.info(
           `Domain ${launchResult.primaryDomainSource} does not have any AAAA records.`
         )
+        return [] // no AAAA records found
       }
       logger.error(
         `Error when trying to get AAAA records for domain ${launchResult.primaryDomainSource}: ${e}`
@@ -315,6 +316,12 @@ export class FormsgSiteLaunchRouter {
         logger.info(
           `Domain ${launchResult.primaryDomainSource} does not have any CAA records.`
         )
+
+        // if no CAA records, no need to add Amazon CAA and letsencrypt.org CAA
+        return {
+          addAWSACMCertCAA: false,
+          addLetsEncryptCAA: false,
+        }
       }
       logger.error(
         `Error when trying to get CAA records for domain ${launchResult.primaryDomainSource}: ${e}`


### PR DESCRIPTION
## Problem

When there was no records that were found, dns:node throws an error. While we did handle it, there should have been an additional return statement to exit early rather than propagating into an error state. 

## Solution

If the error is of type `ENODATA`, return early with some default values instead.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)


## Tests
Locally enter these values into `support/routes/v2/formsg/index.ts`

```
formsgSiteLaunchRouter
  .digAAAADomainRecords({
    primaryDomainSource: "singaopreoae.sg",
  } as SiteLaunchResult)
  .then(console.log)
  .catch(console.error)

formsgSiteLaunchRouter
  .digCAADomainRecords({
    primaryDomainSource: "singaopreoae.sg",
  } as SiteLaunchResult)
  .then(console.log)
  .catch(console.error)

```

assert that the console log outputs 

![Screenshot 2024-04-30 at 9.24.39 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/4JosFH65rhzwIvkZw2J6/0f0ef21a-b3b3-482d-8b6d-e8f3e88b020a.png)

## Deploy Notes

This fix is meant to go into prod line asap