### PR TITLE
chore: log all sites retrieved

### DIFF
--- a/src/services/identity/SitesService.ts
+++ b/src/services/identity/SitesService.ts
@@ -11,6 +11,7 @@ import MissingUserEmailError from "@root/errors/MissingUserEmailError"
 import MissingUserError from "@root/errors/MissingUserError"
 import { NotFoundError } from "@root/errors/NotFoundError"
 import { UnprocessableError } from "@root/errors/UnprocessableError"
+import logger from "@root/logger/logger"
 import PreviewService from "@root/services/identity/PreviewService"
 import {
   getAllRepoData,
@@ -411,7 +412,16 @@ class SitesService {
     // Github users are using their own access token, which already filters sites to only those they have write access to
     // Admin users should have access to all sites regardless
 
-    return getAllRepoData(accessToken)
+    const repos = await getAllRepoData(accessToken)
+    logger.info({
+      message: "logging repos retrieved for user",
+      meta: {
+        userId,
+        repos,
+      },
+    })
+
+    return repos
   }
 
   async checkHasAccessForGitHubUser(sessionData: UserWithSiteSessionData) {


### PR DESCRIPTION
## Problem
During debugging of the github login issue, a problem faced was determining whether the issue was internal (we using stale data) or external (github giving us stale data). 

If we had the list of sites returned, it would have helped us to troubleshoot this issue.

## Solution
This PR logs the list of sites as well as an identifier for the user's id. no sensitive information is logged in our system here. i didn't log any further down (this is done at `SitesService`) because any further down (eg: `SitesCacheService`) discards the `userId`, which is required for user identification