### PR TITLE
feat: add Datadog monitoring for RDS

### DIFF
--- a/.aws/deploy/backend-task-definition.prod.json
+++ b/.aws/deploy/backend-task-definition.prod.json
@@ -270,7 +270,18 @@
       "dockerLabels": {
         "com.datadoghq.tags.env": "production",
         "com.datadoghq.tags.service": "isomer",
-        "com.datadoghq.tags.version": "7"
+        "com.datadoghq.tags.version": "7",
+        "com.datadoghq.ad.check_names": ["postgres"],
+        "com.datadoghq.ad.init_configs": [{}],
+        "com.datadoghq.ad.instances": [
+          {
+            "dbm": true,
+            "host": "<RDS_READER_ENDPOINT>",
+            "port": 5432,
+            "username": "datadog",
+            "password": "<RDS_DATADOG_PASSWORD>"
+          }
+        ]
       },
       "mountPoints": [],
       "volumesFrom": [],

--- a/.aws/deploy/backend-task-definition.prod.json
+++ b/.aws/deploy/backend-task-definition.prod.json
@@ -271,17 +271,9 @@
         "com.datadoghq.tags.env": "production",
         "com.datadoghq.tags.service": "isomer",
         "com.datadoghq.tags.version": "7",
-        "com.datadoghq.ad.check_names": ["postgres"],
-        "com.datadoghq.ad.init_configs": [{}],
-        "com.datadoghq.ad.instances": [
-          {
-            "dbm": true,
-            "host": "<RDS_READER_ENDPOINT>",
-            "port": 5432,
-            "username": "datadog",
-            "password": "<RDS_DATADOG_PASSWORD>"
-          }
-        ]
+        "com.datadoghq.ad.check_names": "[\"postgres\"]",
+        "com.datadoghq.ad.init_configs": "[{}]",
+        "com.datadoghq.ad.instances": "[{\"dbm\": true, \"host\": \"<RDS_READER_ENDPOINT>\", \"port\": 5432, \"username\": \"datadog\", \"password\": \"<RDS_DATADOG_PASSWORD>\"}]"
       },
       "mountPoints": [],
       "volumesFrom": [],

