### PR TITLE
fix: use admin token for privatisation

### DIFF
--- a/src/services/db/GitHubService.ts
+++ b/src/services/db/GitHubService.ts
@@ -17,6 +17,8 @@ import logger from "@root/logger/logger"
 import { GitCommitResult } from "@root/types/gitfilesystem"
 import { GitHubRepoInfo, RawGitTreeEntry, RepoState } from "@root/types/github"
 
+import { E2E_TEST_GH_TOKEN } from "../middlewareServices/AuthenticationMiddlewareService"
+
 import * as ReviewApi from "./review"
 
 export default class GitHubService {
@@ -861,9 +863,9 @@ export default class GitHubService {
     const endpointTemplate = urlTemplate.parse(`{siteName}`)
     const endpoint = endpointTemplate.expand({ siteName })
 
-    // Privatising a repo is restricted to repo admins - an admin token will be inserted in via our axios interceptor
+    // Privatising a repo is restricted to repo admins - our main admin token is used
     const headers = {
-      Authorization: "",
+      Authorization: `token ${E2E_TEST_GH_TOKEN}`,
       "Content-Type": "application/json",
     }
 

--- a/src/services/db/__tests__/GitHubService.spec.ts
+++ b/src/services/db/__tests__/GitHubService.spec.ts
@@ -48,6 +48,7 @@ describe("Github Service", () => {
   const resourceCategoryFileName = "index.html"
 
   const sessionData = mockUserWithSiteSessionData
+  const mockE2eToken = "test"
 
   const authHeader = {
     headers: {
@@ -1042,7 +1043,7 @@ describe("Github Service", () => {
   describe("changeRepoPrivacy", () => {
     const refEndpoint = `${siteName}`
     const headers = {
-      Authorization: `token ${accessToken}`,
+      Authorization: `token ${mockE2eToken}`,
       "Content-Type": "application/json",
     }
     it("should modify the repo privacy accordingly if making repo private", async () => {

--- a/src/services/db/__tests__/GitHubService.spec.ts
+++ b/src/services/db/__tests__/GitHubService.spec.ts
@@ -1042,7 +1042,7 @@ describe("Github Service", () => {
   describe("changeRepoPrivacy", () => {
     const refEndpoint = `${siteName}`
     const headers = {
-      Authorization: "",
+      Authorization: `token ${accessToken}`,
       "Content-Type": "application/json",
     }
     it("should modify the repo privacy accordingly if making repo private", async () => {


### PR DESCRIPTION
Uses our admin token to privatise repos, to fix github's changes to disallow write tokens to change repo status.