### PR TITLE
fix(sl): fix error code

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -76,6 +76,8 @@ export const REDIRECTION_SERVER_IPS = [
   "18.138.108.8",
   "18.139.47.66",
 ]
+export const ALLOWED_DNS_ERROR_CODES = ["ENOTFOUND", "ENODATA"]
+
 export const DNS_INDIRECTION_DOMAIN = "hostedon.isomer.gov.sg"
 export const DNS_INDIRECTION_REPO = "isomer-indirection"
 export const ISOMER_ADMIN_EMAIL = "admin@isomer.gov.sg"

--- a/support/routes/v2/formsg/formsgSiteLaunch.ts
+++ b/support/routes/v2/formsg/formsgSiteLaunch.ts
@@ -14,7 +14,7 @@ import InitializationError from "@errors/InitializationError"
 
 import { getField, getFieldsFromTable } from "@utils/formsg-utils"
 
-import { ISOMER_SUPPORT_EMAIL } from "@root/constants"
+import { ALLOWED_DNS_ERROR_CODES, ISOMER_SUPPORT_EMAIL } from "@root/constants"
 import { attachFormSGHandler } from "@root/middleware"
 import { mailer } from "@root/services/utilServices/MailClient"
 import {
@@ -258,7 +258,11 @@ export class FormsgSiteLaunchRouter {
         value: record,
       }))
     } catch (e) {
-      if (isErrnoException(e) && e.code === "ENODATA") {
+      if (
+        isErrnoException(e) &&
+        e.code &&
+        ALLOWED_DNS_ERROR_CODES.includes(e.code)
+      ) {
         this.siteLaunchLogger.info({
           message: `Domain does not have any AAAA records.`,
           meta: {
@@ -329,7 +333,11 @@ export class FormsgSiteLaunchRouter {
 
       return result
     } catch (e) {
-      if (isErrnoException(e) && e.code === "ENODATA") {
+      if (
+        isErrnoException(e) &&
+        e.code &&
+        ALLOWED_DNS_ERROR_CODES.includes(e.code)
+      ) {
         this.siteLaunchLogger.info({
           message: `Domain does not have any CAA records.`,
           meta: {


### PR DESCRIPTION
## Problem

There was a bug in the implementation of #1355. This worked for sites that were already launched. Newer sites which do no resolve to any host name throws a `ENOTFOUND`, which should be an ok error.  

## Solution

To fix this issue, we explicitly check for this error code as well to ensure that this does not error out. 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)



## Tests
tldr; below we are testing for 
1. domains that have caa + aaaa record (google.com)
2. domains that dont resolve to a host name (dontexist.sg)
3. domains that do resolve to a host name but dont have an aaaa/caa record (isomer.gov.sg)
 
Locally enter these values into `support/routes/v2/formsg/index.ts`

```
formsgSiteLaunchRouter
  .digAAAADomainRecords({
    primaryDomainSource: "isomer.gov.sg",
  } as SiteLaunchResult)
  .then(console.log)
  .catch(console.error)

formsgSiteLaunchRouter
  .digCAADomainRecords({
    primaryDomainSource: "isomer.gov.sg",
  } as SiteLaunchResult)
  .then(console.log)
  .catch(console.error)
formsgSiteLaunchRouter
  .digAAAADomainRecords({
    primaryDomainSource: "dontexist.sg",
  } as SiteLaunchResult)
  .then(console.log)
  .catch(console.error)

formsgSiteLaunchRouter
  .digCAADomainRecords({
    primaryDomainSource: "dontexist.sg",
  } as SiteLaunchResult)
  .then(console.log)
  .catch(console.error)
formsgSiteLaunchRouter
  .digAAAADomainRecords({
    primaryDomainSource: "google.com",
  } as SiteLaunchResult)
  .then(console.log)
  .catch(console.error)

formsgSiteLaunchRouter
  .digCAADomainRecords({
    primaryDomainSource: "google.com",
  } as SiteLaunchResult)
  .then(console.log)
  .catch(console.error)

```

assert that the console log outputs 

```
support-1   | [08:59:33.272] INFO (56): Domain does not have any AAAA records.
support-1   |     module: "formsgSiteLaunch"
support-1   |     meta: {
support-1   |       "domain": "isomer.gov.sg"
support-1   |     }
support-1   | { addAWSACMCertCAA: true, addLetsEncryptCAA: false }
support-1   | [
support-1   |   {
support-1   |     domain: 'google.com',
support-1   |     type: 'AAAA',
support-1   |     value: '2404:6800:4003:c11::64'
support-1   |   },
support-1   |   {
support-1   |     domain: 'google.com',
support-1   |     type: 'AAAA',
support-1   |     value: '2404:6800:4003:c11::65'
support-1   |   },
support-1   |   {
support-1   |     domain: 'google.com',
support-1   |     type: 'AAAA',
support-1   |     value: '2404:6800:4003:c11::71'
support-1   |   },
support-1   |   {
support-1   |     domain: 'google.com',
support-1   |     type: 'AAAA',
support-1   |     value: '2404:6800:4003:c11::8b'
support-1   |   }
support-1   | ]
support-1   | []
support-1   | { addAWSACMCertCAA: false, addLetsEncryptCAA: false }
support-1   | { addAWSACMCertCAA: false, addLetsEncryptCAA: false }
support-1   | []
support-1   | [08:59:33.272] INFO (56): Domain does not have any CAA records.
support-1   |     module: "formsgSiteLaunch"
support-1   |     meta: {
support-1   |       "domain": "isomer.gov.sg"
support-1   |     }
support-1   | [08:59:33.272] INFO (56): Domain does not have any CAA records.
support-1   |     module: "formsgSiteLaunch"
support-1   |     meta: {
support-1   |       "domain": "dontexist.sg"
support-1   |     }
support-1   | [08:59:33.272] INFO (56): Domain does not have any AAAA records.
support-1   |     module: "formsgSiteLaunch"
support-1   |     meta: {
support-1   |       "domain": "dontexist.sg"
support-1   |     }
```


