### PR TITLE
fix: add git to dd for staging

### DIFF
--- a/.aws/deploy/backend-task-definition.staging.json
+++ b/.aws/deploy/backend-task-definition.staging.json
@@ -10,7 +10,17 @@
         }
       ],
       "essential": true,
-      "environment": [{ "name": "ENV_TYPE", "value": "STAGING" }],
+      "environment": [
+        { "name": "ENV_TYPE", "value": "STAGING" },
+        {
+          "name": "DD_GIT_COMMIT_SHA",
+          "value": "<DD_COMMIT_SHA>"
+        },
+        {
+          "name": "DD_GIT_REPOSITORY_URL",
+          "value": "github.com/isomerpages/isomercms-backend"
+        }
+      ],
       "mountPoints": [
         {
           "sourceVolume": "ggs-efs",


### PR DESCRIPTION
## Problem
we only added source code integration to `production` but not to `staging`. 

## Solution
this PR adds that in through the [required](https://docs.datadoghq.com/integrations/guide/source-code-integration/?tab=nodejs#tag-your-telemetry-with-git-information) env vars.