--- a/.aws/deploy/backend-task-definition.prod.json
+++ b/.aws/deploy/backend-task-definition.prod.json
@@ -19,7 +19,8 @@
         {
           "name": "DD_GIT_REPOSITORY_URL",
           "value": "github.com/isomerpages/isomercms-backend"
-        }
+        },
+        { "name": "DD_DBM_PROPAGATION_MODE", "value": "full" }
       ],
       "mountPoints": [
         {

--- a/.aws/deploy/backend-task-definition.staging.json
+++ b/.aws/deploy/backend-task-definition.staging.json
@@ -279,7 +279,18 @@
       "dockerLabels": {
         "com.datadoghq.tags.env": "staging",
         "com.datadoghq.tags.service": "isomer",
-        "com.datadoghq.tags.version": "7"
+        "com.datadoghq.tags.version": "7",
+        "com.datadoghq.ad.check_names": ["postgres"],
+        "com.datadoghq.ad.init_configs": [{}],
+        "com.datadoghq.ad.instances": [
+          {
+            "dbm": true,
+            "host": "<RDS_READER_ENDPOINT>",
+            "port": 5432,
+            "username": "datadog",
+            "password": "<RDS_DATADOG_PASSWORD>"
+          }
+        ]
       },
       "mountPoints": [],
       "volumesFrom": [],

--- a/.aws/deploy/backend-task-definition.staging.json
+++ b/.aws/deploy/backend-task-definition.staging.json
@@ -280,17 +280,9 @@
         "com.datadoghq.tags.env": "staging",
         "com.datadoghq.tags.service": "isomer",
         "com.datadoghq.tags.version": "7",
-        "com.datadoghq.ad.check_names": ["postgres"],
-        "com.datadoghq.ad.init_configs": [{}],
-        "com.datadoghq.ad.instances": [
-          {
-            "dbm": true,
-            "host": "<RDS_READER_ENDPOINT>",
-            "port": 5432,
-            "username": "datadog",
-            "password": "<RDS_DATADOG_PASSWORD>"
-          }
-        ]
+        "com.datadoghq.ad.check_names": "[\"postgres\"]",
+        "com.datadoghq.ad.init_configs": "[{}]",
+        "com.datadoghq.ad.instances": "[{\"dbm\": true, \"host\": \"<RDS_READER_ENDPOINT>\", \"port\": 5432, \"username\": \"datadog\", \"password\": \"<RDS_DATADOG_PASSWORD>\"}]"
       },
       "mountPoints": [],
       "volumesFrom": [],

--- a/.aws/deploy/backend-task-definition.staging.json
+++ b/.aws/deploy/backend-task-definition.staging.json
@@ -19,7 +19,8 @@
         {
           "name": "DD_GIT_REPOSITORY_URL",
           "value": "github.com/isomerpages/isomercms-backend"
-        }
+        },
+        { "name": "DD_DBM_PROPAGATION_MODE", "value": "full" }
       ],
       "mountPoints": [
         {

--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -66,6 +66,12 @@ on:
       DD_API_KEY:
         description: "Datadog API key for sending logs"
         required: true
+      RDS_READER_ENDPOINT:
+        description: "RDS reader endpoint for database connection"
+        required: false
+      RDS_DATADOG_PASSWORD:
+        description: "Password for datadog user inside RDS"
+        required: false
 
 permissions:
   id-token: write

--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -31,15 +31,15 @@ on:
         description: "Container port number in ECS task definition"
         required: true
         type: number
-      environment: 
+      environment:
         description: "Environment to deploy to"
         required: true
         type: string
-      shortEnv: 
+      shortEnv:
         description: "Shortened version of the environment"
         required: true
         type: string
-      task-definition-path: 
+      task-definition-path:
         description: "Path to task definition file"
         required: true
         type: string
@@ -56,14 +56,14 @@ on:
         required: true
         type: string
 
-    secrets: 
+    secrets:
       AWS_ACCOUNT_ID:
         description: "AWS account ID to deploy to"
         required: true
-      EFS_FILE_SYSTEM_ID: 
+      EFS_FILE_SYSTEM_ID:
         description: "EFS file system ID to mount"
         required: true
-      DD_API_KEY: 
+      DD_API_KEY:
         description: "Datadog API key for sending logs"
         required: true
 
@@ -103,7 +103,7 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
-      
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
@@ -123,8 +123,10 @@ jobs:
             sed -i 's/<AWS_ACCOUNT_ID>/${{ secrets.AWS_ACCOUNT_ID }}/g' ${{ inputs.task-definition-path }}
             sed -i 's/<EFS_FILE_SYSTEM_ID>/${{ secrets.EFS_FILE_SYSTEM_ID }}/g' ${{ inputs.task-definition-path }}
             sed -i 's/<DD_API_KEY>/${{ secrets.DD_API_KEY }}/g' ${{ inputs.task-definition-path }}
+            sed -i 's/<RDS_READER_ENDPOINT>/${{ secrets.RDS_READER_ENDPOINT }}/g' ${{ inputs.task-definition-path }}
+            sed -i 's/<RDS_DATADOG_PASSWORD>/${{ secrets.RDS_DATADOG_PASSWORD }}/g' ${{ inputs.task-definition-path }}
             sed -i 's/<DD_COMMIT_SHA>/${{ github.sha }}/g' ${{ inputs.task-definition-path }}
-      
+
       - name: Replace variables in appspec
         run: |
           sed -i 's/<AWS_ACCOUNT_ID>/${{ secrets.AWS_ACCOUNT_ID }}/g' .aws/deploy/appspec.json

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -55,5 +55,3 @@ jobs:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       EFS_FILE_SYSTEM_ID: ${{ secrets.PROD_EFS_FILE_SYSTEM_ID }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
-      RDS_READER_ENDPOINT: ""
-      RDS_DATADOG_PASSWORD: ""

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -1,11 +1,11 @@
-name: Deploy to production 
+name: Deploy to production
 
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
 on:
-  workflow_call: 
+  workflow_call:
 
 jobs:
   deploy-app:
@@ -21,17 +21,19 @@ jobs:
       ecs-container-port: 8081
       environment: "prod"
       shortEnv: "prod"
-      task-definition-path: ".aws/deploy/backend-task-definition.prod.json" 
+      task-definition-path: ".aws/deploy/backend-task-definition.prod.json"
       codedeploy-application: "isomer-prod-ecs-app"
       codedeploy-deployment-group: "isomer-prod-ecs-dg"
       path-to-dockerfile: "Dockerfile"
 
-    secrets: 
+    secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       EFS_FILE_SYSTEM_ID: ${{ secrets.PROD_EFS_FILE_SYSTEM_ID }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      RDS_READER_ENDPOINT: ${{ secrets.PROD_RDS_READER_ENDPOINT }}
+      RDS_DATADOG_PASSWORD: ${{ secrets.PROD_RDS_DATADOG_PASSWORD }}
 
-  deploy-support: 
+  deploy-support:
     name: Deploy support to staging
     uses: ./.github/workflows/aws_deploy.yml
     with:
@@ -44,12 +46,14 @@ jobs:
       ecs-container-port: 8082
       environment: "prod"
       shortEnv: "prod"
-      task-definition-path: ".aws/deploy/support-task-definition.prod.json" 
+      task-definition-path: ".aws/deploy/support-task-definition.prod.json"
       codedeploy-application: "prod-support-ecs-app"
       codedeploy-deployment-group: "prod-support-ecs-dg"
       path-to-dockerfile: "support/Dockerfile"
-      
-    secrets: 
+
+    secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       EFS_FILE_SYSTEM_ID: ${{ secrets.PROD_EFS_FILE_SYSTEM_ID }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      RDS_READER_ENDPOINT: ""
+      RDS_DATADOG_PASSWORD: ""

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -58,5 +58,3 @@ jobs:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       EFS_FILE_SYSTEM_ID: ${{ secrets.STAGING_EFS_FILE_SYSTEM_ID }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
-      RDS_READER_ENDPOINT: ""
-      RDS_DATADOG_PASSWORD: ""

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -21,20 +21,22 @@ jobs:
       ecs-cluster-name: "isomer-stg-ecs"
       ecs-web-service-name: "isomer-stg-ecs-service"
       ecs-container-name: "backend"
-      ecs-container-port: 8081 
+      ecs-container-port: 8081
       environment: "staging"
       shortEnv: "stg"
-      task-definition-path: ".aws/deploy/backend-task-definition.staging.json" 
+      task-definition-path: ".aws/deploy/backend-task-definition.staging.json"
       codedeploy-application: "isomer-stg-ecs-app"
       codedeploy-deployment-group: "isomer-stg-ecs-dg"
       path-to-dockerfile: "Dockerfile"
 
-    secrets: 
+    secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       EFS_FILE_SYSTEM_ID: ${{ secrets.STAGING_EFS_FILE_SYSTEM_ID }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
-  
-  deploy-support: 
+      RDS_READER_ENDPOINT: ${{ secrets.STAGING_RDS_READER_ENDPOINT }}
+      RDS_DATADOG_PASSWORD: ${{ secrets.STAGING_RDS_DATADOG_PASSWORD }}
+
+  deploy-support:
     name: Deploy support to staging
     uses: ./.github/workflows/aws_deploy.yml
     with:
@@ -47,12 +49,14 @@ jobs:
       ecs-container-port: 8082
       environment: "staging"
       shortEnv: "stg"
-      task-definition-path: ".aws/deploy/support-task-definition.staging.json" 
+      task-definition-path: ".aws/deploy/support-task-definition.staging.json"
       codedeploy-application: "stg-support-ecs-app"
       codedeploy-deployment-group: "stg-support-ecs-dg"
       path-to-dockerfile: "support/Dockerfile"
 
-    secrets: 
+    secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       EFS_FILE_SYSTEM_ID: ${{ secrets.STAGING_EFS_FILE_SYSTEM_ID }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      RDS_READER_ENDPOINT: ""
+      RDS_DATADOG_PASSWORD: ""


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-935.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible with ALL of the following feature flags in this [doc](https://www.notion.so/opengov/Existing-feature-flags-518ad2cdc325420893a105e88c432be5)

**Features**:

- Adds the required labels for Datadog to monitor our RDS systems.
    - Ref: https://docs.datadoghq.com/database_monitoring/setup_postgres/aurora?tab=docker#grant-the-agent-access
- Also adds `DD_DBM_PROPAGATION_MODE` env var to the app docker container.
    - Ref: https://docs.datadoghq.com/database_monitoring/connect_dbm_and_apm/

## Deploy Notes

<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

_None_