### PR TITLE
feat: move DNS checker slackbot from lambda

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -79,7 +79,8 @@ export const REDIRECTION_SERVER_IPS = [
 export const ALLOWED_DNS_ERROR_CODES = ["ENOTFOUND", "ENODATA"]
 
 export const DNS_INDIRECTION_DOMAIN = "hostedon.isomer.gov.sg"
-export const DNS_CNAME_SUFFIXES = ["cloudfront.net", "kxcdn.com"]
+export const DNS_KEYCDN_SUFFIX = "kxcdn.com"
+export const DNS_CNAME_SUFFIXES = ["cloudfront.net", DNS_KEYCDN_SUFFIX]
 export const DNS_INDIRECTION_REPO = "isomer-indirection"
 export const ISOMER_ADMIN_EMAIL = "admin@isomer.gov.sg"
 export const ISOMER_SUPPORT_EMAIL = "support@isomer.gov.sg"

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -79,6 +79,7 @@ export const REDIRECTION_SERVER_IPS = [
 export const ALLOWED_DNS_ERROR_CODES = ["ENOTFOUND", "ENODATA"]
 
 export const DNS_INDIRECTION_DOMAIN = "hostedon.isomer.gov.sg"
+export const DNS_CNAME_SUFFIXES = ["cloudfront.net", "kxcdn.com"]
 export const DNS_INDIRECTION_REPO = "isomer-indirection"
 export const ISOMER_ADMIN_EMAIL = "admin@isomer.gov.sg"
 export const ISOMER_SUPPORT_EMAIL = "support@isomer.gov.sg"

--- a/src/types/dnsChecker.ts
+++ b/src/types/dnsChecker.ts
@@ -1,0 +1,11 @@
+export interface DnsCheckerResponse {
+  // eslint-disable-next-line camelcase
+  response_type: "in_channel"
+  blocks: Array<{
+    type: "section"
+    text: {
+      type: "mrkdwn"
+      text: string
+    }
+  }>
+}

--- a/support/routes/v2/isobot/index.ts
+++ b/support/routes/v2/isobot/index.ts
@@ -54,8 +54,6 @@ const handleDnsChecker: RequestHandler<
       message: `Sorry, \`${req.body.text}\` is not a valid domain name. Please try again with a valid one instead.`,
     })
 
-  // We need to return 200 OK to Slack before we process the request
-  // The response will be done via the response_url provided in the payload
   return botService
     .dnsChecker(req.body)
     .map((response) => res.status(200).send(response))

