### PR TITLE
chore(sitelaunch): better error message

### DIFF
--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -53,6 +53,10 @@ export class Logger {
     return new Logger(child)
   }
 
+  public setBindings = (bindings: { [key: string]: unknown }): void => {
+    this._logger.setBindings(bindings)
+  }
+
   public error = (
     // NOTE: Giving type as `unknown` here
     // because when we do a `catch`,

--- a/support/routes/v2/formsg/formsgSiteLaunch.ts
+++ b/support/routes/v2/formsg/formsgSiteLaunch.ts
@@ -8,7 +8,7 @@ import { err, ok } from "neverthrow"
 
 import { config } from "@config/config"
 
-import logger from "@logger/logger"
+import parentLogger from "@logger/logger"
 
 import InitializationError from "@errors/InitializationError"
 
@@ -85,9 +85,15 @@ export class FormsgSiteLaunchRouter {
       },
     ]
 
-    logger.info(
-      `Launch site form submission [${submissionId}] (repoName '${repoName}', domain '${primaryDomain}') requested by <${requesterEmail}>`
-    )
+    this.siteLaunchLogger.info({
+      message: "Launch site form submission",
+      meta: {
+        submissionId,
+        repoName,
+        primaryDomain,
+        requesterEmail,
+      },
+    })
 
     // 2. Check arguments
     if (!requesterEmail) {
@@ -146,6 +152,10 @@ export class FormsgSiteLaunchRouter {
   private readonly usersService: FormsgSiteLaunchRouterProps["usersService"]
 
   private readonly infraService: FormsgSiteLaunchRouterProps["infraService"]
+
+  private readonly siteLaunchLogger = parentLogger.child({
+    module: "formsgSiteLaunch",
+  })
 
   constructor({ usersService, infraService }: FormsgSiteLaunchRouterProps) {
     this.usersService = usersService
@@ -249,14 +259,21 @@ export class FormsgSiteLaunchRouter {
       }))
     } catch (e) {
       if (isErrnoException(e) && e.code === "ENODATA") {
-        logger.info(
-          `Domain ${launchResult.primaryDomainSource} does not have any AAAA records.`
-        )
+        this.siteLaunchLogger.info({
+          message: `Domain does not have any AAAA records.`,
+          meta: {
+            domain: launchResult.primaryDomainSource,
+          },
+        })
         return [] // no AAAA records found
       }
-      logger.error(
-        `Error when trying to get AAAA records for domain ${launchResult.primaryDomainSource}: ${e}`
-      )
+      this.siteLaunchLogger.error({
+        message: "Error when trying to get AAAA records for domain",
+        error: e,
+        meta: {
+          domain: launchResult.primaryDomainSource,
+        },
+      })
       throw e
     }
   }
@@ -313,9 +330,12 @@ export class FormsgSiteLaunchRouter {
       return result
     } catch (e) {
       if (isErrnoException(e) && e.code === "ENODATA") {
-        logger.info(
-          `Domain ${launchResult.primaryDomainSource} does not have any CAA records.`
-        )
+        this.siteLaunchLogger.info({
+          message: `Domain does not have any CAA records.`,
+          meta: {
+            domain: launchResult.primaryDomainSource,
+          },
+        })
 
         // if no CAA records, no need to add Amazon CAA and letsencrypt.org CAA
         return {
@@ -323,9 +343,14 @@ export class FormsgSiteLaunchRouter {
           addLetsEncryptCAA: false,
         }
       }
-      logger.error(
-        `Error when trying to get CAA records for domain ${launchResult.primaryDomainSource}: ${e}`
-      )
+
+      this.siteLaunchLogger.error({
+        message: "Error when trying to get CAA records for domain",
+        error: e,
+        meta: {
+          domain: launchResult.primaryDomainSource,
+        },
+      })
       throw e
     }
   }
@@ -375,9 +400,13 @@ export class FormsgSiteLaunchRouter {
 
       await this.sendLaunchError(submissionId, failureResults)
     } catch (e) {
-      logger.error(
-        `Something unexpected went wrong when launching sites from form submission ${submissionId}. Error: ${e}`
-      )
+      this.siteLaunchLogger.error({
+        message: `Something unexpected went wrong when launching sites from form submission`,
+        error: e,
+        meta: {
+          submissionId,
+        },
+      })
     }
   }
 


### PR DESCRIPTION
## Problem
The existing statements does not print the error (since errors are not serializable) as mentioned [here](https://github.com/isomerpages/isomercms-backend/pull/1355#discussion_r1584027034)

In addition, we have not been using the child loggers as effectively as possible to provide the context needed to debug efficiently when errors arise. A obvious example is our constant noise of `Github API call made`, but we have no context surrounding that particular call being made.

To fix this issue, this pr introduces a small introduction of using child loggers, which has already been declared in our codebase by @seaerchin. A child logger is used to create a new logger instance that inherits all of its parent's metadata (e.g. logger name) and attach new metadata for all logs written by that child logger. This way we avoid having to keep repeating our context in the multiple calls that are needed. 


## Help needed, but not a blocker to this particular PR.
Moving forward, my stance is that we would want to inject the logger directly onto the child functions in different modules. 

eg in this trace in the happy path, we can see that the trace for all the calls are not instantiated with the meta that I would like it to have. 

![Screenshot 2024-05-02 at 11 12 45 AM](https://github.com/isomerpages/isomercms-backend/assets/42832651/9225723b-cc0c-4b1b-9460-9703b3099f37)

The reason for this is because the other logs are done in seperate modules, and if we were to pass the child logger over, this means that for every call, we would need to pass in the logger with bindings as needed. But, I see how this could lead to verbose code. 

To me, it seems like there is a balance to be strived for. I personally think using child loggers just the module is not very helpful. What I found more useful is the ability to view the context around the call useful. Ie, `with what set of inputs did this module behave in the manner that we see here`. I think this can help with debugging, rather than just the module name. But I am not too sure where to draw the line between passing the context form the parent service vs depending on the child service to log the relevant meta as needed during debugging. Happy to hear your thoughts on this. Note that regardless of the direction that we chose, this pr should still go in as it is only scoped to one module + it is an incremental improvement to introducing the usage of child loggers in our codebase.  
 
## Solution

use pino to serialize the errors instead + use child loggers with relevant context so that subsequent loggers do not need to keep repeating the context over and over again.