--- a/support/routes/v2/isobot/index.ts
+++ b/support/routes/v2/isobot/index.ts
@@ -48,20 +48,6 @@ const handleDnsChecker: RequestHandler<
   unknown,
   never
 > = async (req, res) => {
-  const slackTimestamp = req.headers["x-slack-request-timestamp"] as string
-  const slackSig = req.headers["x-slack-signature"] as string
-
-  if (!slackTimestamp || !slackSig)
-    return res.status(400).send({ message: "Missing header/signature" })
-
-  const isVerifiedMessage = botService.verifySignature(
-    slackSig,
-    slackTimestamp,
-    req.body
-  )
-  if (!isVerifiedMessage)
-    return res.status(400).send({ message: "Invalid signature" })
-
   const validatedDomain = botService.getValidatedDomain(req.body)
   if (!validatedDomain)
     return res.status(200).send({

--- a/support/routes/v2/isobot/ops/botService.ts
+++ b/support/routes/v2/isobot/ops/botService.ts
@@ -1,11 +1,19 @@
 import { createHmac, timingSafeEqual } from "node:crypto"
+import dns from "node:dns/promises"
 
+import { ResultAsync, okAsync } from "neverthrow"
 import qs from "qs"
 
 import { config } from "@config/config"
 
+import {
+  DNS_CNAME_SUFFIXES,
+  DNS_INDIRECTION_DOMAIN,
+  REDIRECTION_SERVER_IPS,
+} from "@root/constants"
 import logger from "@root/logger/logger"
 import WhitelistService from "@root/services/identity/WhitelistService"
+import { DnsCheckerResponse } from "@root/types/dnsChecker"
 
 export interface SlackPayload {
   token: string
@@ -19,11 +27,82 @@ export interface SlackPayload {
   text: string
 }
 
+// Slack only gives us 3 seconds to respond, but usually DNS resolution is fast,
+// so we will give it 2 seconds before we give up
+const DNS_TIMEOUT = 2000
+
 class BotService {
   whitelistService: WhitelistService
 
   constructor(whitelistService: WhitelistService) {
     this.whitelistService = whitelistService
+  }
+
+  private checkCname(domain: string) {
+    return ResultAsync.fromPromise(
+      Promise.race([
+        dns.resolveCname(domain),
+        new Promise<null>((_, reject) =>
+          setTimeout(() => reject(null), DNS_TIMEOUT)
+        ),
+      ]),
+      () => {
+        logger.info({
+          message: "Error resolving CNAME",
+          meta: { domain, method: "checkCname" },
+        })
+        return new Error()
+      }
+    )
+      .andThen((cname) => {
+        if (!cname || cname.length === 0) {
+          return okAsync(null)
+        }
+
+        return okAsync(cname[0])
+      })
+      .orElse(() => okAsync(null))
+  }
+
+  private checkA(domain: string) {
+    return ResultAsync.fromPromise(
+      Promise.race([
+        dns.resolve4(domain),
+        new Promise<null>((_, reject) =>
+          setTimeout(() => reject(null), DNS_TIMEOUT)
+        ),
+      ]),
+      () => {
+        logger.info({
+          message: "Error resolving A record",
+          meta: { domain, method: "checkA" },
+        })
+        return new Error()
+      }
+    )
+      .andThen((a) => {
+        if (!a || a.length === 0) {
+          return okAsync(null)
+        }
+
+        return okAsync(a)
+      })
+      .orElse(() => okAsync(null))
+  }
+
+  private getSlackMessage(message: string | string[]): DnsCheckerResponse {
+    return {
+      response_type: "in_channel",
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: typeof message === "string" ? message : message.join("\n"),
+          },
+        },
+      ],
+    }
   }
 
   public verifySignature(
@@ -93,6 +172,274 @@ class BotService {
     logger.info({ message: "Whitelisting emails", meta: { emails } })
 
     await this.whitelistService.addWhitelist(emails)
+  }
+
+  getValidatedDomain(payload: SlackPayload) {
+    const { text: domain } = payload
+    const DOMAIN_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$/
+
+    if (!DOMAIN_NAME_REGEX.test(domain)) {
+      return false
+    }
+
+    return domain
+  }
+
+  getDnsCheckerMessage(
+    domain: string,
+    cnameDomain: string | null,
+    redirectionDomain: string,
+    cnameRecord: string | null,
+    indirectionDomain: string,
+    intermediateRecords: string[] | null,
+    redirectionRecords: string[] | null
+  ) {
+    // Domain has a CNAME pointing to one of our known suffixes
+    const isDomainCnameCorrect =
+      cnameRecord &&
+      (cnameRecord.endsWith(`.${DNS_INDIRECTION_DOMAIN}`) ||
+        DNS_CNAME_SUFFIXES.some((suffix) => cnameRecord.endsWith(`.${suffix}`)))
+
+    // Domain is directly pointing to our indirection layer
+    const isDomainOnIndirection =
+      cnameRecord && cnameRecord.endsWith(`.${DNS_INDIRECTION_DOMAIN}`)
+
+    // The intermediate layer (indirection or CNAME) is resolving to valid IPs
+    // If on KeyCDN, then there should only be 1 IP, otherwise there should be 4
+    const isIntermediateValid =
+      intermediateRecords &&
+      ((cnameRecord &&
+        cnameRecord.endsWith(".kxcdn.com") &&
+        intermediateRecords.length === 1) ||
+        (isDomainCnameCorrect && intermediateRecords.length === 4))
+
+    // The redirection domain has records that are all resolving to our known IPs
+    const isRedirectionValid =
+      redirectionRecords &&
+      redirectionRecords.every((ip) => REDIRECTION_SERVER_IPS.includes(ip))
+
+    const response = []
+
+    if (
+      isDomainCnameCorrect &&
+      cnameDomain &&
+      !cnameDomain.startsWith("www.")
+    ) {
+      // Domain is a CNAME domain and does not have www in it -> No redirection domain to check
+      if (isDomainOnIndirection) {
+        if (isIntermediateValid) {
+          response.push(`The domain ${domain} is *all valid*!`)
+        } else {
+          response.push(
+            `Jialat, the domain \`${domain}\` is correctly pointing to our indirection layer, but the indirection layer does not seem to be configured correctly.`
+          )
+          response.push("This is *OUR* fault!")
+        }
+      } else {
+        response.push(
+          `Hmm, the domain ${domain} is *valid*, but it points to ${cnameRecord} which is not something that I recognise. Probably not an Isomer site?`
+        )
+        response.push(
+          `-   A records checker: https://dnschecker.org/#A/${domain}`
+        )
+        response.push(
+          `-   CNAME records checker: https://dnschecker.org/#CNAME/${domain}`
+        )
+      }
+    } else if (
+      isDomainCnameCorrect &&
+      cnameDomain &&
+      cnameDomain.startsWith("www.")
+    ) {
+      // Domain is a CNAME domain and also starts with www -> Check the apex domain as well
+      if (isDomainOnIndirection) {
+        if (isIntermediateValid && isRedirectionValid) {
+          response.push(
+            `The domain ${domain} is *all valid*! The apex domain \`${redirectionDomain}\` is also correctly configured to our redirection service.`
+          )
+        } else if (isIntermediateValid && !isRedirectionValid) {
+          response.push(
+            `Weird eh, the domain \`${domain}\` is correctly pointing to our indirection layer but the apex domain is not configured correctly.`
+          )
+          response.push("This is *AGENCY fault*!")
+        } else if (!isIntermediateValid && isRedirectionValid) {
+          response.push(
+            `Jialat, the domain \`${domain}\` is correctly pointing to our indirection layer and the apex domain is correctly configured, but the indirection layer does not seem to be configured correctly.`
+          )
+          response.push("This is *OUR fault*!")
+        } else {
+          response.push(
+            `Wah, the domain \`${domain}\` is correctly pointing to our indirection layer, but both the indirection layer and the apex domain does not seem to be configured correctly.`
+          )
+          response.push("This is *both OUR and AGENCY fault*!")
+        }
+      } else if (isIntermediateValid && isRedirectionValid) {
+        response.push(
+          `The domain ${domain} is *all valid*! Although it is directly pointing to our CDN hosting provider and not the indirection layer. The apex domain \`${redirectionDomain}\` is also correctly configured to our redirection service.`
+        )
+      } else if (isIntermediateValid && !isRedirectionValid) {
+        response.push(
+          `Weird eh, the domain \`${domain}\` is correctly pointing to our CDN hosting provider (not indirection layer) but the apex domain is not configured correctly.`
+        )
+        response.push("This is *AGENCY fault*!")
+      } else if (!isIntermediateValid && isRedirectionValid) {
+        response.push(
+          `Jialat, the domain \`${domain}\` is correctly pointing to our CDN hosting provider (not indirection layer) and the apex domain is correctly configured, but the CDN hosting provider does not seem to be configured correctly.`
+        )
+        response.push("This is *OUR fault*!")
+      } else {
+        response.push(
+          `Wah, the domain \`${domain}\` is correctly pointing to our CDN hosting provider (not indirection layer), but both the CDN hosting provider and the apex domain does not seem to be configured correctly.`
+        )
+        response.push("This is *both OUR and AGENCY fault*!")
+      }
+    } else if (isIntermediateValid) {
+      // Domain is likely gone or points directly to A records, but our indirection layer is still correct
+      response.push(
+        `Oh no, the domain \`${domain}\` seems to be gone, but okay lah our indirection layer is correctly configured.`
+      )
+      response.push("This is *AGENCY fault*!")
+    } else if (!cnameRecord && !redirectionRecords) {
+      // Everything is gone
+      response.push(
+        `Jialat, the DNS for \`${domain}\` seems to be gone, and our indirection layer does not seem to be configured correctly.`
+      )
+      response.push(
+        "If this site is supposed to be live, then this is *both OUR and AGENCY fault*!"
+      )
+    } else {
+      // Some weird configuration
+      response.push(
+        `Wah, I don't know how to handle \`${domain}\` sia, might need to manually check.`
+      )
+      response.push(
+        `-   A records checker: https://dnschecker.org/#A/${domain}`
+      )
+      response.push(
+        `-   CNAME records checker: https://dnschecker.org/#CNAME/${domain}`
+      )
+    }
+
+    response.push(
+      `-   \`${domain}\` points to ${
+        cnameRecord ? `\`${cnameRecord}\`` : "no CNAME records"
+      }`
+    )
+
+    if (cnameRecord || indirectionDomain) {
+      response.push(
+        `-   \`${cnameRecord || indirectionDomain}\` points to ${
+          intermediateRecords
+            ? `\`${intermediateRecords.join(", ")}\``
+            : "nothing"
+        }`
+      )
+    }
+
+    if (redirectionDomain !== cnameDomain) {
+      response.push(
+        `-   \`${redirectionDomain}\` points to ${
+          redirectionRecords
+            ? `\`${redirectionRecords.join(", ")}\``
+            : "no A records"
+        }`
+      )
+    }
+
+    return this.getSlackMessage(response)
+  }
+
+  dnsChecker(payload: SlackPayload) {
+    // Step 1: Get the domain name provided by the user
+    const { user_name: user, channel_name: channel, text: domain } = payload
+    logger.info({
+      message: "DNS check requested",
+      meta: {
+        method: "dnsChecker",
+        user,
+        channel,
+        domain,
+      },
+    })
+
+    return this.checkCname(domain)
+      .andThen((cname) => {
+        // Original domain does not have a CNAME record, check if the www
+        // version has a valid CNAME record
+        if (!cname && !domain.startsWith("www.")) {
+          const cnameDomain = `www.${domain}`
+          return ResultAsync.combine([
+            okAsync(cnameDomain),
+            this.checkCname(cnameDomain),
+          ])
+        }
+
+        return ResultAsync.combine([okAsync(domain), okAsync(cname)])
+      })
+      .andThen(([cnameDomain, cnameRecord]) => {
+        // Original and www version of the domain do not have a CNAME record,
+        // check if our indirection domain is still correct
+        if (!cnameRecord) {
+          const indirectionDomain = domain.startsWith("www.")
+            ? `${domain
+                .slice(4)
+                .replaceAll(".", "-")}.${DNS_INDIRECTION_DOMAIN}`
+            : `${domain.replaceAll(".", "-")}.${DNS_INDIRECTION_DOMAIN}`
+
+          return ResultAsync.combine([
+            okAsync(null),
+            okAsync(cnameRecord),
+            okAsync(indirectionDomain),
+            this.checkA(indirectionDomain),
+          ])
+        }
+
+        // Either the original or www version of the domain has a CNAME record,
+        // check if the CNAME record is valid
+        return ResultAsync.combine([
+          okAsync(cnameDomain),
+          okAsync(cnameRecord),
+          okAsync(cnameRecord),
+          this.checkA(cnameRecord),
+        ])
+      })
+      .andThen(
+        ([cnameDomain, cnameRecord, indirectionDomain, indirectionRecords]) => {
+          const redirectionDomain = domain.startsWith("www.")
+            ? domain.slice(4)
+            : domain
+
+          return ResultAsync.combine([
+            okAsync(cnameDomain),
+            okAsync(cnameRecord),
+            okAsync(indirectionDomain),
+            okAsync(indirectionRecords),
+            okAsync(redirectionDomain),
+            this.checkA(redirectionDomain),
+          ])
+        }
+      )
+      .andThen(
+        ([
+          cnameDomain,
+          cnameRecord,
+          indirectionDomain,
+          indirectionRecords,
+          redirectionDomain,
+          redirection,
+        ]) =>
+          okAsync(
+            this.getDnsCheckerMessage(
+              domain,
+              cnameDomain,
+              redirectionDomain,
+              cnameRecord,
+              indirectionDomain,
+              indirectionRecords,
+              redirection
+            )
+          )
+      )
   }
 }
 

--- a/support/routes/v2/isobot/ops/botService.ts
+++ b/support/routes/v2/isobot/ops/botService.ts
@@ -196,7 +196,7 @@ class BotService {
   ) {
     // Domain has a CNAME pointing to one of our known suffixes
     const isDomainCnameCorrect =
-      cnameRecord &&
+      !!cnameRecord &&
       (cnameRecord.endsWith(`.${DNS_INDIRECTION_DOMAIN}`) ||
         DNS_CNAME_SUFFIXES.some((suffix) => cnameRecord.endsWith(`.${suffix}`)))
 
@@ -211,7 +211,9 @@ class BotService {
       ((cnameRecord &&
         cnameRecord.endsWith(".kxcdn.com") &&
         intermediateRecords.length === 1) ||
-        (isDomainCnameCorrect && intermediateRecords.length === 4))
+        (intermediateRecords.length === 4 &&
+          (isDomainCnameCorrect ||
+            indirectionDomain.endsWith(`.${DNS_INDIRECTION_DOMAIN}`))))
 
     // The redirection domain has records that are all resolving to our known IPs
     const isRedirectionValid =
@@ -299,7 +301,7 @@ class BotService {
         `Oh no, the domain \`${domain}\` seems to be gone, but okay lah our indirection layer is correctly configured.`
       )
       response.push("This is *AGENCY fault*!")
-    } else if (!cnameRecord && !redirectionRecords) {
+    } else if (!cnameRecord && !intermediateRecords && !redirectionRecords) {
       // Everything is gone
       response.push(
         `Jialat, the DNS for \`${domain}\` seems to be gone, and our indirection layer does not seem to be configured correctly.`

--- a/support/routes/v2/isobot/ops/botService.ts
+++ b/support/routes/v2/isobot/ops/botService.ts
@@ -9,6 +9,7 @@ import { config } from "@config/config"
 import {
   DNS_CNAME_SUFFIXES,
   DNS_INDIRECTION_DOMAIN,
+  DNS_KEYCDN_SUFFIX,
   REDIRECTION_SERVER_IPS,
 } from "@root/constants"
 import logger from "@root/logger/logger"
@@ -209,7 +210,7 @@ class BotService {
     const isIntermediateValid =
       intermediateRecords &&
       ((cnameRecord &&
-        cnameRecord.endsWith(".kxcdn.com") &&
+        cnameRecord.endsWith(`.${DNS_KEYCDN_SUFFIX}`) &&
         intermediateRecords.length === 1) ||
         (intermediateRecords.length === 4 &&
           (isDomainCnameCorrect ||

--- a/support/routes/v2/isobot/ops/botService.ts
+++ b/support/routes/v2/isobot/ops/botService.ts
@@ -389,9 +389,11 @@ class BotService {
             : `${domain.replaceAll(".", "-")}.${DNS_INDIRECTION_DOMAIN}`
 
           return ResultAsync.combine([
-            okAsync(null),
-            okAsync(cnameRecord),
-            okAsync(indirectionDomain),
+            okAsync({
+              cnameDomain: null,
+              cnameRecord,
+              indirectionDomain,
+            }),
             this.checkA(indirectionDomain),
           ])
         }
@@ -399,35 +401,44 @@ class BotService {
         // Either the original or www version of the domain has a CNAME record,
         // check if the CNAME record is valid
         return ResultAsync.combine([
-          okAsync(cnameDomain),
-          okAsync(cnameRecord),
-          okAsync(cnameRecord),
+          okAsync({
+            cnameDomain,
+            cnameRecord,
+            indirectionDomain: cnameRecord,
+          }),
           this.checkA(cnameRecord),
         ])
       })
       .andThen(
-        ([cnameDomain, cnameRecord, indirectionDomain, indirectionRecords]) => {
+        ([
+          { cnameDomain, cnameRecord, indirectionDomain },
+          indirectionRecords,
+        ]) => {
           const redirectionDomain = domain.startsWith("www.")
             ? domain.slice(4)
             : domain
 
           return ResultAsync.combine([
-            okAsync(cnameDomain),
-            okAsync(cnameRecord),
-            okAsync(indirectionDomain),
-            okAsync(indirectionRecords),
-            okAsync(redirectionDomain),
+            okAsync({
+              cnameDomain,
+              cnameRecord,
+              indirectionDomain,
+              indirectionRecords,
+              redirectionDomain,
+            }),
             this.checkA(redirectionDomain),
           ])
         }
       )
       .andThen(
         ([
-          cnameDomain,
-          cnameRecord,
-          indirectionDomain,
-          indirectionRecords,
-          redirectionDomain,
+          {
+            cnameDomain,
+            cnameRecord,
+            indirectionDomain,
+            indirectionRecords,
+            redirectionDomain,
+          },
           redirection,
         ]) =>
           okAsync(


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The DNS checker Slackbot currently lives inside a lambda.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Move the lambda function into the CMS support container.
    - There's quite a bit of permutations on the possible states, so the code is a little jank. Open to suggestions on how we can improve it.

## Tests

<!-- What tests should be run to confirm functionality? -->

- Use the slash command `/stagingasjklasd` inside our Slack (this is connected to our staging instance)
- Verify the output for a few domains

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*None*